### PR TITLE
fix(server): handle exceptions in messages route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,7 @@ async function run(options: RunOptions = {}) {
       await streamOpenAIResponse(res, completion, req.body.model, req.body);
     } catch (e) {
       log("Error in OpenAI API call:", e);
+      return res.status(500).json({ error: e });
     }
   });
   server.start();

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -2,10 +2,10 @@ import { getServiceInfo } from './processCheck';
 
 export function showStatus() {
     const info = getServiceInfo();
-    
+
     console.log('\n📊 Claude Code Router Status');
     console.log('═'.repeat(40));
-    
+
     if (info.running) {
         console.log('✅ Status: Running');
         console.log(`🆔 Process ID: ${info.pid}`);
@@ -15,13 +15,13 @@ export function showStatus() {
         console.log('');
         console.log('🚀 Ready to use! Run the following commands:');
         console.log('   ccr code    # Start coding with Claude');
-        console.log('   ccr close   # Stop the service');
+        console.log('   ccr stop   # Stop the service');
     } else {
         console.log('❌ Status: Not Running');
         console.log('');
         console.log('💡 To start the service:');
         console.log('   ccr start');
     }
-    
+
     console.log('');
 }


### PR DESCRIPTION
This PR includes two small but important fixes to improve the overall usability and robustness of the `claude-code-router`.

**Changes:**

1.  **Corrected Outdated Command in Status Message (`src/utils/status.ts`)**
    * The status message displayed by `ccr status` was suggesting the outdated command `ccr close`.
    * This has been updated to the correct command, `ccr stop`, to avoid user confusion and align with the current CLI implementation.

2.  **Added Exception Handling for `/v1/messages` Route (`src/index.ts`)**
    * Previously, if a downstream API call (e.g., to OpenAI/DeepSeek) failed, the server would catch the exception but not send a response to the client. This caused the client's request to hang until it timed out.
    * An error handling mechanism has been added to the `catch` block. Now, if an error occurs, the server will immediately respond with a `500 Internal Server Error` status and a JSON body containing the error details. This ensures the client receives a prompt and clear response upon failure.

These changes enhance the user experience and make the server's behavior more predictable and reliable.

Thank you for your review and consideration!


