### PR TITLE
增加鉴权支持，从 配置文件中读取密钥

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ ccr code
     "default": "deepseek,deepseek-chat", // IMPORTANT OPENAI_MODEL has been deprecated
     "background": "ollama,qwen2.5-coder:latest",
     "think": "deepseek,deepseek-reasoner",
-    "longContext": "openrouter,google/gemini-2.5-pro-preview"
+    "longContext": "openrouter,google/gemini-2.5-pro-preview",
+    "auth_key": ["sk-xxx","test"] //optional
   }
 }
 ```

--- a/config.example.json
+++ b/config.example.json
@@ -71,6 +71,7 @@
     "default": "deepseek,deepseek-chat",
     "background": "ollama,qwen2.5-coder:latest",
     "think": "deepseek,deepseek-reasoner",
-    "longContext": "openrouter,google/gemini-2.5-pro-preview"
+    "longContext": "openrouter,google/gemini-2.5-pro-preview",
+    "auth_key": ["sk-xxx","test"]
   }
 }

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -27,6 +27,16 @@ const getUseModel = (req: any, tokenCount: number, config: any) => {
 };
 
 export const router = async (req: any, res: any, config: any) => {
+  // --- 添加鉴权逻辑开始 ---
+  const expectedAuthKey = config.Router.auth_key; // 从 config.json 读取密钥
+  const receivedAuthKey = req.headers["x-api-key"]; // 从请求头部读取 x-api-key
+
+  if (expectedAuthKey && receivedAuthKey !== expectedAuthKey) {
+    res.code(401); // Unauthorized
+    res.send(`Unauthorized: Invalid API key. Received: ${receivedAuthKey}`);
+    return; // 阻止请求继续处理
+  }
+  // --- 添加鉴权逻辑结束 ---
   const { messages, system = [], tools }: MessageCreateParamsBase = req.body;
   try {
     let tokenCount = 0;
@@ -60,10 +70,6 @@ export const router = async (req: any, res: any, config: any) => {
         if (item.type !== "text") return;
         if (typeof item.text === "string") {
           tokenCount += enc.encode(item.text).length;
-        } else if (Array.isArray(item.text)) {
-          item.text.forEach((textPart) => {
-            tokenCount += enc.encode(textPart || "").length;
-          });
         }
       });
     }

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -31,7 +31,23 @@ export const router = async (req: any, res: any, config: any) => {
   const expectedAuthKey = config.Router.auth_key; // 从 config.json 读取密钥
   const receivedAuthKey = req.headers["x-api-key"]; // 从请求头部读取 x-api-key
 
-  if (expectedAuthKey && receivedAuthKey !== expectedAuthKey) {
+  let isAuthorized = false;
+  if (Array.isArray(expectedAuthKey)) {
+    // 如果 expectedAuthKey 是一个数组，检查 receivedAuthKey 是否在数组中
+    if (receivedAuthKey && expectedAuthKey.includes(receivedAuthKey)) {
+      isAuthorized = true;
+    }
+  } else if (expectedAuthKey) {
+    // 如果 expectedAuthKey 是一个字符串，执行原有的字符串匹配
+    if (receivedAuthKey === expectedAuthKey) {
+      isAuthorized = true;
+    }
+  } else {
+    // 如果没有设置 expectedAuthKey，则认为授权通过
+    isAuthorized = true;
+  }
+
+  if (!isAuthorized) {
     res.code(401); // Unauthorized
     res.send(`Unauthorized: Invalid API key. Received: ${receivedAuthKey}`);
     return; // 阻止请求继续处理


### PR DESCRIPTION
在将 ccr 进行容器化部署在云服务器后，为了安全考虑
增加一个密钥鉴权机制。
通过在 json 文件中设置被允许的密钥列表，只有请求中的密钥匹配时，才会实现路由，否则进行拦截
```json
  "Router": {
    "default": "deepseek,deepseek-chat",
    "background": "ollama,qwen2.5-coder:latest",
    "think": "deepseek,deepseek-reasoner",
    "longContext": "openrouter,google/gemini-2.5-pro-preview",
    "auth_key": ["sk-xxx","test"]
  }
```
