### PR TITLE
Add API_TIMEOUT_MS configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The `config.json` file has several key sections:
 
 - **`Providers`**: Used to configure different model providers.
 - **`Router`**: Used to set up routing rules. `default` specifies the default model, which will be used for all requests if no other route is configured.
+- **`API_TIMEOUT_MS`**: Specifies the timeout for API calls in milliseconds.
 
 Here is a comprehensive example:
 
@@ -52,6 +53,7 @@ Here is a comprehensive example:
   "APIKEY": "your-secret-key",
   "PROXY_URL": "http://127.0.0.1:7890",
   "LOG": true,
+  "API_TIMEOUT_MS": 600000,
   "Providers": [
     {
       "name": "openrouter",

--- a/README_zh.md
+++ b/README_zh.md
@@ -40,6 +40,7 @@ npm install -g @musistudio/claude-code-router
 - **`HOST`** (可选): 您可以设置服务的主机地址。如果未设置 `APIKEY`，出于安全考虑，主机地址将强制设置为 `127.0.0.1`，以防止未经授权的访问。例如：`"HOST": "0.0.0.0"`。
 - **`Providers`**: 用于配置不同的模型提供商。
 - **`Router`**: 用于设置路由规则。`default` 指定默认模型，如果未配置其他路由，则该模型将用于所有请求。
+- **`API_TIMEOUT_MS`**: API 请求超时时间，单位为毫秒。
 
 这是一个综合示例：
 
@@ -48,6 +49,7 @@ npm install -g @musistudio/claude-code-router
   "APIKEY": "your-secret-key",
   "PROXY_URL": "http://127.0.0.1:7890",
   "LOG": true,
+  "API_TIMEOUT_MS": 600000,
   "Providers": [
     {
       "name": "openrouter",

--- a/config.example.json
+++ b/config.example.json
@@ -113,5 +113,6 @@
     "webSearch": "gemini,gemini-2.5-flash"
   },
   "APIKEY": "your-secret-key",
-  "HOST": "0.0.0.0"
+  "HOST": "0.0.0.0",
+  "API_TIMEOUT_MS": 600000
 }

--- a/src/utils/codeCommand.ts
+++ b/src/utils/codeCommand.ts
@@ -13,7 +13,7 @@ export async function executeCodeCommand(args: string[] = []) {
     ...process.env,
     ANTHROPIC_AUTH_TOKEN: "test",
     ANTHROPIC_BASE_URL: `http://127.0.0.1:${config.PORT || 3456}`,
-    API_TIMEOUT_MS: "600000",
+    API_TIMEOUT_MS: String(config.API_TIMEOUT_MS ?? 600000), // Default to 10 minutes if not set
   };
 
   if (config?.APIKEY) {


### PR DESCRIPTION
添加一个新的配置选项API_TIMEOUT_MS，允许自定义API调用的超时时间,可以按需设置。

- 修改了 `src/utils/codeCommand.ts` 以使用配置的超时数字，而不是硬编码的600000ms（10分钟）
- 在`config.example.json`中添加了`API_TIMEOUT_MS`，默认值为600000ms（10分钟）
- 更新了 `README.md` 和 `README_zh.md` 对应的配置选项
- 如果配置中未设置，则默认为600000ms（10分钟）
