### PR TITLE
feat(ui): add API_TIMEOUT_MS setting to configuration UI(添加 API 超时时间设置功能)

### DIFF
--- a/ui/config.example.json
+++ b/ui/config.example.json
@@ -4,6 +4,7 @@
   "HOST": "127.0.0.1",
   "PORT": 8080,
   "APIKEY": "1",
+  "API_TIMEOUT_MS": 600000,
   "transformers": [
     {
       "path": "/Users/abc/.claude-code-router/plugins/gemini-cli.js",

--- a/ui/src/components/ConfigProvider.tsx
+++ b/ui/src/components/ConfigProvider.tsx
@@ -41,6 +41,7 @@ export interface Config {
   HOST: string;
   PORT: number;
   APIKEY: string;
+  API_TIMEOUT_MS: string;
   transformers: Transformer[];
   Providers: Provider[];
   Router: RouterConfig;
@@ -116,6 +117,7 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
           HOST: typeof data.HOST === 'string' ? data.HOST : '127.0.0.1',
           PORT: typeof data.PORT === 'number' ? data.PORT : 3456,
           APIKEY: typeof data.APIKEY === 'string' ? data.APIKEY : '',
+          API_TIMEOUT_MS: typeof data.API_TIMEOUT_MS === 'string' ? data.API_TIMEOUT_MS : '600000',
           transformers: Array.isArray(data.transformers) ? data.transformers : [],
           Providers: Array.isArray(data.Providers) ? data.Providers : [],
           Router: data.Router && typeof data.Router === 'object' ? {
@@ -146,6 +148,7 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
             HOST: '127.0.0.1',
             PORT: 3456,
             APIKEY: '',
+            API_TIMEOUT_MS: '600000',            
             transformers: [],
             Providers: [],
             Router: {

--- a/ui/src/components/SettingsDialog.tsx
+++ b/ui/src/components/SettingsDialog.tsx
@@ -58,6 +58,10 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
             <Input id="port" type="number" value={config.PORT} onChange={(e) => setConfig({ ...config, PORT: parseInt(e.target.value, 10) })} className="transition-all-ease focus:scale-[1.01]" />
           </div>
           <div className="space-y-2">
+            <Label htmlFor="timeout" className="transition-all-ease hover:scale-[1.01] cursor-pointer">{t("toplevel.timeout")}</Label>
+            <Input id="timeout" value={config.API_TIMEOUT_MS} onChange={(e) => setConfig({ ...config, API_TIMEOUT_MS: e.target.value })} className="transition-all-ease focus:scale-[1.01]" />
+          </div>
+          <div className="space-y-2">
             <Label htmlFor="apikey" className="transition-all-ease hover:scale-[1.01] cursor-pointer">{t("toplevel.apikey")}</Label>
             <Input id="apikey" type="password" value={config.APIKEY} onChange={(e) => setConfig({ ...config, APIKEY: e.target.value })} className="transition-all-ease focus:scale-[1.01]" />
           </div>

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -30,7 +30,8 @@
     "claude_path": "Claude Path",
     "host": "Host",
     "port": "Port",
-    "apikey": "API Key"
+    "apikey": "API Key",
+    "timeout": "API Timeout (ms)"
   },
   "transformers": {
     "title": "Custom Transformers",

--- a/ui/src/locales/zh.json
+++ b/ui/src/locales/zh.json
@@ -30,7 +30,8 @@
     "claude_path": "Claude 路径",
     "host": "主机",
     "port": "端口",
-    "apikey": "API 密钥"
+    "apikey": "API 密钥",
+    "timeout": "API 超时时间 (毫秒)"
   },
   "transformers": {
     "title": "自定义转换器",


### PR DESCRIPTION
- Add API_TIMEOUT_MS input field to SettingsDialog
- Add translations for the new setting in both English and Chinese locales
- Update ConfigProvider to handle API_TIMEOUT_MS configuration

  此 PR 在 UI 配置界面中添加了 API 超时时间 (API_TIMEOUT_MS) 的设置选项，使用户能够在前端界面中配置 API 请求的超时时间。

  - 在设置对话框中添加了 API_TIMEOUT_MS 输入字段
  - 为新设置项添加了英文和中文翻译
  - 更新了 ConfigProvider 以处理 API_TIMEOUT_MS 配置