### PR TITLE
feat: support setting ANTHROPIC_SMALL_FAST_MODEL from config file

### DIFF
--- a/src/utils/codeCommand.ts
+++ b/src/utils/codeCommand.ts
@@ -16,6 +16,11 @@ export async function executeCodeCommand(args: string[] = []) {
     API_TIMEOUT_MS: String(config.API_TIMEOUT_MS ?? 600000), // Default to 10 minutes if not set
   };
 
+  // Set ANTHROPIC_SMALL_FAST_MODEL if it exists in config
+  if (config?.ANTHROPIC_SMALL_FAST_MODEL) {
+    env.ANTHROPIC_SMALL_FAST_MODEL = config.ANTHROPIC_SMALL_FAST_MODEL;
+  }
+
   if (config?.APIKEY) {
     env.ANTHROPIC_API_KEY = config.APIKEY;
     delete env.ANTHROPIC_AUTH_TOKEN;


### PR DESCRIPTION
Added support for configuring ANTHROPIC_SMALL_FAST_MODEL through the router's config file. The environment variable is now conditionally set when executing Claude Code commands, allowing users to specify this setting without modifying Claude's own environment.

Default

<img width="942" height="414" alt="iShot_2025-08-04_15 02 58" src="https://github.com/user-attachments/assets/2f7a951e-7547-49c3-882d-ddd9e6674aa7" />


With ANTHROPIC_SMALL_FAST_MODEL config, no more using claude-3-5-haiku

<img width="927" height="424" alt="iShot_2025-08-04_15 01 34" src="https://github.com/user-attachments/assets/d90ab21f-e410-433b-a713-95f74e98cbb6" />
