### PR TITLE
Preserve spaces in quoted args

### DIFF
--- a/src/utils/codeCommand.ts
+++ b/src/utils/codeCommand.ts
@@ -31,7 +31,12 @@ export async function executeCodeCommand(args: string[] = []) {
 
   // Execute claude command
   const claudePath = process.env.CLAUDE_PATH || "claude";
-  const claudeProcess = spawn(claudePath, args, {
+  
+  // Properly join arguments to preserve spaces in quotes
+  // Wrap each argument in double quotes to preserve single and double quotes inside arguments
+  const joinedArgs = args.length > 0 ? args.map(arg => `"${arg.replace(/\"/g, '\\"')}"`).join(" ") : "";
+  
+  const claudeProcess = spawn(claudePath + (joinedArgs ? ` ${joinedArgs}` : ""), [], {
     env,
     stdio: "inherit",
     shell: true,


### PR DESCRIPTION
This makes SDK mode work since the model gets the complete quoted prompt passed in (instead of just the first word). With this change one can use `ccr code -p "What can you do for me"`