### PR TITLE
🐛Bug Fix: 修复多用户环境权限冲突问题

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import os from "node:os";
+import fs from "node:fs";
 
 export const HOME_DIR = path.join(os.homedir(), ".claude-code-router");
 
@@ -9,7 +10,7 @@ export const PLUGINS_DIR = path.join(HOME_DIR, "plugins");
 
 export const PID_FILE = path.join(HOME_DIR, '.claude-code-router.pid');
 
-export const REFERENCE_COUNT_FILE = path.join(os.tmpdir(), "claude-code-reference-count.txt");
+export const REFERENCE_COUNT_FILE = path.join(HOME_DIR, "claude-code-reference-count.txt");
 
 
 export const DEFAULT_CONFIG = {


### PR DESCRIPTION
### 问题描述
  在多用户服务器环境中，当多个用户尝试同时运行 Claude Code Router 时，会出现以下错误：
  Error: EACCES: permission denied, open /tmp/claude-code-reference-count.txt

  这是因为引用计数文件位于系统共享的临时目录中，第一个用户创建文件后，其他用户由于权限不足无法
  访问。

  ### 解决方案
  修改 `src/constants.ts` 文件：
  - 文件路径变更：`/tmp/claude-code-reference-count.txt` →
  `~/.claude-code-router/claude-code-reference-count.txt`
  - 每个用户现在拥有独立的引用计数文件