### PR TITLE
fix: check provider name to prevent duplicate name with different config param

### DIFF
--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -81,7 +81,9 @@
     "import_from_template": "Import from template",
     "no_templates_found": "No templates found",
     "select_template": "Select a template...",
-    "api_key_required": "API Key is required"
+    "api_key_required": "API Key is required",
+    "name_required": "Name is required",
+    "name_duplicate": "A provider with this name already exists"
 
   },
   "router": {

--- a/ui/src/locales/zh.json
+++ b/ui/src/locales/zh.json
@@ -81,7 +81,9 @@
     "import_from_template": "从模板导入",
     "no_templates_found": "未找到模板",
     "select_template": "选择一个模板...",
-    "api_key_required": "API 密钥为必填项"
+    "api_key_required": "API 密钥为必填项",
+    "name_required": "名称为必填项",
+    "name_duplicate": "已存在同名供应商"
 
   },
   "router": {


### PR DESCRIPTION
使用ui 配置供应商时，检查供应商名称是否重复，防止错误配置导致意料之外的消费。
配置偷懒+血亏 20 刀的教训
<img width="652" height="642" alt="image" src="https://github.com/user-attachments/assets/2027e463-a4b3-4570-8a8a-473be4e716ae" />
