### PR TITLE
feat: add model override in cli

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,7 @@ export const createServer = (config: any): Server => {
     }, 1000);
   });
 
+
   // Register static file serving with caching
   server.app.register(fastifyStatic, {
     root: join(__dirname, "..", "dist"),


### PR DESCRIPTION
I'm a big fan of this project! I've implemented some features that I needed during my usage. I'd love to get your feedback and review.

# Overview 

 Add --model CLI option to override the default model configuration at runtime

# Objective

Currently, Claude Code Router uses the model configuration from config.json for all requests. Users need to manually edit the configuration file to use a different model temporarily. This PR adds a --model command-line option that allows users to override the default model for a specific ccr code execution without modifying the configuration file.

# Solution 

Implemented a model override mechanism by leveraging the existing auth token communication channel between the CLI client and server:

  1. CLI Argument Parsing (src/cli.ts):
    - Added parsing for --model option in the code command
    - Format: ccr code --model provider,model "prompt"
    - Updated help text with usage examples
  2. Inter-Process Communication (src/utils/codeCommand.ts):
    - Since CLI and server run in separate processes, embedded model override in auth token
    - Format: test:MODEL:{encoded_model} where commas are encoded as ___
    - This approach works reliably because Claude CLI forwards ANTHROPIC_AUTH_TOKEN
  3. Server-Side Handling (src/index.ts):
    - Added preHandler hook to extract model override from auth token
    - Decodes the model string and overrides the router configuration
    - Only affects the specific request, not global configuration

# Usage Example

```bash
# Use a different model for a single request
ccr code --model openrouter,anthropic/claude-opus-4 "Write a function"

# Default model from config.json
ccr code "Explain this code"
```