### PR TITLE
Add secure API key management via ccr config command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,8 @@ import { spawn, exec } from "child_process";
 import { PID_FILE, REFERENCE_COUNT_FILE } from "./constants";
 import fs, { existsSync, readFileSync } from "fs";
 import { join } from "path";
+import { keyStore } from "./utils/keystore";
+import readline from "node:readline";
 
 const command = process.argv[2];
 
@@ -26,6 +28,7 @@ Commands:
   status        Show server status
   statusline    Integrated statusline
   code          Execute claude command
+  config        Manage API keys securely
   ui            Open the web UI in browser
   -v, version   Show version information
   -h, help      Show help information
@@ -33,6 +36,7 @@ Commands:
 Example:
   ccr start
   ccr code "Write a Hello World"
+  ccr config set cerebras
   ccr ui
 `;
 
@@ -53,6 +57,147 @@ async function waitForService(
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   return false;
+}
+
+async function handleConfig() {
+  const subCommand = process.argv[3];
+  const provider = process.argv[4];
+  
+  const storageType = keyStore.getStorageType();
+  
+  switch (subCommand) {
+    case "set":
+      if (!provider) {
+        console.error("Error: Provider name required");
+        console.log("Usage: ccr config set <provider>");
+        process.exit(1);
+      }
+      
+      let apiKey: string;
+      
+      // Check if input is being piped
+      if (!process.stdin.isTTY) {
+        // Read from piped input
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) {
+          chunks.push(chunk);
+        }
+        apiKey = Buffer.concat(chunks).toString().trim();
+      } else {
+        // Interactive prompt
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        
+        const question = (prompt: string) => new Promise<string>((resolve) => {
+          rl.question(prompt, (answer) => resolve(answer));
+        });
+        
+        console.log(`Storing API key for '${provider}' in ${storageType}`);
+        apiKey = await question(`Enter API key for ${provider}: `);
+        rl.close();
+      }
+      
+      if (!keyStore.validateKey(apiKey)) {
+        console.error("Error: Invalid API key format (must be at least 10 characters)");
+        process.exit(1);
+      }
+      
+      try {
+        await keyStore.setKey(provider, apiKey);
+        console.log(`✓ API key for '${provider}' stored securely in ${storageType}`);
+      } catch (error: any) {
+        console.error(`Error storing API key: ${error.message}`);
+        process.exit(1);
+      }
+      break;
+      
+    case "get":
+      if (!provider) {
+        console.error("Error: Provider name required");
+        console.log("Usage: ccr config get <provider>");
+        process.exit(1);
+      }
+      
+      try {
+        const key = await keyStore.getKey(provider);
+        if (key) {
+          console.log(`API key for '${provider}' is configured (${keyStore.maskKey(key)})`);
+        } else {
+          console.log(`No API key found for '${provider}'`);
+        }
+      } catch (error: any) {
+        console.error(`Error checking API key: ${error.message}`);
+        process.exit(1);
+      }
+      break;
+      
+    case "delete":
+      if (!provider) {
+        console.error("Error: Provider name required");
+        console.log("Usage: ccr config delete <provider>");
+        process.exit(1);
+      }
+      
+      try {
+        await keyStore.deleteKey(provider);
+        console.log(`✓ API key for '${provider}' deleted`);
+      } catch (error: any) {
+        console.error(`Error deleting API key: ${error.message}`);
+        process.exit(1);
+      }
+      break;
+      
+    case "list":
+      try {
+        const providers = await keyStore.listProviders();
+        if (providers.length > 0) {
+          console.log(`Configured providers (${storageType}):`);
+          for (const p of providers) {
+            const key = await keyStore.getKey(p);
+            if (key) {
+              console.log(`  - ${p}: ${keyStore.maskKey(key)}`);
+            }
+          }
+        } else {
+          console.log(`No API keys configured (storage: ${storageType})`);
+        }
+      } catch (error: any) {
+        console.error(`Error listing providers: ${error.message}`);
+        process.exit(1);
+      }
+      break;
+      
+    default:
+      console.log(`
+Usage: ccr config <command> [provider]
+
+Commands:
+  set <provider>     Store API key for a provider
+  get <provider>     Check if API key is configured
+  list               List all configured providers
+  delete <provider>  Remove stored API key
+
+Examples:
+  ccr config set cerebras
+  ccr config get cerebras
+  ccr config list
+  ccr config delete cerebras
+
+Storage: ${storageType}
+
+Migration from environment variables:
+  If you have API keys in environment variables, you can migrate them:
+  
+  echo $CEREBRAS_API_KEY | ccr config set cerebras
+  
+  Then unset the environment variable:
+  unset CEREBRAS_API_KEY
+
+Note: Stored keys take precedence over environment variables.
+`);
+  }
 }
 
 async function main() {
@@ -273,6 +418,9 @@ async function main() {
     case "-v":
     case "version":
       console.log(`claude-code-router version: ${version}`);
+      break;
+    case "config":
+      await handleConfig();
       break;
     case "restart":
       // Stop the service if it's running

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,21 +9,72 @@ import {
   PLUGINS_DIR,
 } from "../constants";
 import { cleanupLogFiles } from "./logCleanup";
+import { keyStore } from "./keystore";
+
+// Cache for keystore lookups to avoid repeated async calls
+const keystoreCache: { [key: string]: string | null } = {};
+const warningsShown = new Set<string>();
+let keystoreCacheInitialized = false;
 
 // Function to interpolate environment variables in config values
-const interpolateEnvVars = (obj: any): any => {
+// PRIORITY: 1. Keystore (if explicitly set by user)
+//           2. Environment variables (backward compatibility)
+//           3. Keep original if neither exists
+const interpolateEnvVars = async (obj: any): Promise<any> => {
+  // Initialize keystore cache on first use
+  if (!keystoreCacheInitialized) {
+    keystoreCacheInitialized = true;
+    // Pre-load all stored keys into cache to minimize async operations
+    try {
+      const providers = await keyStore.listProviders();
+      for (const provider of providers) {
+        const key = await keyStore.getKey(provider);
+        if (key) {
+          // Store with common patterns that users might use in config
+          keystoreCache[`${provider.toUpperCase()}_API_KEY`] = key;
+          keystoreCache[`${provider.toUpperCase()}_KEY`] = key;
+          // Also store the exact provider name for direct lookups
+          keystoreCache[provider.toUpperCase()] = key;
+        }
+      }
+    } catch (e) {
+      // Keystore not available, continue without it
+    }
+  }
+
   if (typeof obj === "string") {
-    // Replace $VAR_NAME or ${VAR_NAME} with environment variable values
+    // Replace $VAR_NAME or ${VAR_NAME} with appropriate values
     return obj.replace(/\$\{([^}]+)\}|\$([A-Z_][A-Z0-9_]*)/g, (match, braced, unbraced) => {
       const varName = braced || unbraced;
-      return process.env[varName] || match; // Keep original if env var doesn't exist
+      
+      // 1. Check keystore first (user's explicit configuration)
+      if (keystoreCache[varName]) {
+        // Warn if env var also exists (help users understand what's happening)
+        if (process.env[varName] && !warningsShown.has(varName)) {
+          warningsShown.add(varName);
+          console.warn(
+            `⚠️  Using stored API key for ${varName} from keystore.\n` +
+            `   Environment variable ${varName} also exists but is being overridden.\n` +
+            `   To use the environment variable instead, run: ccr config delete <provider>`
+          );
+        }
+        return keystoreCache[varName]!;
+      }
+      
+      // 2. Fall back to environment variable (backward compatibility)
+      if (process.env[varName]) {
+        return process.env[varName]!;
+      }
+      
+      // 3. Keep original if neither exists
+      return match;
     });
   } else if (Array.isArray(obj)) {
-    return obj.map(interpolateEnvVars);
+    return Promise.all(obj.map(interpolateEnvVars));
   } else if (obj !== null && typeof obj === "object") {
     const result: any = {};
     for (const [key, value] of Object.entries(obj)) {
-      result[key] = interpolateEnvVars(value);
+      result[key] = await interpolateEnvVars(value);
     }
     return result;
   }
@@ -72,8 +123,8 @@ export const readConfigFile = async () => {
     try {
       // Try to parse with JSON5 first (which also supports standard JSON)
       const parsedConfig = JSON5.parse(config);
-      // Interpolate environment variables in the parsed config
-      return interpolateEnvVars(parsedConfig);
+      // Interpolate environment variables and keystore values in the parsed config
+      return await interpolateEnvVars(parsedConfig);
     } catch (parseError) {
       console.error(`Failed to parse config file at ${CONFIG_FILE}`);
       console.error("Error details:", (parseError as Error).message);

--- a/src/utils/keystore.ts
+++ b/src/utils/keystore.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { HOME_DIR } from "../constants";
+
+/**
+ * Interface for secure key storage backends.
+ * This abstraction allows for different implementations (file-based, OS keychain, etc.)
+ */
+export interface KeyStore {
+  setKey(provider: string, key: string): Promise<void>;
+  getKey(provider: string): Promise<string | null>;
+  deleteKey(provider: string): Promise<void>;
+  listProviders(): Promise<string[]>;
+  isAvailable(): boolean;
+  getStorageType(): string;
+}
+
+const KEYS_FILE = path.join(HOME_DIR, "keys");
+
+/**
+ * File-based key storage implementation.
+ * 
+ * Follows the standard Unix approach used by SSH, AWS CLI, npm, Docker, etc:
+ * - Stores keys in plaintext JSON in ~/.claude-code-router/keys
+ * - Protects the file with restrictive permissions (0600)
+ * - Relies on OS file permissions as the security boundary
+ * 
+ * Security model: "If someone can read your home directory files, you're already compromised"
+ * This is the same model used by ~/.ssh/id_rsa, ~/.aws/credentials, ~/.npmrc, etc.
+ */
+class FileKeyStore implements KeyStore {
+  isAvailable(): boolean {
+    return true; // Always available
+  }
+
+  getStorageType(): string {
+    return "Protected File Storage (~/.claude-code-router/keys)";
+  }
+
+  private async loadKeys(): Promise<Record<string, string>> {
+    try {
+      const data = await fs.readFile(KEYS_FILE, "utf8");
+      return JSON.parse(data);
+    } catch (e) {
+      // File doesn't exist or is invalid JSON, return empty object
+      return {};
+    }
+  }
+
+  private async saveKeys(keys: Record<string, string>): Promise<void> {
+    const data = JSON.stringify(keys, null, 2);
+    
+    // Ensure the directory exists
+    await fs.mkdir(path.dirname(KEYS_FILE), { recursive: true });
+    
+    // Write the file with restrictive permissions
+    await fs.writeFile(KEYS_FILE, data, { mode: 0o600 });
+    
+    // Double-check permissions (some systems might not respect the mode option)
+    try {
+      await fs.chmod(KEYS_FILE, 0o600);
+    } catch {
+      // Ignore chmod errors on systems that don't support it
+    }
+  }
+
+  async setKey(provider: string, key: string): Promise<void> {
+    const keys = await this.loadKeys();
+    keys[provider] = key;
+    await this.saveKeys(keys);
+  }
+
+  async getKey(provider: string): Promise<string | null> {
+    const keys = await this.loadKeys();
+    return keys[provider] || null;
+  }
+
+  async deleteKey(provider: string): Promise<void> {
+    const keys = await this.loadKeys();
+    delete keys[provider];
+    await this.saveKeys(keys);
+  }
+
+  async listProviders(): Promise<string[]> {
+    const keys = await this.loadKeys();
+    return Object.keys(keys);
+  }
+}
+
+/**
+ * Main key store manager that selects the appropriate backend.
+ * Currently uses file-based storage following Unix conventions.
+ * Future PR will add native OS keychain support as an alternative.
+ */
+export class SecureKeyStore {
+  private store: KeyStore;
+
+  constructor() {
+    // For now, we only have the file-based backend
+    // Future PR will add logic here to select native keychain if available
+    this.store = new FileKeyStore();
+  }
+
+  async setKey(provider: string, key: string): Promise<void> {
+    return this.store.setKey(provider, key);
+  }
+
+  async getKey(provider: string): Promise<string | null> {
+    return this.store.getKey(provider);
+  }
+
+  async deleteKey(provider: string): Promise<void> {
+    return this.store.deleteKey(provider);
+  }
+
+  async listProviders(): Promise<string[]> {
+    return this.store.listProviders();
+  }
+
+  isAvailable(): boolean {
+    return this.store.isAvailable();
+  }
+
+  getStorageType(): string {
+    return this.store.getStorageType();
+  }
+
+  // Helper method to mask API keys for display
+  maskKey(key: string): string {
+    if (!key || key.length < 8) return "****";
+    return "*".repeat(key.length - 4) + key.slice(-4);
+  }
+
+  // Helper method to validate API key format
+  validateKey(key: string): boolean {
+    // Basic validation - at least 10 characters
+    return key && key.length >= 10;
+  }
+}
+
+// Export singleton instance
+export const keyStore = new SecureKeyStore();


### PR DESCRIPTION
Fixes #642

## Summary
Implements secure credential storage for API keys, eliminating the need for environment variables or hardcoded keys in config.json.

## Implementation Details

### New `ccr config` Command
- `ccr config set <provider>` - Store API key (supports interactive and piped input)
- `ccr config get <provider>` - Check if key is configured (never shows full key)
- `ccr config list` - List all configured providers with masked keys
- `ccr config delete <provider>` - Remove stored API key

### Storage Approach
- Keys stored in `~/.claude-code-router/keys` as JSON
- File permissions set to 0600 (owner read/write only)
- Follows same security model as SSH, AWS CLI, npm, Docker
- Cross-platform compatible (Unix permissions on Linux/macOS, user profile isolation on Windows)

### Integration
- Modified `interpolateEnvVars` to check keystore first, then environment variables
- Fully backward compatible - existing env var setups continue to work
- Warning shown when both keystore and env var exist (keystore takes precedence)

### Architecture
- Clean `KeyStore` interface for future extensibility
- Current implementation: `FileKeyStore` using filesystem with strict permissions
- Future PR can add `NativeKeyStore` for OS keychains (macOS Keychain, Windows Credential Manager, Linux Secret Service)

## Testing
- Tested storing, retrieving, listing, and deleting keys
- Verified integration with Cerebras API
- Confirmed backward compatibility with environment variables
- Tested piped input for easy migration

## Security Considerations
- No new dependencies required
- Keys never displayed in full
- Same security boundary as other CLI tools (filesystem permissions)
- No encryption complexity that could fail - simple and reliable

## Migration Path
```bash
# Easy migration from environment variables
echo $CEREBRAS_API_KEY | ccr config set cerebras
unset CEREBRAS_API_KEY
```

## Next Steps
Future PR will add optional native OS keychain support via @napi-rs/keyring for users who want additional security beyond filesystem permissions.