### PR TITLE
Add seniorModel routing feature for claude-opus models

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ Here is a comprehensive example:
     "think": "deepseek,deepseek-reasoner",
     "longContext": "openrouter,google/gemini-2.5-pro-preview",
     "longContextThreshold": 60000,
-    "webSearch": "gemini,gemini-2.5-flash"
+    "webSearch": "gemini,gemini-2.5-flash",
+    "seniorModel": "anthropic,claude-opus-4-1-20250805"
   }
 }
 ```
@@ -345,6 +346,7 @@ The `Router` object defines which model to use for different scenarios:
 - `longContext`: A model for handling long contexts (e.g., > 60K tokens).
 - `longContextThreshold` (optional): The token count threshold for triggering the long context model. Defaults to 60000 if not specified.
 - `webSearch`: Used for handling web search tasks and this requires the model itself to support the feature. If you're using openrouter, you need to add the `:online` suffix after the model name.
+- `seniorModel`: A model for handling requests with models starting with "claude-opus". When a request specifies a model that starts with "claude-opus", the router will redirect to this configured model.
 
 You can also switch models dynamically in Claude Code with the `/model` command:
 `/model provider_name,model_name`

--- a/README_zh.md
+++ b/README_zh.md
@@ -163,7 +163,8 @@ npm install -g @musistudio/claude-code-router
     "think": "deepseek,deepseek-reasoner",
     "longContext": "openrouter,google/gemini-2.5-pro-preview",
     "longContextThreshold": 60000,
-    "webSearch": "gemini,gemini-2.5-flash"
+    "webSearch": "gemini,gemini-2.5-flash",
+    "seniorModel": "anthropic,claude-opus-4-1-20250805"
   }
 }
 ```
@@ -318,6 +319,7 @@ Transformers 允许您修改请求和响应负载，以确保与不同提供商 
 -   `longContext`: 用于处理长上下文（例如，> 60K 令牌）的模型。
 -   `longContextThreshold` (可选): 触发长上下文模型的令牌数阈值。如果未指定，默认为 60000。
 -   `webSearch`: 用于处理网络搜索任务，需要模型本身支持。如果使用`openrouter`需要在模型后面加上`:online`后缀。
+-   `seniorModel`: 用于处理以 "claude-opus" 开头的模型请求。当请求指定的模型以 "claude-opus" 开头时，路由器会重定向到这个配置的模型。
 
 您还可以使用 `/model` 命令在 Claude Code 中动态切换模型：
 `/model provider_name,model_name`

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -124,6 +124,14 @@ const getUseModel = async (
     log("Using background model for ", req.body.model);
     return config.Router.background;
   }
+  // If the model is claude-opus, use the senior model
+  if (
+    req.body.model?.startsWith("claude-opus") &&
+    config.Router.seniorModel
+  ) {
+    log("Using senior model for ", req.body.model);
+    return config.Router.seniorModel;
+  }
   // if exits thinking, use the think model
   if (req.body.thinking && config.Router.think) {
     log("Using think model for ", req.body.thinking);

--- a/ui/src/components/ConfigProvider.tsx
+++ b/ui/src/components/ConfigProvider.tsx
@@ -95,14 +95,16 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
             think: typeof data.Router.think === 'string' ? data.Router.think : '',
             longContext: typeof data.Router.longContext === 'string' ? data.Router.longContext : '',
             longContextThreshold: typeof data.Router.longContextThreshold === 'number' ? data.Router.longContextThreshold : 60000,
-            webSearch: typeof data.Router.webSearch === 'string' ? data.Router.webSearch : ''
+            webSearch: typeof data.Router.webSearch === 'string' ? data.Router.webSearch : '',
+            seniorModel: typeof data.Router.seniorModel === 'string' ? data.Router.seniorModel : ''
           } : {
             default: '',
             background: '',
             think: '',
             longContext: '',
             longContextThreshold: 60000,
-            webSearch: ''
+            webSearch: '',
+            seniorModel: ''
           }
         };
         
@@ -131,7 +133,8 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
               think: '',
               longContext: '',
               longContextThreshold: 60000,
-              webSearch: ''
+              webSearch: '',
+              seniorModel: ''
             }
           });
           setError(err as Error);

--- a/ui/src/components/Router.tsx
+++ b/ui/src/components/Router.tsx
@@ -30,7 +30,8 @@ export function Router() {
     think: "",
     longContext: "",
     longContextThreshold: 60000,
-    webSearch: ""
+    webSearch: "",
+    seniorModel: ""
   };
 
   const handleRouterChange = (field: string, value: string | number) => {
@@ -128,6 +129,17 @@ export function Router() {
             options={modelOptions}
             value={routerConfig.webSearch || ""}
             onChange={(value) => handleRouterChange("webSearch", value)}
+            placeholder={t("router.selectModel")}
+            searchPlaceholder={t("router.searchModel")}
+            emptyPlaceholder={t("router.noModelFound")}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>{t("router.seniorModel")}</Label>
+          <Combobox
+            options={modelOptions}
+            value={routerConfig.seniorModel || ""}
+            onChange={(value) => handleRouterChange("seniorModel", value)}
             placeholder={t("router.selectModel")}
             searchPlaceholder={t("router.searchModel")}
             emptyPlaceholder={t("router.noModelFound")}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -105,6 +105,7 @@
     "longContext": "Long Context",
     "longContextThreshold": "Context Threshold",
     "webSearch": "Web Search",
+    "seniorModel": "Senior model",
     "selectModel": "Select a model...",
     "searchModel": "Search model...",
     "noModelFound": "No model found."

--- a/ui/src/locales/zh.json
+++ b/ui/src/locales/zh.json
@@ -105,6 +105,7 @@
     "longContext": "长上下文",
     "longContextThreshold": "上下文阈值",
     "webSearch": "网络搜索",
+    "seniorModel": "高级模型",
     "selectModel": "选择一个模型...",
     "searchModel": "搜索模型...",
     "noModelFound": "未找到模型."

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -18,6 +18,7 @@ export interface RouterConfig {
     longContext: string;
     longContextThreshold: number;
     webSearch: string;
+    seniorModel: string;
     custom?: any;
 }
 


### PR DESCRIPTION
- Add routing logic in src/utils/router.ts to redirect claude-opus model requests to seniorModel
- Add seniorModel configuration option in UI Router component
- Add type definitions for seniorModel in types.ts
- Update localization files with seniorModel translations
- Update README documentation with seniorModel configuration examples


已经过本地编译和测试运行。