### PR TITLE
Fix numeric input UX: allow complete deletion with smart defaults

### DIFF
--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -4,15 +4,72 @@ import { cn } from "@/lib/utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
+    const isNumeric = type === "number";
+    const [tempValue, setTempValue] = React.useState(props.value?.toString() || '');
+    
+    React.useEffect(() => {
+      if (props.value !== undefined) {
+        setTempValue(props.value.toString());
+      }
+    }, [props.value]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      
+      if (isNumeric) {
+        // Only allow empty string or numbers for numeric input
+        if (newValue === '' || /^\d+$/.test(newValue)) {
+          setTempValue(newValue);
+          // Only call onChange if the value is not empty
+          if (props.onChange && newValue !== '') {
+            props.onChange(e);
+          }
+        }
+      } else {
+        setTempValue(newValue);
+        if (props.onChange) {
+          props.onChange(e);
+        }
+      }
+    };
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (isNumeric && tempValue === '') {
+        const defaultValue = props.placeholder || "1";
+        setTempValue(defaultValue);
+        
+        // Create a synthetic event for the corrected value
+        if (props.onChange) {
+          const syntheticEvent = {
+            ...e,
+            target: { ...e.target, value: defaultValue }
+          } as React.ChangeEvent<HTMLInputElement>;
+          
+          props.onChange(syntheticEvent);
+        }
+      }
+      
+      if (props.onBlur) {
+        props.onBlur(e);
+      }
+    };
+
+    // For numeric inputs, use text type and manage value internally
+    const inputType = isNumeric ? "text" : type;
+    const inputValue = isNumeric ? tempValue : props.value;
+
     return (
       <input
-        type={type}
+        {...props}
+        type={inputType}
+        value={inputValue}
+        onChange={handleChange}
+        onBlur={handleBlur}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}
-        {...props}
       />
     )
   }


### PR DESCRIPTION
Enhanced `Input` component to allow users to completely delete numeric field contents while typing, with automatic restoration to placeholder values on blur.

### Changes
- **`ui/src/components/ui/input.tsx`**: Auto-detects `type="number"` and improves UX
  - Allow complete deletion during typing (shows placeholder)
  - Only call `onChange` for non-empty values
  - Auto-restore to placeholder value on blur if empty
  - Uses `type="text"` internally for better control (no spinners)

### Behavior
- **Before**: Deleting content immediately reverts to fallback value

https://github.com/user-attachments/assets/48869235-68b9-47a2-9a01-c35498d5a0f8

- **After**: Can delete completely → shows placeholder → restores on blur

https://github.com/user-attachments/assets/bdbabdf7-07ed-40b6-aceb-78031fd5dacd