### PR TITLE
Fix SSE JSON parsing error in streaming responses

### DIFF
--- a/src/agents/image.agent.ts
+++ b/src/agents/image.agent.ts
@@ -134,6 +134,7 @@ export class ImageAgent implements IAgent {
           headers: {
             'x-api-key': context.config.APIKEY,
             'content-type': 'application/json',
+            'accept': 'text/event-stream',
           },
           body: JSON.stringify({
             model: context.config.Router.image,

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,7 @@ async function run(options: RunOptions = {}) {
                   headers: {
                     'x-api-key': config.APIKEY,
                     'content-type': 'application/json',
+                    'accept': 'text/event-stream',
                   },
                   body: JSON.stringify(req.body),
                 })


### PR DESCRIPTION
## 修复 SSE 流式响应中的 JSON 解析错误

### 问题描述
- 在处理 API 的 Server-Sent Events (SSE) 流式响应时出现 JSON 解析错误
- 错误信息：`SyntaxError: Unexpected token 'e', "event: mes"... is not valid JSON`
- 错误发生在 `undici` 库的 `parseJSONFromBytes` 函数中

### 根本原因
HTTP 请求缺少 `Accept: text/event-stream` 头部，导致 `undici` 库错误地将 Server-Sent Events (SSE) 格式的响应当作 JSON 处理。

### 修复方案
1. **添加正确的 Accept 头部**（主要修复）：
   - `src/index.ts:278` - 工具调用的内部请求
   - `src/agents/image.agent.ts:137` - 图像代理请求
   - 添加 `'accept': 'text/event-stream'` 确保 undici 正确处理 SSE 响应

### 修复效果
- ✅ 消除 JSON 解析错误
- ✅ 正确处理 SSE 流式响应
- ✅ 提高系统稳定性
- ✅ 向后兼容，不影响现有功能

### 测试验证
- 本地测试确认不再出现 `Unexpected token 'e'` 错误
- SSE 流式响应和 usage 统计正常工作
- 所有现有功能保持正常