### PR TITLE
warning message for missing API key instead of overwrite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,9 +66,8 @@ async function run(options: RunOptions = {}) {
 
   let HOST = config.HOST || "127.0.0.1";
 
-  if (config.HOST && !config.APIKEY) {
-    HOST = "127.0.0.1";
-    console.warn("⚠️ API key is not set. HOST is forced to 127.0.0.1.");
+  if (!config.APIKEY) {
+    console.warn("⚠️ API key is not set. Make sure your server is properly secured.");
   }
 
   const port = config.PORT || 3456;


### PR DESCRIPTION
Remove forced HOST override to `127.0.0.1` when API key is missing

Instead of forcing HOST to `127.0.0.1` when no API key is configured, now only shows a warning message. This allows proper deployment flexibility while still alerting about missing authentication.