### PR TITLE
Fix boolean flag handling for Claude Code options

### DIFF
--- a/src/utils/codeCommand.ts
+++ b/src/utils/codeCommand.ts
@@ -63,7 +63,13 @@ export async function executeCodeCommand(args: string[] = []) {
   const argsArr = []
   for (const [argsObjKey, argsObjValue] of Object.entries(argsObj)) {
     if (argsObjKey !== '_' && argsObj[argsObjKey]) {
-      argsArr.push(`${argsObjKey.length === 1 ? '-' : '--'}${argsObjKey} ${JSON.stringify(argsObjValue)}`);
+      const prefix = argsObjKey.length === 1 ? '-' : '--';
+      // For boolean flags, don't append the value
+      if (argsObjValue === true) {
+        argsArr.push(`${prefix}${argsObjKey}`);
+      } else {
+        argsArr.push(`${prefix}${argsObjKey} ${JSON.stringify(argsObjValue)}`);
+      }
     }
   }
   const claudeProcess = spawn(


### PR DESCRIPTION
Problem:
When passing boolean flags like --continue and --resume to Claude Code through ccr, they were incorrectly transformed to "--continue true" and "--resume true". Claude Code expects these as standalone flags without values, causing them to not be recognized.

Solution:
Modified the argument reconstruction logic in codeCommand.ts to check if a flag value is boolean true. Boolean flags are now passed without values (e.g., "--continue"), while non-boolean flags retain their values (e.g., "--option value").