### PR TITLE
refactor:optimize haiku background routing

### DIFF
--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -114,9 +114,10 @@ const getUseModel = async (
       return model[1];
     }
   }
-  // If the model is claude-3-5-haiku, use the background model
+  // Use the background model for any Claude Haiku variant
   if (
-    req.body.model?.startsWith("claude-3-5-haiku") &&
+    req.body.model?.includes("claude") &&
+    req.body.model?.includes("haiku") &&
     config.Router.background
   ) {
     req.log.info(`Using background model for ${req.body.model}`);


### PR DESCRIPTION
## 背景
随着Claude Haiku 4.5  近期发布，cli更新，模型名称或版本标识发生变化，原先的前缀判断 `startsWith("claude-3-5-haiku")` 无法再准确匹配，导致 Haiku 请求不会走背景模型路由。

## 变更内容
- 将 Haiku 模型判定逻辑调整为同时包含 `claude` 与 `haiku` 的通用匹配，确保所有 Claude Haiku 变体均能路由到配置的 background 模型。
- 更新相关注释，描述新的匹配范围。