### PR TITLE
feat(server): integrate local slash command loader into server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,8 @@ import fastifyStatic from "@fastify/static";
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from "fs";
 import { homedir } from "os";
 import {calculateTokenCount} from "./utils/router";
+import { join, extname } from "path";
+
 
 function loadUserTools() {
   const commandsDir = join(homedir(), ".claude", "commands");


### PR DESCRIPTION
### Summary
This PR integrates a local slash command loader directly into `server.ts`.  
The server now automatically reads and registers custom slash command definitions from `~/.claude/commands` at runtime.

### Details
- Added a new `loadUserTools()` function inside `server.ts`.
- Supports three file formats:
  - `.json`: structured tool definitions.
  - `.js`: executable modules exporting `default` objects.
  - `.md`: Markdown-based documentation commands (header = name, body = description).
- Injects loaded tools into `/v1/messages` responses, making them appear as local slash commands inside Claude Code.

### Motivation
This allows developers to define and test their own custom commands without modifying the core Claude Code CLI.  

### Notes
- Fully backward-compatible — if no local commands exist, the router behaves as before.
- Logs each successfully loaded command to the console for visibility.
- Keeps all configuration self-contained within `server.ts` (no external loader dependency).
<img width="861" height="335" alt="Screenshot 2025-10-18 at 21 38 21" src="https://github.com/user-attachments/assets/4bdce713-4b0f-4a58-9cfa-f966a32dcc9d" />


### Example
Example file: `~/.claude/commands/orchestrator.md`
```
# Orchestrator

Split complex tasks into sequential steps, where each step can contain multiple parallel subtasks.

## Process

1. **Initial Analysis**
   - First, analyze the entire task to
   ...
 ```
