### PR TITLE
fix: support JSON5 configuration parsing in model selector

### DIFF
--- a/src/utils/modelSelector.ts
+++ b/src/utils/modelSelector.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { select, input, confirm } from '@inquirer/prompts';
+import JSON5 from 'json5';
 
 // ANSI color codes
 const RESET = "\x1B[0m";
@@ -80,7 +81,7 @@ function getConfigPath(): string {
 
 function loadConfig(): Config {
   const configPath = getConfigPath();
-  return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  return JSON5.parse(fs.readFileSync(configPath, 'utf-8'));
 }
 
 function saveConfig(config: Config): void {


### PR DESCRIPTION
- Add JSON5 dependency for enhanced configuration file support
- Update modelSelector.ts to use JSON5.parse instead of JSON.parse
- Allows configuration files to include comments and other JSON5 features


fix problem like:
1. `config.json` with comments
<img width="777" height="312" alt="image" src="https://github.com/user-attachments/assets/f665df68-8a5b-4714-b99b-d41cd446d7e2" />

2. run `ccr model` will failed.
<img width="738" height="82" alt="image" src="https://github.com/user-attachments/assets/da67138e-a521-4264-996d-34e1207b9cea" />
