### PR TITLE
Fix: Add null checks for config.Router to prevent undefined errors

### DIFF
--- a/src/agents/image.agent.ts
+++ b/src/agents/image.agent.ts
@@ -56,7 +56,7 @@ export class ImageAgent implements IAgent {
   }
 
   shouldHandle(req: any, config: any): boolean {
-    if (!config.Router.image || req.body.model === config.Router.image)
+    if (!config.Router || !config.Router.image || req.body.model === config.Router.image)
       return false;
     const lastMessage = req.body.messages[req.body.messages.length - 1];
     if (

--- a/src/utils/modelSelector.ts
+++ b/src/utils/modelSelector.ts
@@ -119,9 +119,13 @@ function displayCurrentConfig(config: Config): void {
   };
   
   console.log(`${BOLDCYAN}Default Model:${RESET}`);
-  console.log(`  ${formatModel(config.Router.default)}\n`);
-  
-  if (config.Router.background) {
+  if (config.Router && config.Router.default) {
+    console.log(`  ${formatModel(config.Router.default)}\n`);
+  } else {
+    console.log(`  ${DIM}Not configured${RESET}\n`);
+  }
+
+  if (config.Router && config.Router.background) {
     console.log(`${BOLDCYAN}Background Model:${RESET}`);
     console.log(`  ${formatModel(config.Router.background)}\n`);
   }

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -158,6 +158,7 @@ const getUseModel = async (
   if (
     req.body.model?.includes("claude") &&
     req.body.model?.includes("haiku") &&
+    config.Router &&
     config.Router.background
   ) {
     req.log.info(`Using background model for ${req.body.model}`);
@@ -224,7 +225,7 @@ export const router = async (req: any, _res: any, context: any) => {
     req.body.model = model;
   } catch (error: any) {
     req.log.error(`Error in router middleware: ${error.message}`);
-    req.body.model = config.Router!.default;
+    req.body.model = config.Router && config.Router.default ? config.Router.default : 'default';
   }
   return;
 };


### PR DESCRIPTION
## 🐛 Bug Description

CCR crashes with `TypeError: Cannot read properties of undefined` when accessing `config.Router` properties without checking if `config.Router` exists first.

## 🔍 Root Cause

Multiple locations in the codebase access `config.Router.xxx` without verifying that `config.Router` is defined. This happens when:
- No Router configuration is provided in config.json
- First-time setup without Router section  
- Configuration files missing Router object

## ✅ Changes Made

### Files Modified:
- `src/agents/image.agent.ts` (line 59)
- `src/utils/router.ts` (lines 161, 227)
- `src/utils/modelSelector.ts` (line 122)

### Fix Pattern:
All fixes follow defensive programming:
```typescript
// Before
if (!config.Router.image)

// After  
if (!config.Router || !config.Router.image)
```

## 🧪 Testing

Tested with:
- ✅ Qwen3 14B via CCR → Ollama
- ✅ GLM-4 9B via Ollama (direct)
- ✅ DeepSeek-R1 8B via Ollama (direct)
- ✅ CCR health endpoint

All tests passed without crashes.

## 📝 Additional Notes

This is a defensive programming fix that prevents crashes when `config.Router` is undefined. No functionality changes, only safety improvements.