### PR TITLE
fix: handle array flags by expanding to multiple flag pairs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "@fastify/static": "^8.2.0",
-    "@musistudio/llms": "^1.0.38",
     "@inquirer/prompts": "^5.0.0",
+    "@musistudio/llms": "^1.0.38",
     "dotenv": "^16.4.7",
     "find-process": "^2.0.0",
     "json5": "^2.2.3",
@@ -29,11 +29,11 @@
     "minimist": "^1.2.8",
     "openurl": "^1.1.1",
     "rotating-file-stream": "^3.2.7",
-    "shell-quote": "^1.8.3",
     "tiktoken": "^1.0.21",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@types/minimist": "^1.2.5",
     "@types/node": "^24.0.15",
     "esbuild": "^0.25.1",
     "fastify": "^5.4.0",
@@ -46,5 +46,6 @@
       "src/",
       "screenshots/"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       rotating-file-stream:
         specifier: ^3.2.7
         version: 3.2.7
-      shell-quote:
-        specifier: ^1.8.3
-        version: 1.8.3
       tiktoken:
         specifier: ^1.0.21
         version: 1.0.22
@@ -48,6 +45,9 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
     devDependencies:
+      '@types/minimist':
+        specifier: ^1.2.5
+        version: 1.2.5
       '@types/node':
         specifier: ^24.0.15
         version: 24.7.0
@@ -355,6 +355,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
@@ -947,10 +950,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
-
   shelljs@0.9.2:
     resolution: {integrity: sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==}
     engines: {node: '>=18'}
@@ -1401,6 +1400,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@types/minimist@1.2.5': {}
 
   '@types/mute-stream@0.0.4':
     dependencies:
@@ -2003,8 +2004,6 @@ snapshots:
   shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
-
-  shell-quote@1.8.3: {}
 
   shelljs@0.9.2:
     dependencies:


### PR DESCRIPTION
## Description

Fixes #949 by handling array values in CLI flags properly, using a different approach from #952.

When users provide multiple values for a flag (e.g., `ccr code --settings valueA valueB`), minimist parses it as an array. The previous code would `JSON.stringify()` the entire array, resulting in malformed command construction like:

```
--settings [valueA,valueB,{"env":{...}}]
```

This caused errors such as:
```
Error: Settings file not found: [/Users/user/.claude/settings.json,{"env":{...}}]
```

## Approach

This PR takes a **different approach from #952** by keeping the original design intact while adding proper array handling:

- **#952's approach**: Simplifies by removing minimist and passing arguments directly
- **This PR's approach**: Keeps the existing architecture but adds array detection and expansion

### Changes Made

1. ✅ **Array flag handling**: Detects array values and expands them into separate flag-value pairs
   ```typescript
   // Instead of: --settings [value1,value2]
   // Generates: --settings value1 --settings value2
   ```

2. ✅ **Removed `shell-quote` dependency**: No longer needed with proper array handling

3. ✅ **Added `@types/minimist`**: Improved TypeScript support

4. ✅ **Type safety improvements**: Fixed type annotations for `env` and `settingsFlag`

## Benefits of This Approach

- Maintains the original minimist-based argument parsing design
- Supports both single and multiple values naturally
- Minimal changes to existing code structure
- Properly handles edge cases where users intentionally provide multiple flag values

## Testing

This fix allows commands like this to work correctly:
```bash
ccr code --settings ~/.claude/settings.json --settings ~/.claude/settings2.json
```

## Related

- Fixes #949
- Alternative approach to #952

---

**Note**: Both this PR and #952 are valid solutions. This approach preserves more of the existing architecture, while #952 simplifies the overall design. The maintainers can choose which approach better fits the project's direction.
