### PR TITLE
feat: add port availability check before starting service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   isServiceRunning,
   savePid,
 } from "./utils/processCheck";
+import { isPortAvailable } from "./utils/portCheck";
 import { CONFIG_FILE } from "./constants";
 import { createStream } from 'rotating-file-stream';
 import { HOME_DIR } from "./constants";
@@ -73,6 +74,17 @@ async function run(options: RunOptions = {}) {
 
   const port = config.PORT || 3456;
 
+  // Check port availability before starting the service
+  try {
+    const isAvailable = await isPortAvailable(port);
+    if (!isAvailable) {
+      console.log(`Port ${port} is already in use. Please stop the process using this port or change the PORT in your config file.`);
+      process.exit(1);
+    }
+    console.log(`Port ${port} is not in use. start process ....`);
+  } catch (error) {
+    console.log("Could not check port availability, proceeding with start...");
+  }
   // Save the PID of the background process
   savePid(process.pid);
 

--- a/src/utils/portCheck.ts
+++ b/src/utils/portCheck.ts
@@ -1,0 +1,46 @@
+import net from 'net';
+
+/**
+ * Check if a port is available for use
+ * @param port The port number to check
+ * @returns Promise that resolves to true if port is available, false otherwise
+ */
+export async function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    
+    server.once('error', (err: any) => {
+      if (err.code === 'EADDRINUSE') {
+        resolve(false);
+      } else {
+        // Some other error occurred
+        resolve(false);
+      }
+    });
+    
+    server.once('listening', () => {
+      // Port is available, close the server
+      server.close(() => {
+        resolve(true);
+      });
+    });
+    
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+/**
+ * Check if a port is in use by trying to connect to it
+ * @param port The port number to check
+ * @param host The host to check (defaults to 127.0.0.1)
+ * @returns Promise that resolves to true if port is in use, false otherwise
+ */
+export async function isPortInUse(port: number, host: string = '127.0.0.1'): Promise<boolean> {
+  try {
+    const result = await isPortAvailable(port);
+    return !result;
+  } catch (error) {
+    // If there's an error checking, assume it's in use
+    return true;
+  }
+}


### PR DESCRIPTION
# Description
ccr code command fails to start correctly when the configured port is already in use. Previously, when ccr code was executed and the service wasn't detected as running, it would attempt to start a background service. However, if the port was already occupied
by another process (or a zombie process from a previous run), the service startup would timeout without providing any indication that the issue was a port conflict. This led to confusing "startup timeout" errors that were difficult to debug.

# Fix

The core issue has been resolved by adding port availability checks before attempting to start the
service in all relevant commands:
- Added isPortAvailable function in a new utility module to check port status
- Implemented port checking in the main run() function in src/index.ts before starting the server
- Added import for the new port checking utility
- Updated error messaging to provide clear indication when a port is already in use

# Changes

- New file: src/utils/portCheck.ts - Contains port availability checking functions
- Modified: src/index.ts - Added port checking logic before server startup with appropriate error handling
- Now provides clear error message when port is already in use instead of generic timeout error