### PR TITLE
feat: add `ccr activate` command for Agent SDK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,32 @@ This command provides an interactive interface to:
 
 The CLI tool validates all inputs and provides helpful prompts to guide you through the configuration process, making it easy to manage complex setups without editing JSON files manually.
 
+### 6. Activate Command (Environment Variables Setup)
+
+The `activate` command allows you to set up environment variables globally in your shell, enabling you to use the `claude` command directly or integrate Claude Code Router with applications built using the Agent SDK.
+
+To activate the environment variables, run:
+
+```shell
+eval "$(ccr activate)"
+```
+
+This command outputs the necessary environment variables in shell-friendly format, which are then set in your current shell session. After activation, you can:
+
+- **Use `claude` command directly**: Run `claude` commands without needing to use `ccr code`. The `claude` command will automatically route requests through Claude Code Router.
+- **Integrate with Agent SDK applications**: Applications built with the Anthropic Agent SDK will automatically use the configured router and models.
+
+The `activate` command sets the following environment variables:
+
+- `ANTHROPIC_AUTH_TOKEN`: API key from your configuration
+- `ANTHROPIC_BASE_URL`: The local router endpoint (default: `http://127.0.0.1:3456`)
+- `NO_PROXY`: Set to `127.0.0.1` to prevent proxy interference
+- `DISABLE_TELEMETRY`: Disables telemetry
+- `DISABLE_COST_WARNINGS`: Disables cost warnings
+- `API_TIMEOUT_MS`: API timeout from your configuration
+
+> **Note**: Make sure the Claude Code Router service is running (`ccr start`) before using the activated environment variables. The environment variables are only valid for the current shell session. To make them persistent, you can add `eval "$(ccr activate)"` to your shell configuration file (e.g., `~/.zshrc` or `~/.bashrc`).
+
 #### Providers
 
 The `Providers` array is where you define the different model providers you want to use. Each provider object requires:

--- a/README_zh.md
+++ b/README_zh.md
@@ -207,6 +207,32 @@ ccr ui
 
 ![UI](/blog/images/ui.png)
 
+### 5. Activate 命令（环境变量设置）
+
+`activate` 命令允许您在 shell 中全局设置环境变量，使您能够直接使用 `claude` 命令或将 Claude Code Router 与使用 Agent SDK 构建的应用程序集成。
+
+要激活环境变量，请运行：
+
+```shell
+eval "$(ccr activate)"
+```
+
+此命令会以 shell 友好的格式输出必要的环境变量，这些变量将在当前的 shell 会话中设置。激活后，您可以：
+
+- **直接使用 `claude` 命令**：无需使用 `ccr code` 即可运行 `claude` 命令。`claude` 命令将自动通过 Claude Code Router 路由请求。
+- **与 Agent SDK 应用程序集成**：使用 Anthropic Agent SDK 构建的应用程序将自动使用配置的路由器和模型。
+
+`activate` 命令设置以下环境变量：
+
+- `ANTHROPIC_AUTH_TOKEN`: 来自配置的 API 密钥
+- `ANTHROPIC_BASE_URL`: 本地路由器端点（默认：`http://127.0.0.1:3456`）
+- `NO_PROXY`: 设置为 `127.0.0.1` 以防止代理干扰
+- `DISABLE_TELEMETRY`: 禁用遥测
+- `DISABLE_COST_WARNINGS`: 禁用成本警告
+- `API_TIMEOUT_MS`: 来自配置的 API 超时时间
+
+> **注意**：在使用激活的环境变量之前，请确保 Claude Code Router 服务正在运行（`ccr start`）。环境变量仅在当前 shell 会话中有效。要使其持久化，您可以将 `eval "$(ccr activate)"` 添加到您的 shell 配置文件（例如 `~/.zshrc` 或 `~/.bashrc`）中。
+
 #### Providers
 
 `Providers` 数组是您定义要使用的不同模型提供商的地方。每个提供商对象都需要：

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
   getServiceInfo,
 } from "./utils/processCheck";
 import { runModelSelector } from "./utils/modelSelector"; // ADD THIS LINE
+import { activateCommand } from "./utils/activateCommand";
 import { version } from "../package.json";
 import { spawn, exec } from "child_process";
 import { PID_FILE, REFERENCE_COUNT_FILE } from "./constants";
@@ -21,13 +22,14 @@ const HELP_TEXT = `
 Usage: ccr [command]
 
 Commands:
-  start         Start server 
+  start         Start server
   stop          Stop server
   restart       Restart server
   status        Show server status
   statusline    Integrated statusline
   code          Execute claude command
   model         Interactive model selection and configuration
+  activate      Output environment variables for shell integration
   ui            Open the web UI in browser
   -v, version   Show version information
   -h, help      Show help information
@@ -36,6 +38,7 @@ Example:
   ccr start
   ccr code "Write a Hello World"
   ccr model
+  eval "$(ccr activate)"  # Set environment variables globally
   ccr ui
 `;
 
@@ -115,6 +118,10 @@ async function main() {
     // ADD THIS CASE
     case "model":
       await runModelSelector();
+      break;
+    case "activate":
+    case "env":
+      await activateCommand();
       break;
     case "code":
       if (!isRunning) {

--- a/src/utils/activateCommand.ts
+++ b/src/utils/activateCommand.ts
@@ -1,0 +1,19 @@
+import { createEnvVariables } from "./createEnvVariables";
+
+/**
+ * Execute the env command
+ */
+export const activateCommand = async () => {
+  const envVars = await createEnvVariables();
+
+  // Output in shell-friendly format for eval
+  for (const [key, value] of Object.entries(envVars)) {
+    if (value === "") {
+      console.log(`export ${key}=""`);
+    } else if (value === undefined) {
+      console.log(`unset ${key}`);
+    } else {
+      console.log(`export ${key}="${value}"`);
+    }
+  }
+}

--- a/src/utils/codeCommand.ts
+++ b/src/utils/codeCommand.ts
@@ -7,23 +7,13 @@ import {
 } from "./processCheck";
 import { quote } from 'shell-quote';
 import minimist from "minimist";
+import { createEnvVariables } from "./createEnvVariables";
 
 
 export async function executeCodeCommand(args: string[] = []) {
-  // Set environment variables
+  // Set environment variables using shared function
   const config = await readConfigFile();
-  const port = config.PORT || 3456;
-  const env: Record<string, string> = {
-    ANTHROPIC_AUTH_TOKEN: config?.APIKEY || "test",
-    ANTHROPIC_API_KEY: '',
-    ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
-    NO_PROXY: `127.0.0.1`,
-    DISABLE_TELEMETRY: 'true',
-    DISABLE_COST_WARNINGS: 'true',
-    API_TIMEOUT_MS: String(config.API_TIMEOUT_MS ?? 600000), // Default to 10 minutes if not set
-   // Reset CLAUDE_CODE_USE_BEDROCK when running with ccr code
-    CLAUDE_CODE_USE_BEDROCK: undefined,
-  };
+  const env = await createEnvVariables();
   const settingsFlag = {
     env
   };

--- a/src/utils/createEnvVariables.ts
+++ b/src/utils/createEnvVariables.ts
@@ -1,0 +1,23 @@
+import { readConfigFile } from ".";
+
+/**
+ * Get environment variables for Agent SDK/Claude Code integration
+ * This function is shared between `ccr env` and `ccr code` commands
+ */
+export const createEnvVariables = async () => {
+  const config = await readConfigFile();
+  const port = config.PORT || 3456;
+  const apiKey = config.APIKEY || "test";
+
+  return {
+    ANTHROPIC_AUTH_TOKEN: apiKey,
+    ANTHROPIC_API_KEY: "",
+    ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+    NO_PROXY: "127.0.0.1",
+    DISABLE_TELEMETRY: "true",
+    DISABLE_COST_WARNINGS: "true",
+    API_TIMEOUT_MS: String(config.API_TIMEOUT_MS ?? 600000),
+    // Reset CLAUDE_CODE_USE_BEDROCK when running with ccr
+    CLAUDE_CODE_USE_BEDROCK: undefined,
+  };
+}


### PR DESCRIPTION
## Background

I'm the author of [d-kimuson/claude-code-viewer](https://github.com/d-kimuson/claude-code-viewer), which uses the Agent SDK to provide a web-based GUI for Claude Code. I received [this issue](https://github.com/d-kimuson/claude-code-viewer/issues/52) from a user who wanted to use it with claude-code-router.

After reading the implementation, I realized it should work in principle by running `ccr start` and setting the appropriate environment variables. However, manually converting the config file to environment variables is cumbersome. I thought it would be beneficial to have a CLI command that just handles the environment variable setup. This would enable seamless integration not only with claude-code-viewer but with any Agent SDK-based application.

## Implementation

This PR adds a `ccr activate` command to achieve this goal. This is also a proof of concept - if a different interface design is preferred, feel free to reject this and recreate it, or let me know and I can make the changes.

## Usage

### Basic Usage

```bash
$ ccr activate
export ANTHROPIC_AUTH_TOKEN="test"
export ANTHROPIC_API_KEY=""
export ANTHROPIC_BASE_URL="http://127.0.0.1:3456"
export NO_PROXY="127.0.0.1"
export DISABLE_TELEMETRY="true"
export DISABLE_COST_WARNINGS="true"
export API_TIMEOUT_MS="600000"
unset CLAUDE_CODE_USE_BEDROCK

$ eval $(ccr activate)

$ echo $ANTHROPIC_AUTH_TOKEN
test
```

### With Agent SDK Applications

```bash
# Start the router
ccr start

# Activate environment variables
eval $(ccr activate)

# Now any Agent SDK application will use ccr's routing
npx @kimuson/claude-code-viewer@latest
# or any other Agent SDK application
```

## Technical Details

- Refactored environment variable creation logic from `ccr code` into a shared `createEnvVariables()` function
- The `activate` command outputs in shell-friendly format by default (no `--shell` flag needed)
- Environment variables match exactly what `ccr code` uses internally
- Updated both English and Chinese documentation

## Testing

Tested on my local environment:
- `ccr activate` outputs correct environment variables ✅
- `eval $(ccr activate)` successfully sets environment variables ✅
- `ccr code` still works correctly with refactored code ✅
