### PR TITLE
fix(ui): 修复空包体请求携带错误的 Content-Type 头导致的接口报错

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -75,10 +75,13 @@ class ApiClient {
   private async apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
     
+    // Only set Content-Type if there is a body
+    const contentType = options.body ? 'application/json' : '';
+    
     const config: RequestInit = {
       ...options,
       headers: {
-        ...this.createHeaders(),
+        ...this.createHeaders(contentType),
         ...options.headers,
       },
     };


### PR DESCRIPTION
while user try to delete log file , the ui 调用 createHeaders()，导致 DELETE 等无包体请求也被强制加上了 Content-Type: application/json。 Fastify 服务端在收到此头时会尝试解析 Body，面对空 Body 直接抛出 FST_ERR_CTP_EMPTY_JSON_BODY 错误。

修改后：仅在 options.body 存在时才添加 JSON Content-Type 头。
<img width="2559" height="565" alt="image" src="https://github.com/user-attachments/assets/f147c05b-613a-4a32-9814-dc74a3df0fb5" />
