### PR TITLE
fix: resolve DEP0190 warning in child_process spawn

### DIFF
--- a/src/utils/codeCommand.ts
+++ b/src/utils/codeCommand.ts
@@ -64,9 +64,12 @@ export async function executeCodeCommand(args: string[] = []) {
       }
     }
   }
+  // Fix for DEP0190: Passing args to a child process with shell option true
+  // We join the command and arguments into a single string
+  const command = `${JSON.stringify(claudePath)} ${argsArr.join(" ")}`;
   const claudeProcess = spawn(
-    claudePath,
-    argsArr,
+    command,
+    [],
     {
       env: process.env,
       stdio: stdioConfig,


### PR DESCRIPTION
Update `executeCodeCommand` to pass the command and arguments as a single string when using `shell: true`. 
This addresses the Node.js DEP0190 DeprecationWarning regarding potential security vulnerabilities with unescaped arguments in shell mode.