### PR TITLE
feat(auth): support multiple API keys configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The `config.json` file has several key sections:
 - **Logging Systems**: The Claude Code Router uses two separate logging systems:
   - **Server-level logs**: HTTP requests, API calls, and server events are logged using pino in the `~/.claude-code-router/logs/` directory with filenames like `ccr-*.log`
   - **Application-level logs**: Routing decisions and business logic events are logged in `~/.claude-code-router/claude-code-router.log`
-- **`APIKEY`** (optional): You can set a secret key to authenticate requests. When set, clients must provide this key in the `Authorization` header (e.g., `Bearer your-secret-key`) or the `x-api-key` header. Example: `"APIKEY": "your-secret-key"`.
+- **`APIKEY`** (optional): You can set a secret key to authenticate requests. When set, clients must provide this key in the `Authorization` header (e.g., `Bearer your-secret-key`) or the `x-api-key` header. Example: `"APIKEY": "your-secret-key"`. Also supports multiple keys via array format (e.g., `"APIKEY": ["key1", "key2"]`) or comma-separated string (e.g., `"APIKEY": "key1,key2"`).
 - **`HOST`** (optional): You can set the host address for the server. If `APIKEY` is not set, the host will be forced to `127.0.0.1` for security reasons to prevent unauthorized access. Example: `"HOST": "0.0.0.0"`.
 - **`NON_INTERACTIVE_MODE`** (optional): When set to `true`, enables compatibility with non-interactive environments like GitHub Actions, Docker containers, or other CI/CD systems. This sets appropriate environment variables (`CI=true`, `FORCE_COLOR=0`, etc.) and configures stdin handling to prevent the process from hanging in automated environments. Example: `"NON_INTERACTIVE_MODE": true`.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,7 +53,7 @@ npm install -g @musistudio/claude-code-router
 - **日志系统**: Claude Code Router 使用两个独立的日志系统：
   - **服务器级别日志**: HTTP 请求、API 调用和服务器事件使用 pino 记录在 `~/.claude-code-router/logs/` 目录中，文件名类似于 `ccr-*.log`
   - **应用程序级别日志**: 路由决策和业务逻辑事件记录在 `~/.claude-code-router/claude-code-router.log` 文件中
-- **`APIKEY`** (可选): 您可以设置一个密钥来进行身份验证。设置后，客户端请求必须在 `Authorization` 请求头 (例如, `Bearer your-secret-key`) 或 `x-api-key` 请求头中提供此密钥。例如：`"APIKEY": "your-secret-key"`。
+- **`APIKEY`** (可选): 您可以设置一个密钥来进行身份验证。设置后，客户端请求必须在 `Authorization` 请求头 (例如, `Bearer your-secret-key`) 或 `x-api-key` 请求头中提供此密钥。例如：`"APIKEY": "your-secret-key"`。也支持多密钥配置：数组格式 (例如：`"APIKEY": ["key1", "key2"]`) 或逗号分隔字符串 (例如：`"APIKEY":  "key1,key2"`)。
 - **`HOST`** (可选): 您可以设置服务的主机地址。如果未设置 `APIKEY`，出于安全考虑，主机地址将强制设置为 `127.0.0.1`，以防止未经授权的访问。例如：`"HOST": "0.0.0.0"`。
 - **`NON_INTERACTIVE_MODE`** (可选): 当设置为 `true` 时，启用与非交互式环境（如 GitHub Actions、Docker 容器或其他 CI/CD 系统）的兼容性。这会设置适当的环境变量（`CI=true`、`FORCE_COLOR=0` 等）并配置 stdin 处理，以防止进程在自动化环境中挂起。例如：`"NON_INTERACTIVE_MODE": true`。
 - **`Providers`**: 用于配置不同的模型提供商。

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -41,7 +41,11 @@ export const apiKeyAuth =
       token = authKey;
     }
 
-    if (token !== apiKey) {
+    const validKeys = Array.isArray(apiKey)
+      ? apiKey.map((k: string) => k.trim()).filter(Boolean)
+      : String(apiKey).split(",").map((k) => k.trim()).filter(Boolean);
+
+    if (!validKeys.includes(token)) {
       reply.status(401).send("Invalid API key");
       return;
     }


### PR DESCRIPTION
  ## Summary

  - Add support for configuring multiple API keys in authentication middleware
  - Support array format: `["key1", "key2", "key3"]`
  - Support comma-separated string: `"key1,key2,key3"`
  - Backward compatible with existing single-key configurations

  ## Use Cases

  - Team members using individual keys
  - Key rotation without service interruption
  - Environment-specific keys (dev/staging/prod)

  ## Test plan

  - [x] Test single key (legacy format) - ✅ works
  - [x] Test comma-separated keys - ✅ works
  - [x] Test array format keys - ✅ works
  - [x] Test invalid key rejection - ✅ returns 401

  ---

  ## 概述

  - 在认证中间件中添加多 API 密钥配置支持
  - 支持数组格式：`["key1", "key2", "key3"]`
  - 支持逗号分隔字符串：`"key1,key2,key3"`
  - 向后兼容现有的单密钥配置

  ## 使用场景

  - 团队成员使用独立密钥
  - 密钥轮换时无需中断服务
  - 不同环境使用不同密钥（开发/测试/生产）

  ## 测试计划

  - [x] 测试单密钥（旧格式）- ✅ 通过
  - [x] 测试逗号分隔密钥 - ✅ 通过
  - [x] 测试数组格式密钥 - ✅ 通过
  - [x] 测试无效密钥拒绝 - ✅ 返回 401

  🤖 Generated with [Claude Code](https://claude.com/claude-code)