### PR TITLE
Fix #402: --print flag not being handled correctly

### DIFF
--- a/packages/cli/src/utils/codeCommand.ts
+++ b/packages/cli/src/utils/codeCommand.ts
@@ -5,7 +5,6 @@ import {
   incrementReferenceCount,
   closeService,
 } from "./processCheck";
-import { quote } from 'shell-quote';
 import minimist from "minimist";
 import { createEnvVariables } from "./createEnvVariables";
 
@@ -93,14 +92,14 @@ export async function executeCodeCommand(
   // Execute claude command
   const claudePath = config?.CLAUDE_PATH || process.env.CLAUDE_PATH || "claude";
 
-  const joinedArgs = args.length > 0 ? quote(args) : "";
-
   const stdioConfig: StdioOptions = config.NON_INTERACTIVE_MODE
     ? ["pipe", "inherit", "inherit"] // Pipe stdin for non-interactive
     : "inherit"; // Default inherited behavior
 
   const argsObj = minimist(args)
-  const argsArr = []
+  const argsArr: string[] = []
+  
+  // Handle flags and their values
   for (const [argsObjKey, argsObjValue] of Object.entries(argsObj)) {
     if (argsObjKey !== '_' && argsObj[argsObjKey]) {
       const prefix = argsObjKey.length === 1 ? '-' : '--';
@@ -108,10 +107,17 @@ export async function executeCodeCommand(
       if (argsObjValue === true) {
         argsArr.push(`${prefix}${argsObjKey}`);
       } else {
-        argsArr.push(`${prefix}${argsObjKey} ${JSON.stringify(argsObjValue)}`);
+        argsArr.push(`${prefix}${argsObjKey}`);
+        argsArr.push(String(argsObjValue)); // Separate arg, not concatenated
       }
     }
   }
+  
+  // CRITICAL: Add positional arguments (the prompt text after -p)
+  if (argsObj._ && argsObj._.length > 0) {
+    argsArr.push(...argsObj._.map(String));
+  }
+  
   const claudeProcess = spawn(
     claudePath,
     argsArr,
@@ -120,7 +126,7 @@ export async function executeCodeCommand(
         ...process.env,
       },
       stdio: stdioConfig,
-      shell: true,
+      shell: false, // Changed from true to false for proper argument handling
     }
   );
 


### PR DESCRIPTION
## Problem

`ccr code -p "prompt"` or `ccr code --print "prompt"` doesn't work - it opens interactive mode instead of running in print/headless mode.

## Root Cause

In `packages/cli/src/utils/codeCommand.ts`, the `executeCodeCommand` function had broken argument handling:

1. Used minimist to parse args into `argsObj`
2. Reconstructed args into `argsArr` but **ignored `argsObj._`** (positional arguments containing the prompt)
3. Concatenated flag values like `-p "prompt"` as a single string instead of separate args
4. Used `shell: true` which caused additional parsing issues

## Solution

- Pass flag values as separate arguments instead of concatenated strings
- Include positional arguments from `argsObj._` (the prompt text after `-p`)
- Change `shell: true` to `shell: false` for proper argument handling
- Remove unused `shell-quote` import and `joinedArgs` variable

## Testing

After the fix, these commands work correctly:

```bash
ccr code -p "Hello world"  # runs non-interactively, prints response
ccr code --print "Hello world"  # same behavior
ccr code -p "Create a file" --dangerously-skip-permissions  # runs with permissions bypassed
```

Tested locally and confirmed the fix works as expected.

Closes #402