### PR TITLE
Fix links in quick-start documentation

### DIFF
--- a/docs/docs/cli/quick-start.md
+++ b/docs/docs/cli/quick-start.md
@@ -70,6 +70,6 @@ Or restart directly through the Web UI.
 
 ## What's Next?
 
-- [Basic Configuration](/docs/cli/config/basic) - Learn about configuration options
-- [Routing](/docs/cli/config/routing) - Configure smart routing rules
-- [CLI Commands](/docs/category/cli-commands) - Explore all CLI commands
+- [Basic Configuration](/docs/docs/cli/config/basic.md) - Learn about configuration options
+- [Routing](/docs/docs/server/config/routing.md) - Configure smart routing rules
+- [CLI Commands](/docs/docs/cli/commands) - Explore all CLI commands


### PR DESCRIPTION
I found that former links[`quick-start.md#L73-L75`](https://github.com/musistudio/claude-code-router/blob/c73fe0d49d7cb0e8b8c7d0b1677c170b92d2a2ae/docs/docs/cli/quick-start.md?plain=1#L73-L75) are invalid. Correct links might be this. Hopefully, I didn't get anything wrong. Please let me know if you want further communication. I'm always willing to help!