### PR TITLE
use CleanThinkingInMessageTransformer in openai model

### DIFF
--- a/packages/cli/src/utils/modelSelector.ts
+++ b/packages/cli/src/utils/modelSelector.ts
@@ -61,6 +61,7 @@ const AVAILABLE_TRANSFORMERS = [
   'sampling',
   'enhancetool',
   'cleancache',
+  'cleanThinkingInMessage',
   'vertex-gemini',
   'chutes-glm',
   'qwen-cli',

--- a/packages/core/src/transformer/cleanThinkingInMessage.transformer.ts
+++ b/packages/core/src/transformer/cleanThinkingInMessage.transformer.ts
@@ -1,0 +1,22 @@
+import { MessageContent, UnifiedChatRequest } from "@/types/llm";
+import { Transformer } from "../types/transformer";
+
+export class CleanThinkingInMessageTransformer implements Transformer {
+  name = "cleanThinkingInMessage";
+  logger?: any;
+
+  async transformRequestIn(request: UnifiedChatRequest): Promise<UnifiedChatRequest> {
+    this.logger?.debug(`[${this.name}] Cleaning thinking content from messages`);
+    
+    if (Array.isArray(request.messages)) {
+      var messages = request.messages.map((msg) => {
+        if (!!msg.thinking){
+          delete msg.thinking;
+        }
+        return msg;
+      });
+      request.messages = messages;
+    }
+    return request;
+  }
+}

--- a/packages/core/src/transformer/index.ts
+++ b/packages/core/src/transformer/index.ts
@@ -19,6 +19,7 @@ import { CustomParamsTransformer } from "./customparams.transformer";
 import { VercelTransformer } from "./vercel.transformer";
 import { OpenAIResponsesTransformer } from "./openai.responses.transformer";
 import { ForceReasoningTransformer } from "./forcereasoning.transformer"
+import { CleanThinkingInMessageTransformer } from "./cleanThinkingInMessage.transformer";
 
 export default {
   AnthropicTransformer,
@@ -41,5 +42,6 @@ export default {
   CustomParamsTransformer,
   VercelTransformer,
   OpenAIResponsesTransformer,
-  ForceReasoningTransformer
+  ForceReasoningTransformer,
+  CleanThinkingInMessageTransformer,
 };


### PR DESCRIPTION
how to config

```
    {
      "name": "azureopenai",
      "api_base_url": "https://<xxx>/openai/responses?api-version=2025-04-01-preview",
      "api_key": "xxx",
      "models": [
        "gpt-5.2-codex",
        "gpt-4.1"
      ],
      "transformer": {
        "use": [
          "cleancache",
          "cleanThinkingInMessage",
          "openai-responses",
          "max_output_tokens"
        ]
      }
    }
```


to fix issue

>{"level":50,"time":1769183247463,"pid":21265,"hostname":"Mac","reqId":"req-3","err":{"type":"Error","message":"Error from provider(azureopenai,gpt-5.2-codex: 400): {\n  \"error\": {\n    \"message\": \"Unknown parameter: 'input[42].thinking'.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"input[42].thinking\",\n    \"code\": \"unknown_parameter\"\n  }\n}","stack":"Error: Error from provider(azureopenai,gpt-5.2-codex: 400): {\n  \"error\": {\n    \"message\": \"Unknown parameter: 'input[42].thinking'.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"input[42].thinking\",\n    \"code\": \"unknown_parameter\"\n  }\n}\n    at Vn (/Users/zhuzhirui/vscodeworkspace/claude-code-router/dist/cli.js:582:7451)\n    at dD (/Users/zhuzhirui/vscodeworkspace/claude-code-router/dist/cli.js:582:11338)\n    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)\n    at async AN (/Users/zhuzhirui/vscodeworkspace/claude-code-router/dist/cli.js:582:8659)","statusCode":400,"code":"provider_response_error"},"msg":"Error from provider(azureopenai,gpt-5.2-codex: 400): {\n  \"error\": {\n    \"message\": \"Unknown parameter: 'input[42].thinking'.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"input[42].thinking\",\n    \"code\": \"unknown_parameter\"\n  }\n}"}
