### PR TITLE
feat: add handleError hook to custom router for dynamic failover

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -113,13 +113,43 @@ async function handleFallback(
   error: any
 ): Promise<any> {
   const scenarioType = (req as any).scenarioType || 'default';
-  const fallbackConfig = fastify.configService.get<any>('fallback');
+  let fallbackList: string[] = [];
 
-  if (!fallbackConfig || !fallbackConfig[scenarioType]) {
-    return null;
+  // Try custom router error handler first
+  const customRouterPath = fastify.configService.get("CUSTOM_ROUTER_PATH");
+  if (customRouterPath && typeof customRouterPath === 'string') {
+    try {
+      const customRouter = require(customRouterPath);
+      if (customRouter.handleError && typeof customRouter.handleError === 'function') {
+        const providerName = (req as any).provider;
+        const modelName = (req.body as any)?.model;
+        const statusCode = error.statusCode || 500;
+        
+        const fallbackModel = await customRouter.handleError(
+          providerName,
+          modelName,
+          statusCode,
+          error
+        );
+
+        if (fallbackModel && typeof fallbackModel === 'string') {
+          fallbackList.push(fallbackModel);
+          req.log.info(`Custom router suggested fallback model: ${fallbackModel}`);
+        }
+      }
+    } catch (e: any) {
+      req.log.error(`Failed to execute custom router error handler: ${e.message}`);
+    }
   }
 
-  const fallbackList = fallbackConfig[scenarioType] as string[];
+  // If no custom fallback, try configuration fallback
+  if (fallbackList.length === 0) {
+    const fallbackConfig = fastify.configService.get<any>('fallback');
+    if (fallbackConfig && fallbackConfig[scenarioType]) {
+      fallbackList = fallbackConfig[scenarioType] as string[];
+    }
+  }
+
   if (!Array.isArray(fallbackList) || fallbackList.length === 0) {
     return null;
   }


### PR DESCRIPTION
### Description
This PR introduces a new `handleError` hook to the custom router script. This allows users to dynamically determine a fallback model when a provider returns an error (e.g., HTTP 429 Rate Limit).

### Why is this needed?
When using tools like **Claude Code**, hitting rate limits on a specific model often causes the entire session to fail. While the project has a static fallback configuration, it doesn't allow for the dynamic, programmable logic required to switch providers or models based on the specific error context.

### Changes
- Updated `packages/core/src/api/routes.ts`:
  - Added a check for the `handleError` method in the custom router script.
  - If present, `handleError(providerName, modelName, statusCode, error)` is called.
  - The return value (if a string) is prioritized as the fallback model.
  - Maintained backward compatibility by falling back to the static `fallback` config if the hook isn't used.

### Usage Example in custom-router.js
```javascript
module.exports = {
  handleError: async (provider, model, status, error) => {
    if (status === 429 && model.includes('claude-3-5-sonnet')) {
      return 'openai/gpt-4o'; // Dynamically switch to GPT-4o on rate limit
    }
    return null;
  }
};
```