### PR TITLE
add venice provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ Here is a comprehensive example:
         "claude-opus-4-20250514",
         "gemini-2.5-pro"
       ]
+    },
+    {
+      "name": "venice",
+      "api_base_url": "https://api.venice.ai/api/v1/chat/completions",
+      "api_key": "VENICE-INFERENCE-KEY-xxx",
+      "models": ["claude-opus-45", "claude-sonnet-45"],
+      "transformer": {
+        "use": ["anthropic"]
+      }
     }
   ],
   "Router": {

--- a/README_zh.md
+++ b/README_zh.md
@@ -166,6 +166,15 @@ npm install -g @musistudio/claude-code-router
         "claude-opus-4-20250514",
         "gemini-2.5-pro"
       ]
+    },
+    {
+      "name": "venice",
+      "api_base_url": "https://api.venice.ai/api/v1/chat/completions",
+      "api_key": "VENICE-INFERENCE-KEY-xxx",
+      "models": ["claude-opus-45", "claude-sonnet-45"],
+      "transformer": {
+        "use": ["anthropic"]
+      }
     }
   ],
   "Router": {


### PR DESCRIPTION
## Summary
- Add Venice.ai as a provider in the comprehensive configuration example
- Updated both English (README.md) and Chinese (README_zh.md) documentation

## Configuration
```json
{
  "name": "venice",
  "api_base_url": "https://api.venice.ai/api/v1/chat/completions",
  "api_key": "VENICE-INFERENCE-KEY-xxx",
  "models": ["claude-opus-45", "claude-sonnet-45"],
  "transformer": {
    "use": ["anthropic"]
  }
}
```

## Reference
- Venice Claude Code documentation: https://docs.venice.ai/overview/guides/claude-code
- How to Use Claude Code Without Paying $100/Month (Using Venice): https://www.youtube.com/watch?v=gtIuDDSy9HU