### PR TITLE
fix(cli): avoid DEP0190 in code command spawn

### DIFF
--- a/packages/cli/src/utils/codeCommand.ts
+++ b/packages/cli/src/utils/codeCommand.ts
@@ -5,9 +5,8 @@ import {
   incrementReferenceCount,
   closeService,
 } from "./processCheck";
-import { quote } from 'shell-quote';
-import minimist from "minimist";
 import { createEnvVariables } from "./createEnvVariables";
+import { quote } from "shell-quote";
 
 export interface PresetConfig {
   noServer?: boolean;
@@ -93,36 +92,20 @@ export async function executeCodeCommand(
   // Execute claude command
   const claudePath = config?.CLAUDE_PATH || process.env.CLAUDE_PATH || "claude";
 
-  const joinedArgs = args.length > 0 ? quote(args) : "";
-
   const stdioConfig: StdioOptions = config.NON_INTERACTIVE_MODE
     ? ["pipe", "inherit", "inherit"] // Pipe stdin for non-interactive
     : "inherit"; // Default inherited behavior
 
-  const argsObj = minimist(args)
-  const argsArr = []
-  for (const [argsObjKey, argsObjValue] of Object.entries(argsObj)) {
-    if (argsObjKey !== '_' && argsObj[argsObjKey]) {
-      const prefix = argsObjKey.length === 1 ? '-' : '--';
-      // For boolean flags, don't append the value
-      if (argsObjValue === true) {
-        argsArr.push(`${prefix}${argsObjKey}`);
-      } else {
-        argsArr.push(`${prefix}${argsObjKey} ${JSON.stringify(argsObjValue)}`);
-      }
-    }
-  }
-  const claudeProcess = spawn(
-    claudePath,
-    argsArr,
-    {
-      env: {
-        ...process.env,
-      },
-      stdio: stdioConfig,
-      shell: true,
-    }
-  );
+  const joinedArgs = args.length > 0 ? quote(args) : "";
+  const command = joinedArgs ? `${quote([claudePath])} ${joinedArgs}` : quote([claudePath]);
+
+  const claudeProcess = spawn(command, {
+    env: {
+      ...process.env,
+    },
+    stdio: stdioConfig,
+    shell: true,
+  });
 
   // Close stdin for non-interactive mode
   if (config.NON_INTERACTIVE_MODE) {


### PR DESCRIPTION
Fixes https://github.com/musistudio/claude-code-router/issues/974
`ccr code` currently calls `spawn(command, args, { shell: true })`, which triggers Node's DEP0190 warning because args are concatenated by the shell.

This change keeps shell behavior, but switches to a single safely quoted command string and calls `spawn(commandString, { shell: true })`. Argument forwarding stays intact, including values with spaces.

## Test Plan
- [x] `pnpm build`
- [x] `CLAUDE_PATH=echo NODE_OPTIONS=--trace-deprecation node dist/cli.js code --help`
- [x] `CLAUDE_PATH=echo node dist/cli.js code --model "claude sonnet" --verbose`