### PR TITLE
fix: correctly determine finish reason in gemini streaming

### DIFF
--- a/packages/core/src/utils/gemini.util.ts
+++ b/packages/core/src/utils/gemini.util.ts
@@ -526,7 +526,16 @@ export async function transformResponseOut(
     let thinkingContent = "";
     let thinkingSignature = "";
 
-    const parts = jsonResponse.candidates[0]?.content?.parts || [];
+    const finalChoice = Array.isArray(jsonResponse)
+      ? jsonResponse.find((r: any) =>
+        r.candidates?.some((c: any) => c.finishReason)
+      ) || jsonResponse[jsonResponse.length - 1]
+      : jsonResponse;
+
+    const parts =
+      finalChoice?.candidates?.[0]?.content?.parts ||
+      jsonResponse[0]?.candidates?.[0]?.content?.parts ||
+      [];
     const nonThinkingParts: Part[] = [];
 
     for (const part of parts) {
@@ -567,9 +576,8 @@ export async function transformResponseOut(
       choices: [
         {
           finish_reason:
-            (
-              jsonResponse.candidates[0].finishReason as string
-            )?.toLowerCase() || null,
+            (finalChoice?.candidates?.[0]?.finishReason as string)?.toLowerCase() ||
+            null,
           index: 0,
           message: {
             content: textContent,
@@ -1041,4 +1049,6 @@ export async function transformResponseOut(
       headers: response.headers,
     });
   }
+
+  return response;
 }


### PR DESCRIPTION
This change addresses an issue where the finish reason was not being correctly determined in Gemini streaming mode, particularly when multiple response chunks were received.

Previously, the logic only considered the first candidate of the first response, which could lead to a null `finish_reason` if that initial chunk was not the final one.

The updated implementation now correctly handles multiple response chunks by iterating through them to find the candidate that contains a `finishReason`. This ensures that the final response is properly identified and the `finish_reason` is accurately reported.

This change improves the reliability of response handling in streaming scenarios and prevents potential issues with incomplete or misidentified responses.
