### PR TITLE
feat: add passthrough_auth option for OAuth bearer token forwarding

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -350,6 +350,22 @@ async function sendRequestToProvider(
     }
   }
 
+  // Passthrough auth: forward auth and relevant headers from the incoming request
+  if (provider.passthroughAuth && context?.req?.headers) {
+    const incomingHeaders = context.req.headers;
+    const passthroughHeaders = [
+      'authorization',
+      'x-api-key',
+      'anthropic-version',
+      'anthropic-beta',
+    ];
+    for (const header of passthroughHeaders) {
+      if (incomingHeaders[header]) {
+        requestHeaders[header] = incomingHeaders[header];
+      }
+    }
+  }
+
   const response = await sendUnifiedRequest(
     url,
     requestBody,

--- a/packages/core/src/services/provider.ts
+++ b/packages/core/src/services/provider.ts
@@ -32,7 +32,7 @@ export class ProviderService {
         if (
           !providerConfig.name ||
           !providerConfig.api_base_url ||
-          !providerConfig.api_key
+          (!providerConfig.api_key && !providerConfig.passthrough_auth)
         ) {
           return;
         }
@@ -87,6 +87,7 @@ export class ProviderService {
           name: providerConfig.name,
           baseUrl: providerConfig.api_base_url,
           apiKey: providerConfig.api_key,
+          passthroughAuth: providerConfig.passthrough_auth,
           models: providerConfig.models || [],
           transformer: providerConfig.transformer ? transformer : undefined,
         });

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -200,7 +200,8 @@ export interface ConversionOptions {
 export interface LLMProvider {
   name: string;
   baseUrl: string;
-  apiKey: string;
+  apiKey?: string;
+  passthroughAuth?: boolean;
   models: string[];
   transformer?: {
     [key: string]: {
@@ -228,7 +229,8 @@ export interface RequestRouteInfo {
 export interface ConfigProvider {
   name: string;
   api_base_url: string;
-  api_key: string;
+  api_key?: string;
+  passthrough_auth?: boolean;
   models: string[];
   transformer: {
     use?: string[] | Array<any>[];


### PR DESCRIPTION
## Summary

This PR adds a `passthrough_auth` option for provider configuration, enabling 
Claude Code users with Anthropic Max subscriptions (OAuth authentication) to use 
Claude Code Router.

Previously, providers without an `api_key` were silently skipped during 
registration, making it impossible to route requests to Anthropic's API when 
using OAuth bearer tokens instead of API keys.

### Changes
- `api_key` is now optional when `passthrough_auth: true`
- Incoming auth headers (Authorization, x-api-key, anthropic-version, 
  anthropic-beta) are forwarded to the upstream provider
- No breaking changes to existing api_key-based authentication

### Related issues
- #943 (Support for header passthrough)
- #358 (Not proxying headers)

Built and tested with the help of Claude Code on a hybrid local/cloud setup.