### PR TITLE
Fix: use CLAUDE_CODE_ATTRIBUTION_HEADER to avoid breaking cache

### DIFF
--- a/packages/cli/src/types.d.ts
+++ b/packages/cli/src/types.d.ts
@@ -70,6 +70,7 @@ interface ClaudeSettingsFlag {
     NO_PROXY: string;
     DISABLE_TELEMETRY: string;
     DISABLE_COST_WARNINGS: string;
+    CLAUDE_CODE_ATTRIBUTION_HEADER: any;
     API_TIMEOUT_MS: string;
     CLAUDE_CODE_USE_BEDROCK?: undefined;
     [key: string]: any;

--- a/packages/cli/src/utils/createEnvVariables.ts
+++ b/packages/cli/src/utils/createEnvVariables.ts
@@ -15,6 +15,7 @@ export const createEnvVariables = async (): Promise<Record<string, string | unde
     NO_PROXY: "127.0.0.1",
     DISABLE_TELEMETRY: "true",
     DISABLE_COST_WARNINGS: "true",
+    CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
     API_TIMEOUT_MS: String(config.API_TIMEOUT_MS ?? 600000),
     // Reset CLAUDE_CODE_USE_BEDROCK when running with ccr
     CLAUDE_CODE_USE_BEDROCK: undefined,


### PR DESCRIPTION
Claude Code version >= 2.1.36 now sending special header that changes in every request, it looks like this:
`text:"x-anthropic-billing-header: cc_version=xxxx; cc_entrypoint=cli; cch=xxxx;"`
This breaks prompt cache and triggers full prompt processing on every request, slowing down local inference significantly.
When CLAUDE_CODE_ATTRIBUTION_HEADER is set to 0 in env, claude code stops sending this header and prompt cache works.

Undocumented variable is taken from https://github.com/anthropics/claude-code/issues/24168