### PR TITLE
feat(openrouter): forward custom provider headers

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -336,6 +336,7 @@ async function sendRequestToProvider(
   // Prepare headers
   const requestHeaders: Record<string, string> = {
     Authorization: `Bearer ${provider.apiKey}`,
+    ...(provider.headers || {}),
     ...(config?.headers || {}),
   };
 

--- a/packages/core/src/services/provider.ts
+++ b/packages/core/src/services/provider.ts
@@ -87,6 +87,7 @@ export class ProviderService {
           name: providerConfig.name,
           baseUrl: providerConfig.api_base_url,
           apiKey: providerConfig.api_key,
+          headers: providerConfig.headers,
           models: providerConfig.models || [],
           transformer: providerConfig.transformer ? transformer : undefined,
         });

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -201,6 +201,7 @@ export interface LLMProvider {
   name: string;
   baseUrl: string;
   apiKey: string;
+  headers?: Record<string, string>;
   models: string[];
   transformer?: {
     [key: string]: {
@@ -229,6 +230,7 @@ export interface ConfigProvider {
   name: string;
   api_base_url: string;
   api_key: string;
+  headers?: Record<string, string>;
   models: string[];
   transformer: {
     use?: string[] | Array<any>[];


### PR DESCRIPTION
## Summary
- add optional `headers` to provider config types
- forward `providerConfig.headers` when registering providers
- merge `provider.headers` into upstream request headers before `fetch`

## Problem
Custom OpenRouter app headers configured in `config.json` were not forwarded to outgoing requests.

## Verification
- before: `final request` logs showed only `authorization` and `content-type`
- after: `final request` logs include `http-referer` and `x-title`
