### PR TITLE
feat: add built-in Venice transformer for web search support

### DIFF
--- a/packages/core/src/transformer/index.ts
+++ b/packages/core/src/transformer/index.ts
@@ -19,6 +19,7 @@ import { CustomParamsTransformer } from "./customparams.transformer";
 import { VercelTransformer } from "./vercel.transformer";
 import { OpenAIResponsesTransformer } from "./openai.responses.transformer";
 import { ForceReasoningTransformer } from "./forcereasoning.transformer"
+import { VeniceTransformer } from "./venice.transformer";
 
 export default {
   AnthropicTransformer,
@@ -41,5 +42,6 @@ export default {
   CustomParamsTransformer,
   VercelTransformer,
   OpenAIResponsesTransformer,
-  ForceReasoningTransformer
+  ForceReasoningTransformer,
+  VeniceTransformer
 };

--- a/packages/core/src/transformer/venice.transformer.ts
+++ b/packages/core/src/transformer/venice.transformer.ts
@@ -1,0 +1,33 @@
+import { LLMProvider, UnifiedChatRequest } from "../types/llm";
+import { Transformer, TransformerContext } from "../types/transformer";
+
+export class VeniceTransformer implements Transformer {
+  static TransformerName = "Venice";
+
+  async transformRequestIn(
+    request: UnifiedChatRequest,
+    _provider: LLMProvider,
+    _context: TransformerContext
+  ): Promise<UnifiedChatRequest> {
+    const modified = { ...request } as any;
+
+    const hasWebSearch = modified.tools?.some(
+      (t: any) => t.function?.name === "web_search"
+    );
+
+    if (hasWebSearch) {
+      modified.venice_parameters = {
+        enable_web_search: "auto",
+        enable_web_citations: true,
+      };
+      modified.tools = modified.tools.filter(
+        (t: any) => t.function?.name !== "web_search"
+      );
+      if (modified.tools.length === 0) {
+        modified.tools = undefined;
+      }
+    }
+
+    return modified;
+  }
+}


### PR DESCRIPTION
## Description

Adds a Venice transformer for Claude Code web search routing.

Claude Code sends web search as an Anthropic server tool, but Venice expects `venice_parameters.enable_web_search`. The transformer removes the malformed converted function tool and injects Venice web-search parameters instead.

- Adds `VeniceTransformer`.
- Registers it in the transformer index.

## Verification
- `pnpm build`

Manual CCR GUI and web-search smoke tests are still needed.

<img width="620" height="267" alt="Screenshot 2026-02-25 at 3 41 52 pm" src="https://github.com/user-attachments/assets/b253de25-8caa-4200-8b3c-5d15108f9efb" />

<img width="1281" height="554" alt="Screenshot 2026-02-25 at 3 42 25 pm" src="https://github.com/user-attachments/assets/a6fffa2a-3394-48a8-ac60-49e965d799de" />

