### PR TITLE
fix: handle images in tool_result content blocks

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -89,16 +89,55 @@ export class AnthropicTransformer implements Transformer {
             );
             if (toolParts.length) {
               toolParts.forEach((tool: any) => {
+                let toolContent: string;
+                const extractedImages: any[] = [];
+
+                if (typeof tool.content === "string") {
+                  toolContent = tool.content;
+                } else if (Array.isArray(tool.content)) {
+                  const textParts: string[] = [];
+                  tool.content.forEach((c: any) => {
+                    if (c.type === "image" && c.source) {
+                      extractedImages.push(c);
+                    } else if (c.type === "text") {
+                      textParts.push(c.text);
+                    } else {
+                      textParts.push(JSON.stringify(c));
+                    }
+                  });
+                  toolContent = textParts.length
+                    ? textParts.join("\n")
+                    : "[see image below]";
+                } else {
+                  toolContent = JSON.stringify(tool.content);
+                }
+
                 const toolMessage: UnifiedMessage = {
                   role: "tool",
-                  content:
-                    typeof tool.content === "string"
-                      ? tool.content
-                      : JSON.stringify(tool.content),
+                  content: toolContent,
                   tool_call_id: tool.tool_use_id,
                   cache_control: tool.cache_control,
                 };
                 messages.push(toolMessage);
+
+                if (extractedImages.length) {
+                  messages.push({
+                    role: "user",
+                    content: extractedImages.map((img: any) => ({
+                      type: "image_url",
+                      image_url: {
+                        url:
+                          img.source?.type === "base64"
+                            ? formatBase64(
+                                img.source.data,
+                                img.source.media_type
+                              )
+                            : img.source.url,
+                      },
+                      media_type: img.source.media_type,
+                    })),
+                  });
+                }
               });
             }
 

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -13,7 +13,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import { getThinkLevel } from "@/utils/thinking";
 import { createApiError } from "@/api/middleware";
-import { formatBase64 } from "@/utils/image";
+import { toImageUrlPart } from "@/utils/image";
 
 export class AnthropicTransformer implements Transformer {
   name = "Anthropic";
@@ -123,19 +123,7 @@ export class AnthropicTransformer implements Transformer {
                 if (extractedImages.length) {
                   messages.push({
                     role: "user",
-                    content: extractedImages.map((img: any) => ({
-                      type: "image_url",
-                      image_url: {
-                        url:
-                          img.source?.type === "base64"
-                            ? formatBase64(
-                                img.source.data,
-                                img.source.media_type
-                              )
-                            : img.source.url,
-                      },
-                      media_type: img.source.media_type,
-                    })),
+                    content: extractedImages.map(toImageUrlPart),
                   });
                 }
               });
@@ -151,19 +139,7 @@ export class AnthropicTransformer implements Transformer {
                 role: "user",
                 content: textAndMediaParts.map((part: any) => {
                   if (part?.type === "image") {
-                    return {
-                      type: "image_url",
-                      image_url: {
-                        url:
-                          part.source?.type === "base64"
-                            ? formatBase64(
-                                part.source.data,
-                                part.source.media_type
-                              )
-                            : part.source.url,
-                      },
-                      media_type: part.source.media_type,
-                    };
+                    return toImageUrlPart(part);
                   }
                   return part;
                 }),

--- a/packages/core/src/utils/image.ts
+++ b/packages/core/src/utils/image.ts
@@ -1,3 +1,15 @@
+// Convert an Anthropic image content block to an OpenAI-compatible image_url part
+export const toImageUrlPart = (img: any) => ({
+  type: "image_url",
+  image_url: {
+    url:
+      img.source?.type === "base64"
+        ? formatBase64(img.source.data, img.source.media_type)
+        : img.source.url,
+  },
+  media_type: img.source.media_type,
+});
+
 export const formatBase64 = (data: string, media_type: string) => {
   if (data.includes("base64")) {
     data = data.split("base64").pop() as string;


### PR DESCRIPTION
## Description

Fixes image content inside Claude Code `tool_result` blocks.

When a tool result contains an array with image blocks, the Anthropic transformer now extracts image parts instead of stringifying base64 into text. Extracted images are emitted as OpenAI-compatible `image_url` parts in a follow-up user message.

- Parses array tool result content.
- Adds shared `toImageUrlPart`.
- Keeps existing user-message image conversion on the same helper.

## Verification
- `pnpm build`

Manual vision-model validation is still needed.

