### PR TITLE
fix: populate input_tokens in transformer and fix non-streaming response

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -349,7 +349,7 @@ export class AnthropicTransformer implements Transformer {
                         stop_sequence: null,
                       },
                       usage: {
-                        input_tokens: 0,
+                        input_tokens: context?.req?.tokenCount || 0,
                         output_tokens: 0,
                         cache_read_input_tokens: 0,
                       },
@@ -457,7 +457,7 @@ export class AnthropicTransformer implements Transformer {
                       stop_reason: null,
                       stop_sequence: null,
                       usage: {
-                        input_tokens: 0,
+                        input_tokens: context?.req?.tokenCount || 0,
                         output_tokens: 0,
                       },
                     },

--- a/packages/core/src/utils/router.ts
+++ b/packages/core/src/utils/router.ts
@@ -266,12 +266,12 @@ export const router = async (req: any, _res: any, context: RouterContext) => {
       );
     }
 
+    req.tokenCount = tokenCount; // Always set for context window tracking
     let model;
     const customRouterPath = configService.get("CUSTOM_ROUTER_PATH");
     if (customRouterPath) {
       try {
         const customRouter = require(customRouterPath);
-        req.tokenCount = tokenCount; // Pass token count to custom router
         model = await customRouter(req, configService.getAll(), {
           event,
         });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -410,7 +410,7 @@ async function getServer(options: RunOptions = {}) {
         if (payload.error) {
           return done(payload.error, null)
         } else {
-          return done(payload, null)
+          return done(null, payload)
         }
       }
     }


### PR DESCRIPTION
## Summary

Three fixes for input token tracking and non-streaming response handling:

### 1. Always set `req.tokenCount` (router.ts)
Moved `req.tokenCount = tokenCount` before model selection logic. Previously it was only assigned inside the `if (customRouterPath)` branch, so most users (without a custom router) had `req.tokenCount` as `undefined`, making downstream token count usage ineffective.

### 2. Use estimated token count in AnthropicTransformer (anthropic.transformer.ts)
When synthesizing `message_start` and fallback `message_delta` events in `convertOpenAIStreamToAnthropic()`, use `context.req.tokenCount` instead of hardcoding `input_tokens: 0`. This provides Claude Code CLI with a meaningful token estimate for context window tracking when routing through non-Anthropic providers (OpenAI, Gemini, DeepSeek, etc.).

### 3. Fix `done()` callback argument order (index.ts)
In the `onSend` hook's non-streaming success path, the callback was invoked as `done(payload, null)` — putting the payload in the error position. Fixed to `done(null, payload)` to match the Fastify `onSend` hook signature `done(error, payload)`. This was causing non-streaming responses to be treated as errors.

## Changes
- `packages/core/src/utils/router.ts` — Move `req.tokenCount` assignment earlier
- `packages/core/src/transformer/anthropic.transformer.ts` — Use `context.req.tokenCount` in synthetic events
- `packages/server/src/index.ts` — Fix `done()` argument order
