### PR TITLE
fix: prevent `Cannot read properties of undefined (reading 'name')` when using Anthropic tool format in Gemini Provider

### DIFF
--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -157,22 +157,26 @@ export class OpenAIResponsesTransformer implements Transformer {
 
     if (Array.isArray(request.tools)) {
       const webSearch = request.tools.find(
-        (tool) => tool.function.name === "web_search"
+        (tool: any) => (tool.function?.name || tool.name) === "web_search"
       );
 
       (request as any).tools = request.tools
-        .filter((tool) => tool.function.name !== "web_search")
-        .map((tool) => {
-          if (tool.function.name === "WebSearch") {
-            delete tool.function.parameters.properties.allowed_domains;
+        .filter((tool: any) => (tool.function?.name || tool.name) !== "web_search")
+        .map((tool: any) => {
+          const name = tool.function?.name || tool.name;
+          const description = tool.function?.description || tool.description;
+          const parameters = tool.function?.parameters || tool.input_schema;
+          
+          if (name === "WebSearch") {
+            delete parameters.properties.allowed_domains;
           }
-          if (tool.function.name === "Edit") {
+          if (name === "Edit") {
             return {
               type: tool.type,
-              name: tool.function.name,
-              description: tool.function.description,
+              name: name,
+              description: description,
               parameters: {
-                ...tool.function.parameters,
+                ...parameters,
                 required: [
                   "file_path",
                   "old_string",
@@ -185,9 +189,9 @@ export class OpenAIResponsesTransformer implements Transformer {
           }
           return {
             type: tool.type,
-            name: tool.function.name,
-            description: tool.function.description,
-            parameters: tool.function.parameters,
+            name: name,
+            description: description,
+            parameters: parameters,
           };
         });
 

--- a/packages/core/src/utils/gemini.util.ts
+++ b/packages/core/src/utils/gemini.util.ts
@@ -244,12 +244,12 @@ export function buildRequestBody(
 ): Record<string, any> {
   const tools = [];
   const functionDeclarations = request.tools
-    ?.filter((tool) => tool.function.name !== "web_search")
-    ?.map((tool) => {
+    ?.filter((tool: any) => (tool.function?.name || tool.name) !== "web_search")
+    ?.map((tool: any) => {
       return {
-        name: tool.function.name,
-        description: tool.function.description,
-        parametersJsonSchema: tool.function.parameters,
+        name: tool.function?.name || tool.name,
+        description: tool.function?.description || tool.description,
+        parametersJsonSchema: tool.function?.parameters || tool.input_schema,
       };
     });
   if (functionDeclarations?.length) {
@@ -260,7 +260,7 @@ export function buildRequestBody(
     );
   }
   const webSearch = request.tools?.find(
-    (tool) => tool.function.name === "web_search"
+    (tool: any) => (tool.function?.name || tool.name) === "web_search"
   );
   if (webSearch) {
     tools.push({
@@ -336,8 +336,8 @@ export function buildRequestBody(
                 id:
                   toolCall.id ||
                   `tool_${Math.random().toString(36).substring(2, 15)}`,
-                name: toolCall.function.name,
-                args: JSON.parse(toolCall.function.arguments || "{}"),
+                name: toolCall.function?.name || toolCall.name,
+                args: JSON.parse(toolCall.function?.arguments || toolCall.input || "{}"),
               },
               thoughtSignature:
                 index === 0 && message.thinking?.signature
@@ -426,10 +426,10 @@ export function buildRequestBody(
       toolConfig.functionCallingConfig.mode = "none";
     } else if (request.tool_choice === "required") {
       toolConfig.functionCallingConfig.mode = "any";
-    } else if (request.tool_choice?.function?.name) {
+    } else if (request.tool_choice?.function?.name || request.tool_choice?.name) {
       toolConfig.functionCallingConfig.mode = "any";
       toolConfig.functionCallingConfig.allowedFunctionNames = [
-        request.tool_choice?.function?.name,
+        request.tool_choice?.function?.name || request.tool_choice?.name,
       ];
     }
     body.toolConfig = toolConfig;


### PR DESCRIPTION
### Describe the bug
When using the official `@anthropic-ai/claude-code` CLI, it sends requests with the native Anthropic API schema. This means tools are defined directly with properties like `name`, `description`, and `input_schema` rather than being wrapped in an OpenAI-style `function` object. 

When `claude-code-router` routes these requests to the Gemini provider, the `transformRequestOut` function assumes all incoming requests are strictly formatted in the OpenAI schema. It attempts to access `a.function.name`, which crashes the server with the error:
`Cannot read properties of undefined (reading 'name')`

### Proposed Fix / Solution
Added optional chaining and fallback logic (`?.function?.xxx || .xxx`) to support both OpenAI and Anthropic formats natively in `gemini.util.ts` and `openai.responses.transformer.ts`. This safely handles Anthropic's native `tool` and `tool_choice` format without breaking existing OpenAI compatibility.