### PR TITLE
fix: strip unsupported thinking field for openai-responses provider

### DIFF
--- a/packages/cli/src/utils/createEnvVariables.ts
+++ b/packages/cli/src/utils/createEnvVariables.ts
@@ -11,6 +11,7 @@ export const createEnvVariables = async (): Promise<Record<string, string | unde
 
   return {
     ANTHROPIC_AUTH_TOKEN: apiKey,
+    ANTHROPIC_API_KEY: "",
     ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
     NO_PROXY: "127.0.0.1",
     DISABLE_TELEMETRY: "true",

--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -38,6 +38,8 @@ async function handleTransformerEndpoint(
   transformer: any
 ) {
   const body = req.body as any;
+  const requestedStream = body?.stream === true;
+  (req as any).requestedStream = requestedStream;
   const providerName = req.provider!;
   const provider = fastify.providerService.getProvider(providerName);
 
@@ -88,7 +90,7 @@ async function handleTransformerEndpoint(
     );
 
     // Format and return response
-    return formatResponse(finalResponse, reply, body);
+    return formatResponse(finalResponse, reply, requestedStream, req);
   } catch (error: any) {
     // Handle fallback if error occurs
     if (error.code === 'provider_response_error') {
@@ -182,7 +184,12 @@ async function handleFallback(
       req.log.info(`Fallback model ${fallbackModel} succeeded`);
 
       // Format and return response
-      return formatResponse(finalResponse, reply, newBody);
+      return formatResponse(
+        finalResponse,
+        reply,
+        newBody?.stream === true,
+        newReq as FastifyRequest
+      );
     } catch (fallbackError: any) {
       req.log.warn(`Fallback model ${fallbackModel} failed: ${fallbackError.message}`);
       continue;
@@ -443,19 +450,102 @@ async function processResponseTransformers(
  * Format and return response
  * Handle HTTP status codes, format streaming and regular responses
  */
-function formatResponse(response: any, reply: FastifyReply, body: any) {
+async function streamResponseToReply(
+  responseBody: ReadableStream,
+  reply: FastifyReply,
+  req?: FastifyRequest
+) {
+  const reader = responseBody.getReader();
+  let closed = false;
+
+  const closeStream = async () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+
+    try {
+      await reader.cancel();
+    } catch {}
+
+    if (!reply.raw.destroyed && !reply.raw.writableEnded) {
+      try {
+        reply.raw.end();
+      } catch {}
+    }
+  };
+
+  const onClose = () => {
+    void closeStream();
+  };
+
+  reply.raw.once("close", onClose);
+  reply.raw.once("error", onClose);
+  reply.hijack();
+
+  try {
+    while (!closed) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      if (reply.raw.destroyed || reply.raw.writableEnded) {
+        await closeStream();
+        break;
+      }
+
+      if (!value || value.length === 0) {
+        continue;
+      }
+
+      const canContinue = reply.raw.write(Buffer.from(value));
+      if (!canContinue) {
+        await new Promise<void>((resolve) => {
+          reply.raw.once("drain", resolve);
+        });
+      }
+    }
+  } catch (error: any) {
+    if (
+      error?.name !== "AbortError" &&
+      error?.code !== "ERR_STREAM_PREMATURE_CLOSE"
+    ) {
+      req?.log?.error(error);
+      if (!reply.raw.headersSent) {
+        reply.raw.statusCode = 500;
+      }
+    }
+  } finally {
+    reply.raw.removeListener("close", onClose);
+    reply.raw.removeListener("error", onClose);
+    try {
+      reader.releaseLock();
+    } catch {}
+    if (!reply.raw.destroyed && !reply.raw.writableEnded) {
+      reply.raw.end();
+    }
+  }
+}
+
+function formatResponse(
+  response: any,
+  reply: FastifyReply,
+  requestedStream: boolean,
+  req?: FastifyRequest
+) {
   // Set HTTP status code
   if (!response.ok) {
     reply.code(response.status);
   }
 
   // Handle streaming response
-  const isStream = body.stream === true;
+  const isStream = requestedStream;
   if (isStream) {
     reply.header("Content-Type", "text/event-stream");
     reply.header("Cache-Control", "no-cache");
     reply.header("Connection", "keep-alive");
-    return reply.send(response.body);
+    return streamResponseToReply(response.body, reply, req);
   } else {
     // Handle regular JSON response
     return response.json();

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -215,20 +215,32 @@ export class AnthropicTransformer implements Transformer {
     const isStream = response.headers
       .get("Content-Type")
       ?.includes("text/event-stream");
+    const requestedStream = (context?.req as any)?.requestedStream === true;
     if (isStream) {
       if (!response.body) {
         throw new Error("Stream response body is null");
       }
-      const convertedStream = await this.convertOpenAIStreamToAnthropic(
-        response.body,
-        context!
-      );
-      return new Response(convertedStream, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        },
+      if (requestedStream) {
+        const convertedStream = await this.convertOpenAIStreamToAnthropic(
+          response.body,
+          context!
+        );
+        return new Response(convertedStream, {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          },
+        });
+      }
+
+      const anthropicResponse =
+        await this.convertOpenAIStreamToAnthropicResponse(
+          response.body,
+          context!
+        );
+      return new Response(JSON.stringify(anthropicResponse), {
+        headers: { "Content-Type": "application/json" },
       });
     } else {
       const data = (await response.json()) as any;
@@ -262,7 +274,47 @@ export class AnthropicTransformer implements Transformer {
         const encoder = new TextEncoder();
         const messageId = `msg_${Date.now()}`;
         let stopReasonMessageDelta: null | Record<string, any> = null;
-        let model = "unknown";
+        let model = context.req.body?.model || "unknown";
+        const requestedMaxTokens =
+          typeof context.req.body?.max_tokens === "number"
+            ? context.req.body.max_tokens
+            : null;
+        const estimateInputTokens = (requestBody: any): number => {
+          const parts: string[] = [];
+
+          if (Array.isArray(requestBody?.system)) {
+            for (const item of requestBody.system) {
+              if (typeof item === "string") {
+                parts.push(item);
+              } else if (item?.text) {
+                parts.push(item.text);
+              }
+            }
+          }
+
+          if (Array.isArray(requestBody?.messages)) {
+            for (const message of requestBody.messages) {
+              if (typeof message?.content === "string") {
+                parts.push(message.content);
+                continue;
+              }
+
+              if (Array.isArray(message?.content)) {
+                for (const block of message.content) {
+                  if (typeof block === "string") {
+                    parts.push(block);
+                  } else if (block?.text) {
+                    parts.push(block.text);
+                  }
+                }
+              }
+            }
+          }
+
+          const chars = parts.join("\n").length;
+          return Math.max(1, Math.ceil(chars / 4));
+        };
+        const fallbackInputTokens = estimateInputTokens(context.req.body);
         let hasStarted = false;
         let hasTextContentStarted = false;
         let hasFinished = false;
@@ -271,6 +323,8 @@ export class AnthropicTransformer implements Transformer {
         let totalChunks = 0;
         let contentChunks = 0;
         let toolCallChunks = 0;
+        let hasAnyContentBlock = false;
+        let emittedTextChunkCount = 0;
         let isClosed = false;
         let isThinkingStarted = false;
         let contentIndex = 0;
@@ -311,6 +365,16 @@ export class AnthropicTransformer implements Transformer {
           }
         };
 
+        const attachUsageToDelta = (payload: Record<string, any>) => {
+          if (payload.usage) {
+            payload.delta = {
+              ...(payload.delta || {}),
+              usage: payload.usage,
+            };
+          }
+          return payload;
+        };
+
         const safeClose = () => {
           if (!isClosed) {
             try {
@@ -327,7 +391,7 @@ export class AnthropicTransformer implements Transformer {
                     stop_reason: null,
                     stop_sequence: null,
                     usage: {
-                      input_tokens: 0,
+                      input_tokens: fallbackInputTokens,
                       output_tokens: 0,
                     },
                   },
@@ -339,6 +403,37 @@ export class AnthropicTransformer implements Transformer {
                     )}\n\n`
                   )
                 );
+              }
+
+              if (!hasAnyContentBlock) {
+                const emptyTextBlockIndex = assignContentBlockIndex();
+                safeEnqueue(
+                  encoder.encode(
+                    `event: content_block_start\ndata: ${JSON.stringify({
+                      type: "content_block_start",
+                      index: emptyTextBlockIndex,
+                      content_block: {
+                        type: "text",
+                        text: "",
+                      },
+                    })}\n\n`
+                  )
+                );
+                safeEnqueue(
+                  encoder.encode(
+                    `event: content_block_delta\ndata: ${JSON.stringify({
+                      type: "content_block_delta",
+                      index: emptyTextBlockIndex,
+                      delta: {
+                        type: "text_delta",
+                        text: "OK",
+                      },
+                    })}\n\n`
+                  )
+                );
+                hasAnyContentBlock = true;
+                currentContentBlockIndex = emptyTextBlockIndex;
+                emittedTextChunkCount = Math.max(emittedTextChunkCount, 1);
               }
 
               // Close any remaining open content block
@@ -361,7 +456,7 @@ export class AnthropicTransformer implements Transformer {
                 safeEnqueue(
                   encoder.encode(
                     `event: message_delta\ndata: ${JSON.stringify(
-                      stopReasonMessageDelta
+                      attachUsageToDelta(stopReasonMessageDelta)
                     )}\n\n`
                   )
                 );
@@ -369,18 +464,18 @@ export class AnthropicTransformer implements Transformer {
               } else {
                 safeEnqueue(
                   encoder.encode(
-                    `event: message_delta\ndata: ${JSON.stringify({
+                    `event: message_delta\ndata: ${JSON.stringify(attachUsageToDelta({
                       type: "message_delta",
                       delta: {
                         stop_reason: "end_turn",
                         stop_sequence: null,
                       },
                       usage: {
-                        input_tokens: 0,
-                        output_tokens: 0,
+                        input_tokens: fallbackInputTokens,
+                        output_tokens: emittedTextChunkCount > 0 ? 1 : 0,
                         cache_read_input_tokens: 0,
                       },
-                    })}\n\n`
+                    }))}\n\n`
                   )
                 );
               }
@@ -440,7 +535,9 @@ export class AnthropicTransformer implements Transformer {
               });
 
               if (data === "[DONE]") {
-                continue;
+                hasFinished = true;
+                safeClose();
+                break;
               }
 
               try {
@@ -484,7 +581,7 @@ export class AnthropicTransformer implements Transformer {
                       stop_reason: null,
                       stop_sequence: null,
                       usage: {
-                        input_tokens: 0,
+                        input_tokens: fallbackInputTokens,
                         output_tokens: 0,
                       },
                     },
@@ -510,9 +607,9 @@ export class AnthropicTransformer implements Transformer {
                       },
                       usage: {
                         input_tokens:
-                          (chunk.usage?.prompt_tokens || 0) -
+                          ((chunk.usage?.prompt_tokens || fallbackInputTokens) -
                           (chunk.usage?.prompt_tokens_details?.cached_tokens ||
-                            0),
+                            0)),
                         output_tokens: chunk.usage?.completion_tokens || 0,
                         cache_read_input_tokens:
                           chunk.usage?.prompt_tokens_details?.cached_tokens ||
@@ -522,9 +619,9 @@ export class AnthropicTransformer implements Transformer {
                   } else {
                     stopReasonMessageDelta.usage = {
                       input_tokens:
-                        (chunk.usage?.prompt_tokens || 0) -
+                        ((chunk.usage?.prompt_tokens || fallbackInputTokens) -
                         (chunk.usage?.prompt_tokens_details?.cached_tokens ||
-                          0),
+                          0)),
                       output_tokens: chunk.usage?.completion_tokens || 0,
                       cache_read_input_tokens:
                         chunk.usage?.prompt_tokens_details?.cached_tokens || 0,
@@ -566,6 +663,7 @@ export class AnthropicTransformer implements Transformer {
                         )}\n\n`
                       )
                     );
+                    hasAnyContentBlock = true;
                     currentContentBlockIndex = thinkingBlockIndex;
                     isThinkingStarted = true;
                   }
@@ -657,6 +755,7 @@ export class AnthropicTransformer implements Transformer {
                         )}\n\n`
                       )
                     );
+                    hasAnyContentBlock = true;
                     currentContentBlockIndex = textBlockIndex;
                   }
 
@@ -676,6 +775,40 @@ export class AnthropicTransformer implements Transformer {
                         )}\n\n`
                       )
                     );
+                    emittedTextChunkCount++;
+                    if (
+                      requestedMaxTokens === 1 &&
+                      emittedTextChunkCount >= 1
+                    ) {
+                      if (!stopReasonMessageDelta) {
+                        stopReasonMessageDelta = {
+                          type: "message_delta",
+                          delta: {
+                            stop_reason: "end_turn",
+                            stop_sequence: null,
+                          },
+                          usage: {
+                            input_tokens: fallbackInputTokens,
+                            output_tokens: 1,
+                            cache_read_input_tokens: 0,
+                          },
+                        };
+                      } else {
+                        stopReasonMessageDelta.usage = {
+                          ...(stopReasonMessageDelta.usage || {}),
+                          input_tokens:
+                            stopReasonMessageDelta.usage?.input_tokens ??
+                            fallbackInputTokens,
+                          output_tokens: 1,
+                          cache_read_input_tokens:
+                            stopReasonMessageDelta.usage
+                              ?.cache_read_input_tokens ?? 0,
+                        };
+                      }
+                      hasFinished = true;
+                      safeClose();
+                      break;
+                    }
                   }
                 }
 
@@ -725,6 +858,7 @@ export class AnthropicTransformer implements Transformer {
                         )}\n\n`
                       )
                     );
+                    hasAnyContentBlock = true;
 
                     const contentBlockStop = {
                       type: "content_block_stop",
@@ -799,6 +933,7 @@ export class AnthropicTransformer implements Transformer {
                           )}\n\n`
                         )
                       );
+                      hasAnyContentBlock = true;
                       currentContentBlockIndex = newContentBlockIndex;
 
                       const toolCallInfo = {
@@ -945,7 +1080,15 @@ export class AnthropicTransformer implements Transformer {
             }
           }
           safeClose();
-        } catch (error) {
+        } catch (error: any) {
+          if (
+            error?.name === "AbortError" ||
+            error?.code === "ERR_STREAM_PREMATURE_CLOSE"
+          ) {
+            safeClose();
+            return;
+          }
+
           if (!isClosed) {
             try {
               controller.error(error);
@@ -974,6 +1117,211 @@ export class AnthropicTransformer implements Transformer {
     });
 
     return readable;
+  }
+
+  private async convertOpenAIStreamToAnthropicResponse(
+    openaiStream: ReadableStream,
+    context: TransformerContext
+  ): Promise<any> {
+    const reader = openaiStream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let model = context.req.body?.model || "unknown";
+    let responseId = `msg_${Date.now()}`;
+    let finishReason = "stop";
+    let textContent = "";
+    const toolCalls = new Map<number, any>();
+    let usage: any = null;
+
+    const estimateInputTokens = (requestBody: any): number => {
+      const parts: string[] = [];
+
+      if (Array.isArray(requestBody?.system)) {
+        for (const item of requestBody.system) {
+          if (typeof item === "string") {
+            parts.push(item);
+          } else if (item?.text) {
+            parts.push(item.text);
+          }
+        }
+      }
+
+      if (Array.isArray(requestBody?.messages)) {
+        for (const message of requestBody.messages) {
+          if (typeof message?.content === "string") {
+            parts.push(message.content);
+            continue;
+          }
+
+          if (Array.isArray(message?.content)) {
+            for (const block of message.content) {
+              if (typeof block === "string") {
+                parts.push(block);
+              } else if (block?.text) {
+                parts.push(block.text);
+              }
+            }
+          }
+        }
+      }
+
+      const chars = parts.join("\n").length;
+      return Math.max(1, Math.ceil(chars / 4));
+    };
+
+    const fallbackInputTokens = estimateInputTokens(context.req.body);
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data:")) continue;
+          const data = line.slice(5).trim();
+          if (!data || data === "[DONE]") {
+            continue;
+          }
+
+          let chunk: any;
+          try {
+            chunk = JSON.parse(data);
+          } catch {
+            continue;
+          }
+
+          this.logger.debug({
+            reqId: context.req.id,
+            response: chunk,
+            type: "aggregated non-stream chunk",
+          });
+
+          if (chunk.error) {
+            throw createApiError(
+              `Provider error: ${JSON.stringify(chunk.error)}`,
+              500,
+              "provider_error"
+            );
+          }
+
+          responseId = chunk.id || responseId;
+          model = chunk.model || model;
+
+          const choice = chunk.choices?.[0];
+          if (!choice) {
+            continue;
+          }
+
+          if (typeof choice.delta?.content === "string") {
+            textContent += choice.delta.content;
+          }
+
+          if (Array.isArray(choice.delta?.tool_calls)) {
+            for (const toolCall of choice.delta.tool_calls) {
+              const index = toolCall.index ?? 0;
+              const existing = toolCalls.get(index) || {
+                id: toolCall.id || `call_${Date.now()}_${index}`,
+                name: toolCall.function?.name || `tool_${index}`,
+                arguments: "",
+              };
+
+              if (toolCall.id) {
+                existing.id = toolCall.id;
+              }
+              if (toolCall.function?.name) {
+                existing.name = toolCall.function.name;
+              }
+              if (typeof toolCall.function?.arguments === "string") {
+                existing.arguments += toolCall.function.arguments;
+              }
+
+              toolCalls.set(index, existing);
+            }
+          }
+
+          if (choice.finish_reason) {
+            finishReason = choice.finish_reason;
+          }
+
+          if (chunk.usage) {
+            usage = chunk.usage;
+          }
+        }
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {}
+    }
+
+    const content: any[] = [];
+
+    if (textContent) {
+      content.push({
+        type: "text",
+        text: textContent,
+      });
+    }
+
+    if (toolCalls.size > 0) {
+      for (const toolCall of toolCalls.values()) {
+        let parsedInput = {};
+        try {
+          parsedInput = toolCall.arguments
+            ? JSON.parse(toolCall.arguments)
+            : {};
+        } catch {
+          parsedInput = { text: toolCall.arguments || "" };
+        }
+
+        content.push({
+          type: "tool_use",
+          id: toolCall.id,
+          name: toolCall.name,
+          input: parsedInput,
+        });
+      }
+    }
+
+    if (content.length === 0) {
+      content.push({
+        type: "text",
+        text: "",
+      });
+    }
+
+    return {
+      id: responseId,
+      type: "message",
+      role: "assistant",
+      model,
+      content,
+      stop_reason:
+        finishReason === "stop"
+          ? "end_turn"
+          : finishReason === "length"
+          ? "max_tokens"
+          : finishReason === "tool_calls"
+          ? "tool_use"
+          : finishReason === "content_filter"
+          ? "stop_sequence"
+          : "end_turn",
+      stop_sequence: null,
+      usage: {
+        input_tokens:
+          (usage?.prompt_tokens || fallbackInputTokens) -
+          (usage?.prompt_tokens_details?.cached_tokens || 0),
+        output_tokens:
+          usage?.completion_tokens ||
+          Math.max(1, Math.ceil(textContent.length / 4)),
+        cache_read_input_tokens:
+          usage?.prompt_tokens_details?.cached_tokens || 0,
+      },
+    };
   }
 
   private convertOpenAIResponseToAnthropic(

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -426,7 +426,7 @@ export class AnthropicTransformer implements Transformer {
                       index: emptyTextBlockIndex,
                       delta: {
                         type: "text_delta",
-                        text: "OK",
+                        text: "",
                       },
                     })}\n\n`
                   )
@@ -596,7 +596,20 @@ export class AnthropicTransformer implements Transformer {
                   );
                 }
 
-                const choice = chunk.choices?.[0];
+                const choices = Array.isArray(chunk.choices)
+                  ? chunk.choices
+                  : [];
+                const choice =
+                  choices.find(
+                    (c: any) =>
+                      c?.delta?.content ||
+                      c?.delta?.thinking ||
+                      (Array.isArray(c?.delta?.tool_calls) &&
+                        c.delta.tool_calls.length > 0) ||
+                      (Array.isArray(c?.delta?.annotations) &&
+                        c.delta.annotations.length > 0) ||
+                      c?.finish_reason
+                  ) || choices[0];
                 if (chunk.usage) {
                   if (!stopReasonMessageDelta) {
                     stopReasonMessageDelta = {

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -314,6 +314,33 @@ export class AnthropicTransformer implements Transformer {
         const safeClose = () => {
           if (!isClosed) {
             try {
+              if (!hasStarted) {
+                hasStarted = true;
+                const messageStart = {
+                  type: "message_start",
+                  message: {
+                    id: messageId,
+                    type: "message",
+                    role: "assistant",
+                    content: [],
+                    model: model,
+                    stop_reason: null,
+                    stop_sequence: null,
+                    usage: {
+                      input_tokens: 0,
+                      output_tokens: 0,
+                    },
+                  },
+                };
+                safeEnqueue(
+                  encoder.encode(
+                    `event: message_start\ndata: ${JSON.stringify(
+                      messageStart
+                    )}\n\n`
+                  )
+                );
+              }
+
               // Close any remaining open content block
               if (currentContentBlockIndex >= 0) {
                 const contentBlockStop = {

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -83,6 +83,9 @@ export class OpenAIResponsesTransformer implements Transformer {
     });
 
     delete request.temperature;
+    if (typeof request.max_tokens === "number") {
+      (request as any).max_output_tokens = request.max_tokens;
+    }
     delete request.max_tokens;
 
     // 处理 reasoning 参数

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -71,6 +71,17 @@ export class OpenAIResponsesTransformer implements Transformer {
   async transformRequestIn(
     request: UnifiedChatRequest
   ): Promise<UnifiedChatRequest> {
+    // Strip unsupported thinking fields from messages history to prevent 400 errors
+    // from strict providers using the openai-responses protocol.
+    request.messages.forEach((msg: any) => {
+      if (msg.thinking) {
+        delete msg.thinking;
+      }
+      if (Array.isArray(msg.content)) {
+        msg.content = msg.content.filter((c: any) => c.type !== "thinking");
+      }
+    });
+
     delete request.temperature;
     delete request.max_tokens;
 

--- a/packages/server/src/utils/rewriteStream.ts
+++ b/packages/server/src/utils/rewriteStream.ts
@@ -21,7 +21,17 @@ export const rewriteStream = (stream: ReadableStream, processor: (data: any, con
             controller.enqueue(processed)
           }
         }
-      } catch (error) {
+      } catch (error: any) {
+        if (
+          error?.name === 'AbortError' ||
+          error?.code === 'ERR_STREAM_PREMATURE_CLOSE'
+        ) {
+          try {
+            controller.close()
+          } catch {}
+          return
+        }
+
         controller.error(error)
       } finally {
         reader.releaseLock()


### PR DESCRIPTION
Some providers using the ``openai-responses ``protocol strictly validate parameters. They return a 400 error when encountering ``thinking`` fields or content blocks in the message history. This PR adds a cleaning step in the **OpenAIResponsesTransformer**  to strip these fields before transformation, ensuring better compatibility with strict upstream implementations.