### PR TITLE
fix: don't send reasoning.enabled:false for disabled thinking mode

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -192,8 +192,15 @@ export class AnthropicTransformer implements Transformer {
       result.reasoning = {
         effort: getThinkLevel(request.thinking.budget_tokens),
         // max_tokens: request.thinking.budget_tokens,
-        enabled: request.thinking.type === "enabled",
       };
+
+      // Only add enabled: true when explicitly enabled
+      // When disabled, don't set enabled field to avoid conflicts with mandatory reasoning models
+      if (request.thinking.type === "enabled") {
+        result.reasoning.enabled = true;
+      }
+      // Note: When thinking.type is "disabled", we intentionally don't set enabled: false
+      // because some models (like MiniMax 2.5) require reasoning and don't accept explicit disable
     }
     if (request.tool_choice) {
       if (request.tool_choice.type === "tool") {


### PR DESCRIPTION
When thinking.type is "disabled", the transformer now omits the enabled field instead of sending enabled:false. This fixes 400 errors with mandatory reasoning models like MiniMax 2.5 on OpenRouter.