### PR TITLE
fix: bound OpenAI stream finalization after finish_reason

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -257,6 +257,7 @@ export class AnthropicTransformer implements Transformer {
     openaiStream: ReadableStream,
     context: TransformerContext
   ): Promise<ReadableStream> {
+    const FINISH_REASON_GRACE_PERIOD_MS = 1000;
     const readable = new ReadableStream({
       start: async (controller) => {
         const encoder = new TextEncoder();
@@ -266,6 +267,7 @@ export class AnthropicTransformer implements Transformer {
         let hasStarted = false;
         let hasTextContentStarted = false;
         let hasFinished = false;
+        let finishedAt: number | null = null;
         const toolCalls = new Map<number, any>();
         const toolCallIndexToContentBlockIndex = new Map<number, number>();
         let totalChunks = 0;
@@ -394,7 +396,43 @@ export class AnthropicTransformer implements Transformer {
               break;
             }
 
-            const { done, value } = await reader.read();
+            const readResult = hasFinished
+              ? await Promise.race([
+                  reader.read().then((result) => ({
+                    ...result,
+                    timedOut: false,
+                  })),
+                  new Promise<{
+                    done: true;
+                    value: undefined;
+                    timedOut: true;
+                  }>((resolve) => {
+                    const remaining =
+                      FINISH_REASON_GRACE_PERIOD_MS -
+                      (Date.now() - (finishedAt || Date.now()));
+                    setTimeout(
+                      () =>
+                        resolve({
+                          done: true,
+                          value: undefined,
+                          timedOut: true,
+                        }),
+                      Math.max(remaining, 0)
+                    );
+                  }),
+                ])
+              : {
+                  ...(await reader.read()),
+                  timedOut: false,
+                };
+            const { done, value, timedOut } = readResult;
+            if (timedOut) {
+              try {
+                await reader.cancel("finish_reason grace timeout");
+              } catch {
+                // Ignore cancellation errors; the stream is being finalized.
+              }
+            }
             if (done) break;
 
             buffer += decoder.decode(value, { stream: true });
@@ -402,7 +440,7 @@ export class AnthropicTransformer implements Transformer {
             buffer = lines.pop() || "";
 
             for (const line of lines) {
-              if (isClosed || hasFinished) break;
+              if (isClosed) break;
 
               if (!line.startsWith("data:")) continue;
               const data = line.slice(5).trim();
@@ -413,7 +451,8 @@ export class AnthropicTransformer implements Transformer {
               });
 
               if (data === "[DONE]") {
-                continue;
+                safeClose();
+                break;
               }
 
               try {
@@ -856,6 +895,9 @@ export class AnthropicTransformer implements Transformer {
                 }
 
                 if (choice?.finish_reason && !isClosed && !hasFinished) {
+                  hasFinished = true;
+                  finishedAt = Date.now();
+
                   if (contentChunks === 0 && toolCallChunks === 0) {
                     console.error(
                       "Warning: No content in the stream response!"
@@ -907,8 +949,6 @@ export class AnthropicTransformer implements Transformer {
                       },
                     };
                   }
-
-                  break;
                 }
               } catch (parseError: any) {
                 this.logger?.error(


### PR DESCRIPTION
This PR fixes a streaming edge case in the Anthropic transformer for OpenAI-compatible SSE providers.

Problem:
- Some providers emit a valid `finish_reason` chunk but do not close the underlying SSE connection promptly.
- `claude-code-router` then keeps waiting for EOF, which can leave Claude Code hanging for a long time even though the assistant turn is already complete.
- At the same time, some providers send `usage` only after `finish_reason`, so we still need a short post-finish window to collect trailing metadata.

What this changes:
- Keep reading briefly after `finish_reason` so trailing `usage` / `[DONE]` can still be processed.
- If the upstream stream does not finish within a short grace period, proactively finalize the Anthropic SSE response instead of waiting indefinitely.
- Close immediately when `[DONE]` arrives.

Why this is not a duplicate of #1235:
- #1235 keeps reading after `finish_reason` to collect usage.
- This PR keeps that behavior but adds a bounded grace timeout so hanging upstream connections do not stall the client forever.

Local verification:
- `corepack pnpm --filter @musistudio/llms build`
- Custom local regression script covering both cases:
  - trailing `usage` after `finish_reason`
  - hanging upstream stream after `finish_reason`
- The hanging case now finalizes in about 1s instead of waiting indefinitely.