### PR TITLE
fix: handle non-ASCII characters in forwarded HTTP headers

### DIFF
--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -14,7 +14,14 @@ export function sendUnifiedRequest(
   if (config.headers) {
     Object.entries(config.headers).forEach(([key, value]) => {
       if (value) {
-        headers.set(key, value as string);
+        const strValue = String(value);
+        // HTTP headers only support ASCII (ByteString). Non-ASCII values
+        // (e.g. Chinese characters from Claude Code system prompts) must be
+        // percent-encoded to avoid "Cannot convert argument to a ByteString" errors.
+        const safeValue = /^[\x00-\xff]*$/.test(strValue)
+          ? strValue
+          : encodeURIComponent(strValue);
+        headers.set(key, safeValue);
       }
     });
   }


### PR DESCRIPTION
## Summary

- Fix `Cannot convert argument to a ByteString` error when Claude Code sends HTTP headers containing non-ASCII characters (e.g., Chinese characters from system prompts in `CLAUDE.md`)
- Non-ASCII header values are now percent-encoded via `encodeURIComponent()` before being set on the `Headers` object

## Problem

When users have non-ASCII content in their `CLAUDE.md` (e.g., Chinese persona instructions), Claude Code includes some of this metadata in HTTP headers. The `sendUnifiedRequest` function in `packages/core/src/utils/request.ts` forwards these headers directly via `Headers.set()`, which only accepts ASCII (ByteString) values, causing the request to fail with:

```
TypeError: Cannot convert argument to a ByteString because the character at index 16 has a value of 26367 which is greater than 255.
```

## Fix

Added a check before `headers.set()`: if the value contains non-ASCII characters (`> \xff`), it is percent-encoded with `encodeURIComponent()` first. ASCII-only values pass through unchanged.

## Test plan

- [x] Verified with a `CLAUDE.md` containing Chinese characters that previously triggered the error
- [x] Confirmed requests are successfully forwarded to OpenRouter after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)