### PR TITLE
fix(gemini): skip thoughtSignature when no thinking content was streamed

### DIFF
--- a/packages/core/src/utils/gemini.util.ts
+++ b/packages/core/src/utils/gemini.util.ts
@@ -680,7 +680,7 @@ export async function transformResponseOut(
                 let signature = parts.find(
                   (part: Part) => part.thoughtSignature
                 )?.thoughtSignature;
-                if (signature && !signatureSent) {
+                if (signature && !signatureSent && hasThinkingContent) {
                   if (!hasThinkingContent) {
                     const thinkingChunk = {
                       choices: [


### PR DESCRIPTION
 ## Problem

  When using models like `gemini-3-flash-preview` (resolved by `gemini-flash-latest`),
  the Gemini API streams a `thoughtSignature` in the final chunk even when no thinking
  content (`thought: true` parts) was included in the response — for example when
  thinking happened internally but `includeThoughts` was not set.

  The existing code unconditionally processed any `thoughtSignature` it encountered,
  inserting a fake thinking block (`"(no content)"` + signature) into the SSE stream
  **after** the actual text content had already been sent. This breaks the Anthropic
  stream format, which requires thinking blocks to appear **before** content blocks.
  As a result, Claude Code silently discarded the response and the user received no output.

  ## Fix

  Added a `hasThinkingContent` guard to the signature handling block so that
  `thoughtSignature` is only processed when actual thinking content (`thought: true`
  parts) was streamed. If no thinking was visible in the stream, the signature is
  ignored and the text response flows through cleanly.

  ## Steps to reproduce

  1. Set model to `gemini,gemini-flash-latest` in Claude Code
  2. Send any message
  3. Observe: no response is displayed despite the server returning HTTP 200

  ## Root cause

  `gemini-3-flash-preview` always emits a `thoughtSignature` in the final SSE chunk
  regardless of whether thinking content was included in the stream.