### PR TITLE
fix: map anthropic output_config effort to reasoning

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -188,11 +188,18 @@ export class AnthropicTransformer implements Transformer {
         : undefined,
       tool_choice: request.tool_choice,
     };
-    if (request.thinking) {
+    if (request.output_config?.effort) {
+      const effort = getThinkLevel(request.output_config.effort);
+      this.logger?.info(
+        {
+          model: request.model,
+          reasoning_effort: effort,
+        },
+        "Mapped Anthropic output_config effort to reasoning effort"
+      );
       result.reasoning = {
-        effort: getThinkLevel(request.thinking.budget_tokens),
-        // max_tokens: request.thinking.budget_tokens,
-        enabled: request.thinking.type === "enabled",
+        effort,
+        enabled: request.thinking?.type === "enabled",
       };
     }
     if (request.tool_choice) {

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -82,7 +82,7 @@ export interface UnifiedTool {
   };
 }
 
-export type ThinkLevel = "none" | "low" | "medium" | "high";
+export type ThinkLevel = "none" | "low" | "medium" | "high" | "xhigh";
 
 // 统一的请求接口
 export interface UnifiedChatRequest {

--- a/packages/core/src/utils/thinking.ts
+++ b/packages/core/src/utils/thinking.ts
@@ -1,8 +1,18 @@
 import { ThinkLevel } from "@/types/llm";
 
-export const getThinkLevel = (thinking_budget: number): ThinkLevel => {
-  if (thinking_budget <= 0) return "none";
-  if (thinking_budget <= 1024) return "low";
-  if (thinking_budget <= 8192) return "medium";
-  return "high";
-};
+export function getThinkLevel(effort?: string): ThinkLevel {
+  switch (effort) {
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "max":
+      return "xhigh";
+    case "none":
+      return "none";
+    default:
+      return "medium";
+  }
+}


### PR DESCRIPTION
## Summary
- map Anthropic reasoning effort from `output_config.effort` instead of `thinking.budget_tokens`
- update `getThinkLevel` to translate explicit effort strings to router `ThinkLevel` values
- add `xhigh` to `ThinkLevel` and guard optional `request.thinking` access

## Verification
- `pnpm --filter @musistudio/llms build`
