### PR TITLE
fix(reasoning): override reasoning.enabled directly to support mandatory-reasoning models

### DIFF
--- a/packages/core/src/transformer/reasoning.transformer.ts
+++ b/packages/core/src/transformer/reasoning.transformer.ts
@@ -20,13 +20,23 @@ export class ReasoningTransformer implements Transformer {
       request.enable_thinking = false;
       return request;
     }
-    if (request.reasoning) {
-      request.thinking = {
-        type: "enabled",
-        budget_tokens: request.reasoning.max_tokens,
-      };
-      request.enable_thinking = true;
-    }
+
+    // `transformRequestOut` (Claude→OpenAI format conversion) runs before
+    // provider transformers. By the time this transformer executes, a normal
+    // Claude request with `thinking: {type: "disabled"}` has already been
+    // converted to `reasoning: {enabled: false, effort: "none"}`.
+    // Mutating `request.thinking` here has no effect on the outgoing body.
+    //
+    // Fix: directly override `request.reasoning` to force reasoning on.
+    // This handles models where reasoning is mandatory (e.g. stepfun/step-3.5-flash)
+    // and would reject the request if `reasoning.enabled` is false.
+    request.reasoning = Object.assign(
+      { effort: "high" },
+      request.reasoning || {},
+      { enabled: true }
+    );
+    delete request.thinking;
+
     return request;
   }
 


### PR DESCRIPTION
## Problem

The `reasoning` transformer sets `request.thinking` in `transformRequestIn`, but the Claude→OpenAI format conversion (`transformRequestOut`) **runs before** provider transformers. By the time `transformRequestIn` executes, the original `thinking: {type: "disabled"}` has already been converted to `reasoning: {enabled: false, effort: "none"}`.

Mutating `request.thinking` at that point has no effect on the outgoing request body. The converted `reasoning: {enabled: false}` field is sent as-is to the provider.

This causes HTTP 400 errors on models where reasoning is mandatory, such as **`stepfun/step-3.5-flash`** via OpenRouter:

```
"Reasoning is mandatory for this endpoint and cannot be disabled."
```

## Root cause

```
Claude Code → router → transformRequestOut (Claude→OpenAI conversion)
                         ↳ thinking:{type:"disabled"} → reasoning:{enabled:false}
                       → transformer.use["reasoning"].transformRequestIn
                         ↳ sets request.thinking = {type:"enabled"} ← too late, ignored
                       → provider receives reasoning:{enabled:false} → 400
```

## Fix

Directly override `request.reasoning` to force `enabled: true`, preserving any existing `effort`/`max_tokens` from the request, and delete the stale `thinking` field.

```typescript
request.reasoning = Object.assign(
  { effort: "high" },
  request.reasoning || {},
  { enabled: true }
);
delete request.thinking;
```

## Testing

Verified with `stepfun/step-3.5-flash:free` via OpenRouter using the following `config.json`:

```json
{
  "Providers": [
    {
      "name": "openrouter-stepfun",
      "api_base_url": "https://openrouter.ai/api/v1/chat/completions",
      "api_key": "...",
      "models": ["stepfun/step-3.5-flash:free"],
      "transformer": {
        "use": ["reasoning"]
      }
    }
  ],
  "Router": {
    "default": "openrouter-stepfun,stepfun/step-3.5-flash:free"
  }
}
```

Before the fix: HTTP 400 on every request.  
After the fix: requests succeed and reasoning content is correctly streamed back.