### PR TITLE
Add Mistral transformer to handle tool→user message transitions

### DIFF
--- a/packages/core/src/transformer/index.ts
+++ b/packages/core/src/transformer/index.ts
@@ -19,6 +19,7 @@ import { CustomParamsTransformer } from "./customparams.transformer";
 import { VercelTransformer } from "./vercel.transformer";
 import { OpenAIResponsesTransformer } from "./openai.responses.transformer";
 import { ForceReasoningTransformer } from "./forcereasoning.transformer"
+import { MistralTransformer } from "./mistral.transformer"
 
 export default {
   AnthropicTransformer,
@@ -41,5 +42,6 @@ export default {
   CustomParamsTransformer,
   VercelTransformer,
   OpenAIResponsesTransformer,
-  ForceReasoningTransformer
+  ForceReasoningTransformer,
+  MistralTransformer
 };

--- a/packages/core/src/transformer/mistral.transformer.ts
+++ b/packages/core/src/transformer/mistral.transformer.ts
@@ -1,0 +1,41 @@
+import { UnifiedChatRequest } from "@/types/llm";
+import { Transformer, TransformerOptions } from "../types/transformer";
+
+/**
+ * Mistral models require that after a "tool" message, the next message must be
+ * "assistant" or another "tool" — never "user". This transformer inserts a
+ * synthetic assistant message between tool→user transitions to satisfy that
+ * constraint.
+ */
+export class MistralTransformer implements Transformer {
+  name = "mistral";
+
+  constructor(private readonly options?: TransformerOptions) {}
+
+  async transformRequestIn(
+    request: UnifiedChatRequest
+  ): Promise<UnifiedChatRequest> {
+    const messages = request.messages;
+    const fixed: typeof messages = [];
+
+    for (let i = 0; i < messages.length; i++) {
+      fixed.push(messages[i]);
+
+      // If current message is "tool" and next message is "user", insert a
+      // synthetic assistant message to bridge the gap.
+      if (
+        messages[i].role === "tool" &&
+        i + 1 < messages.length &&
+        messages[i + 1].role === "user"
+      ) {
+        fixed.push({
+          role: "assistant",
+          content: "",
+        });
+      }
+    }
+
+    request.messages = fixed;
+    return request;
+  }
+}


### PR DESCRIPTION
Mistral models require that after a "tool" message, the next message must be "assistant" or another "tool". This transformer inserts a synthetic assistant message between tool→user transitions to satisfy that constraint.