### PR TITLE
fix: mkdir before writing manifest in saveManifest

### DIFF
--- a/packages/shared/src/preset/install.ts
+++ b/packages/shared/src/preset/install.ts
@@ -345,6 +345,7 @@ export function extractMetadata(manifest: ManifestFile): PresetMetadata {
  */
 export async function saveManifest(presetName: string, manifest: ManifestFile): Promise<void> {
   const presetDir = getPresetDir(presetName);
+  await fs.mkdir(presetDir, { recursive: true });
   const manifestPath = path.join(presetDir, 'manifest.json');
   await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
 }


### PR DESCRIPTION
## Problem

When running `ccr preset install /path/to/preset-dir`, it fails with ENOENT error:

```
Error applying preset: ENOENT: no such file or directory, open '~/.claude-code-router/presets/<name>/manifest.json'
```

The `saveManifest` function in `packages/shared/src/preset/install.ts` tries to write `manifest.json` to the preset directory but the directory doesnt exist yet at that point.

I was running into this on fresh install and it took me a while to understand what is happening.

## Fix

Very simple one line change - added `fs.mkdir(presetDir, { recursive: true })` before `fs.writeFile`. The `recursive: true` makes it safe even if directory already exists so it wont break anything for users who already have the directory created.

Other functions like `extractPreset` and `downloadPresetToTemp` already do this same pattern (mkdir before writeFile), so `saveManifest` was just missing it.

## Verification

- `pnpm build` passes for all packages (cli, server, shared, ui)
- The change is one line addition, no risk of breaking existing behavior

Closes #1278