### PR TITLE
feat: model selector, provider routing, caching and other support & fixes for Vercel transformer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Token calculation uses `tiktoken` (cl100k_base) to estimate request size.
 
 The project uses the `@musistudio/llms` package (external dependency) to handle request/response transformations. Transformers adapt to different provider API differences:
 
-- Built-in transformers: `anthropic`, `deepseek`, `gemini`, `openrouter`, `groq`, `maxtoken`, `tooluse`, `reasoning`, `enhancetool`, etc.
+- Built-in transformers: `anthropic`, `deepseek`, `gemini`, `openrouter`, `vercel`, `groq`, `maxtoken`, `tooluse`, `reasoning`, `enhancetool`, etc.
 - Custom transformers: Load external plugins via `transformers` array in `config.json`
 
 Transformer configuration supports:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## ✨ Features
 
 - **Model Routing**: Route requests to different models based on your needs (e.g., background tasks, thinking, long context).
-- **Multi-Provider Support**: Supports various model providers like OpenRouter, DeepSeek, Ollama, Gemini, Volcengine, and SiliconFlow.
+- **Multi-Provider Support**: Supports various model providers like OpenRouter, DeepSeek, Ollama, Gemini, Volcengine, SiliconFlow, and Vercel.
 - **Request/Response Transformation**: Customize requests and responses for different providers using transformers.
 - **Dynamic Model Switching**: Switch models on-the-fly within Claude Code using the `/model` command.
 - **CLI Model Management**: Manage models and providers directly from the terminal with `ccr model`.
@@ -108,6 +108,18 @@ Here is a comprehensive example:
       ],
       "transformer": {
         "use": ["openrouter"]
+      }
+    },
+    {
+      "name": "vercel",
+      "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
+      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "models": [
+        "anthropic/claude-opus-4.6",
+        "google/gemini-3-pro-preview"
+      ],
+      "transformer": {
+        "use": ["vercel"]
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here is a comprehensive example:
     {
       "name": "vercel",
       "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
-      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "api_key": "vck_xxx",
       "models": [
         "anthropic/claude-opus-4.6",
         "google/gemini-3-pro-preview"

--- a/README_zh.md
+++ b/README_zh.md
@@ -88,7 +88,7 @@ npm install -g @musistudio/claude-code-router
     {
       "name": "vercel",
       "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
-      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "api_key": "vck_xxx",
       "models": [
         "anthropic/claude-opus-4.6",
         "google/gemini-3-pro-preview"

--- a/README_zh.md
+++ b/README_zh.md
@@ -21,7 +21,7 @@
 ## ✨ 功能
 
 -   **模型路由**: 根据您的需求将请求路由到不同的模型（例如，后台任务、思考、长上下文）。
--   **多提供商支持**: 支持 OpenRouter、DeepSeek、Ollama、Gemini、Volcengine 和 SiliconFlow 等各种模型提供商。
+-   **多提供商支持**: 支持 OpenRouter、DeepSeek、Ollama、Gemini、Volcengine、SiliconFlow 和 Vercel 等各种模型提供商。
 -   **请求/响应转换**: 使用转换器为不同的提供商自定义请求和响应。
 -   **动态模型切换**: 在 Claude Code 中使用 `/model` 命令动态切换模型。
 -   **GitHub Actions 集成**: 在您的 GitHub 工作流程中触发 Claude Code 任务。
@@ -83,6 +83,18 @@ npm install -g @musistudio/claude-code-router
       ],
       "transformer": {
         "use": ["openrouter"]
+      }
+    },
+    {
+      "name": "vercel",
+      "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
+      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "models": [
+        "anthropic/claude-opus-4.6",
+        "google/gemini-3-pro-preview"
+      ],
+      "transformer": {
+        "use": ["vercel"]
       }
     },
     {

--- a/docs/docs/cli/quick-start.md
+++ b/docs/docs/cli/quick-start.md
@@ -24,6 +24,15 @@ Edit `~/.claude-code-router/config.json`:
       "api_base_url": "https://api.openai.com/v1/chat/completions",
       "api_key": "your-api-key-here",
       "models": ["gpt-4", "gpt-3.5-turbo"]
+    },
+    {
+      "name": "vercel",
+      "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
+      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
+      "transformer": {
+        "use": ["vercel"]
+      }
     }
   ],
   "Router": {

--- a/docs/docs/cli/quick-start.md
+++ b/docs/docs/cli/quick-start.md
@@ -28,7 +28,7 @@ Edit `~/.claude-code-router/config.json`:
     {
       "name": "vercel",
       "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
-      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "api_key": "vck_xxx",
       "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
       "transformer": {
         "use": ["vercel"]

--- a/docs/docs/server/config/providers.md
+++ b/docs/docs/server/config/providers.md
@@ -62,7 +62,7 @@ Detailed guide for configuring LLM providers.
 {
   "name": "vercel",
   "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
-  "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+  "api_key": "vck_xxx",
   "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
   "transformer": {
     "use": ["vercel"]

--- a/docs/docs/server/config/providers.md
+++ b/docs/docs/server/config/providers.md
@@ -56,6 +56,20 @@ Detailed guide for configuring LLM providers.
 }
 ```
 
+### Vercel AI Gateway
+
+```json
+{
+  "name": "vercel",
+  "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
+  "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+  "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
+  "transformer": {
+    "use": ["vercel"]
+  }
+}
+```
+
 ## Provider Configuration Options
 
 | Field | Type | Required | Description |

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/quick-start.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/quick-start.md
@@ -71,7 +71,7 @@ ccr config edit
     {
       "name": "vercel",
       "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
-      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "api_key": "vck_xxx",
       "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
       "transformer": {
         "use": ["vercel"]

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/quick-start.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/quick-start.md
@@ -67,6 +67,15 @@ ccr config edit
       "api_base_url": "https://api.deepseek.com/chat/completions",
       "api_key": "your-deepseek-api-key",
       "models": ["deepseek-chat", "deepseek-coder"]
+    },
+    {
+      "name": "vercel",
+      "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
+      "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+      "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
+      "transformer": {
+        "use": ["vercel"]
+      }
     }
   ],
   "Router": {

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/config/providers.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/config/providers.md
@@ -65,6 +65,20 @@ sidebar_position: 2
 }
 ```
 
+### Vercel AI Gateway
+
+```json
+{
+  "name": "vercel",
+  "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
+  "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+  "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
+  "transformer": {
+    "use": ["vercel"]
+  }
+}
+```
+
 ### Ollama（本地模型）
 
 ```json

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/config/providers.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/config/providers.md
@@ -71,7 +71,7 @@ sidebar_position: 2
 {
   "name": "vercel",
   "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
-  "api_key": "$VERCEL_AI_GATEWAY_API_KEY",
+  "api_key": "vck_xxx",
   "models": ["anthropic/claude-opus-4.6", "google/gemini-3-pro-preview"],
   "transformer": {
     "use": ["vercel"]

--- a/packages/cli/src/utils/modelSelector.ts
+++ b/packages/cli/src/utils/modelSelector.ts
@@ -53,6 +53,7 @@ const AVAILABLE_TRANSFORMERS = [
   'deepseek',
   'gemini',
   'openrouter',
+  'vercel',
   'groq',
   'maxtoken',
   'tooluse',
@@ -222,6 +223,20 @@ async function configureTransformers(): Promise<TransformerConfig | undefined> {
           validate: (value: string) => value.trim() !== '' || 'Provider cannot be empty'
         });
         transformers.push(['openrouter', { provider: { only: [providerInput] } }]);
+      } else {
+        transformers.push(transformer);
+      }
+    } else if (transformer === 'vercel') {
+      const addProvider = await confirm({
+        message: `\n${BOLDYELLOW}Add provider routing options?${RESET}`,
+        default: false
+      });
+      if (addProvider) {
+        const providerInput = await input({
+          message: 'Provider (e.g., vertex):',
+          validate: (value: string) => value.trim() !== '' || 'Provider cannot be empty'
+        });
+        transformers.push(['vercel', { provider: { only: [providerInput] } }]);
       } else {
         transformers.push(transformer);
       }

--- a/packages/core/src/transformer/vercel.transformer.ts
+++ b/packages/core/src/transformer/vercel.transformer.ts
@@ -46,7 +46,15 @@ export class VercelTransformer implements Transformer {
         }
       });
     }
-    Object.assign(request, this.options || {});
+    if (this.options?.provider?.only) {
+      (request as any).providerOptions = {
+        ...((request as any).providerOptions || {}),
+        gateway: {
+          ...((request as any).providerOptions?.gateway || {}),
+          only: this.options.provider.only,
+        },
+      };
+    }
     return request;
   }
 

--- a/packages/core/src/transformer/vercel.transformer.ts
+++ b/packages/core/src/transformer/vercel.transformer.ts
@@ -19,7 +19,7 @@ export class VercelTransformer implements Transformer {
               delete item.cache_control;
             }
             if (item.type === "image_url") {
-              if (!item.image_url.url.startsWith("http")) {
+              if (!item.image_url.url.startsWith("http") && !item.image_url.url.startsWith("data:")) {
                 item.image_url.url = `data:${item.media_type};base64,${item.image_url.url}`;
               }
               delete item.media_type;
@@ -29,12 +29,15 @@ export class VercelTransformer implements Transformer {
           delete msg.cache_control;
         }
       });
+      (request as any).providerOptions = {
+        gateway: { caching: "auto" },
+      };
     } else {
       request.messages.forEach((msg) => {
         if (Array.isArray(msg.content)) {
           msg.content.forEach((item: any) => {
             if (item.type === "image_url") {
-              if (!item.image_url.url.startsWith("http")) {
+              if (!item.image_url.url.startsWith("http") && !item.image_url.url.startsWith("data:")) {
                 item.image_url.url = `data:${item.media_type};base64,${item.image_url.url}`;
               }
               delete item.media_type;
@@ -67,6 +70,7 @@ export class VercelTransformer implements Transformer {
       let reasoningContent = "";
       let isReasoningComplete = false;
       let hasToolCall = false;
+      let isStreamEnded = false;
       let buffer = ""; // Buffer for incomplete data
 
       const stream = new ReadableStream({
@@ -233,7 +237,9 @@ export class VercelTransformer implements Transformer {
                 controller.enqueue(encoder.encode(line + "\n"));
               }
             } else {
-              // Pass through non-data lines (like [DONE])
+              if (line.trim() === "data: [DONE]") {
+                isStreamEnded = true;
+              }
               controller.enqueue(encoder.encode(line + "\n"));
             }
           };
@@ -241,8 +247,7 @@ export class VercelTransformer implements Transformer {
           try {
             while (true) {
               const { done, value } = await reader.read();
-              if (done) {
-                // Process remaining data in buffer
+              if (done || isStreamEnded) {
                 if (buffer.trim()) {
                   processBuffer(buffer, controller, encoder);
                 }
@@ -323,10 +328,11 @@ export class VercelTransformer implements Transformer {
                   });
                 } catch (error) {
                   console.error("Error processing line:", line, error);
-                  // If parsing fails, pass through the original line
                   controller.enqueue(encoder.encode(line + "\n"));
                 }
+                if (isStreamEnded) break;
               }
+              if (isStreamEnded) break;
             }
           } catch (error) {
             console.error("Stream error:", error);

--- a/packages/ui/config.example.json
+++ b/packages/ui/config.example.json
@@ -83,6 +83,21 @@
       }
     },
     {
+      "name": "vercel",
+      "api_base_url": "https://ai-gateway.vercel.sh/v1/chat/completions",
+      "api_key": "vck_xxx",
+      "models": [
+        "anthropic/claude-opus-4.6",
+        "openai/gpt-5",
+        "google/gemini-3-pro-preview"
+      ],
+      "transformer": {
+        "use": [
+          "vercel"
+        ]
+      }
+    },
+    {
       "name": "deepseek",
       "api_base_url": "https://api.deepseek.com/chat/completions",
       "api_key": "sk-",


### PR DESCRIPTION
# What Changed
- add provider routing support
- add auto caching support for non-anthropic models
- fix streaming issue
- fix double base64 wrap for image
- add vercel transformer to model selector 

# Testing
Tested with `anthropic/claude-sonnet-4`, `openai/gpt-5`, `google/gemini-3-pro-preview`
- tested key features: streaming, reasoning, image input, cache, cross-provider 
- tested model selector workflow 

# Other Information
Vercel AI Gateway supported models can be found at [this endpoint](https://ai-gateway.vercel.sh/v1/models): `https://ai-gateway.vercel.sh/v1/models`