### PR TITLE
fix: make transformer name lookup case-insensitive

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -284,12 +284,14 @@ function shouldBypassTransformers(
   transformer: any,
   body: any
 ): boolean {
+  const nameEq = (a?: string, b?: string) =>
+    a?.toLowerCase() === b?.toLowerCase();
   return (
     provider.transformer?.use?.length === 1 &&
-    provider.transformer.use[0].name === transformer.name &&
+    nameEq(provider.transformer.use[0].name, transformer.name) &&
     (!provider.transformer?.[body.model]?.use.length ||
       (provider.transformer?.[body.model]?.use.length === 1 &&
-        provider.transformer?.[body.model]?.use[0].name === transformer.name))
+        nameEq(provider.transformer?.[body.model]?.use[0].name, transformer.name)))
   );
 }
 

--- a/packages/core/src/services/transformer.ts
+++ b/packages/core/src/services/transformer.ts
@@ -22,7 +22,7 @@ export class TransformerService {
   ) {}
 
   registerTransformer(name: string, transformer: Transformer): void {
-    this.transformers.set(name, transformer);
+    this.transformers.set(name.toLowerCase(), transformer);
     this.logger.info(
       `register transformer: ${name}${
         transformer.endPoint
@@ -35,7 +35,7 @@ export class TransformerService {
   getTransformer(
     name: string
   ): Transformer | TransformerConstructor | undefined {
-    return this.transformers.get(name);
+    return this.transformers.get(name.toLowerCase());
   }
 
   getAllTransformers(): Map<string, Transformer | TransformerConstructor> {
@@ -72,11 +72,11 @@ export class TransformerService {
   }
 
   removeTransformer(name: string): boolean {
-    return this.transformers.delete(name);
+    return this.transformers.delete(name.toLowerCase());
   }
 
   hasTransformer(name: string): boolean {
-    return this.transformers.has(name);
+    return this.transformers.has(name.toLowerCase());
   }
 
   async registerTransformerFromConfig(config: {


### PR DESCRIPTION
Transformer names in provider config (e.g. "anthropic") failed to match registered names with different casing (e.g. "Anthropic"), causing the transformer to silently not load. This led to requests being sent in the wrong format and empty responses.

Normalize all transformer map keys to lowercase on register/get/remove/has, and use case-insensitive comparison in the bypass check.