### PR TITLE
fix(server): support model routing on OpenAI standard endpoints

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -184,7 +184,7 @@ class Server {
       // Add router hook for namespace
       fastify.addHook('preHandler', async (req: any, reply: any) => {
         const url = new URL(`http://127.0.0.1${req.url}`);
-        if (url.pathname.endsWith("/v1/messages")) {
+        if (url.pathname.endsWith("/v1/messages") || url.pathname.endsWith("/v1/chat/completions")) {
           await router(req, reply, {
             configService,
             tokenizerService,
@@ -201,7 +201,7 @@ class Server {
 
       this.app.addHook("preHandler", (req, reply, done) => {
         const url = new URL(`http://127.0.0.1${req.url}`);
-        if (url.pathname.endsWith("/v1/messages") && req.body) {
+        if ((url.pathname.endsWith("/v1/messages") || url.pathname.endsWith("/v1/chat/completions")) && req.body) {
           const body = req.body as any;
           req.log.info({ data: body, type: "request body" });
           if (!body.stream) {
@@ -217,7 +217,7 @@ class Server {
         "preHandler",
         async (req: FastifyRequest, reply: FastifyReply) => {
           const url = new URL(`http://127.0.0.1${req.url}`);
-          if (url.pathname.endsWith("/v1/messages") && req.body) {
+          if ((url.pathname.endsWith("/v1/messages") || url.pathname.endsWith("/v1/chat/completions")) && req.body) {
             try {
               const body = req.body as any;
               if (!body || !body.model) {


### PR DESCRIPTION
Supports OpenAI standard  REST proxying directly on CCR by natively intercepting the request and formatting the body alias and provider properties so Transformers can execute without crashing with `Provider 'undefined' not found` errors.