### PR TITLE
do not quit after a model selected

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,13 +22,16 @@
     "@CCR/shared": "workspace:*",
     "@inquirer/prompts": "^5.0.0",
     "@types/archiver": "^7.0.0",
+    "@types/minimist": "^1.2.5",
     "@types/node": "^24.0.15",
+    "@types/shell-quote": "^1.7.5",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "esbuild": "^0.25.1",
     "find-process": "^2.0.0",
     "minimist": "^1.2.8",
     "openurl": "^1.1.1",
+    "shell-quote": "^1.8.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2"
   }

--- a/packages/cli/src/utils/modelSelector.ts
+++ b/packages/cli/src/utils/modelSelector.ts
@@ -161,7 +161,8 @@ async function selectModelType() {
       { name: 'Long Context Model', value: 'longContext' },
       { name: 'Web Search Model', value: 'webSearch' },
       { name: 'Image Model', value: 'image' },
-      { name: `${BOLDGREEN}+ Add New Model${RESET}`, value: 'addModel' }
+      { name: `${BOLDGREEN}+ Add New Model${RESET}`, value: 'addModel' },
+      { name: `${DIM}Exit${RESET}`, value: 'exit' }
     ]
   });
 }
@@ -432,30 +433,37 @@ export async function runModelSelector(): Promise<void> {
   console.clear();
   
   try {
-    let config = loadConfig();
-    displayCurrentConfig(config);
-    
-    const action = await selectModelType() as string;
-    
-    if (action === 'addModel') {
-      const result = await addNewModel(config);
+    while (true) {
+      let config = loadConfig();
+      displayCurrentConfig(config);
       
-      if (result) {
-        config = loadConfig();
-        config.Router[result.modelType] = `${result.providerName},${result.modelName}`;
-        saveConfig(config);
-        console.log(`${GREEN}✓ ${result.modelType} set to ${result.providerName},${result.modelName}${RESET}`);
+      const action = await selectModelType() as string;
+      
+      if (action === 'exit') {
+        break;
       }
-    } else {
-      const selectedModel = await selectModel(config, action) as string;
-      config.Router[action] = selectedModel;
-      saveConfig(config);
       
-      console.log(`${GREEN}✓ ${action} model updated to: ${selectedModel}${RESET}`);
+      if (action === 'addModel') {
+        const result = await addNewModel(config);
+        
+        if (result) {
+          config = loadConfig();
+          config.Router[result.modelType] = `${result.providerName},${result.modelName}`;
+          saveConfig(config);
+          console.log(`${GREEN}✓ ${result.modelType} set to ${result.providerName},${result.modelName}${RESET}`);
+        }
+      } else {
+        const selectedModel = await selectModel(config, action) as string;
+        config.Router[action] = selectedModel;
+        saveConfig(config);
+        
+        console.log(`${GREEN}✓ ${action} model updated to: ${selectedModel}${RESET}`);
+      }
     }
-    
-    displayCurrentConfig(config);
   } catch (error: any) {
+    if (error.name === 'ExitPromptError') {
+      return;
+    }
     console.error(`${YELLOW}Error:${RESET}`, error.message);
     process.exit(1);
   }


### PR DESCRIPTION
**### Summary**
This PR improves the CLI model selection flow so users can continue configuring multiple routes in one session, instead of exiting immediately after one selection.

**### Motivation**
Previously, the model selector exited after a single update, which made multi-model configuration inefficient and easy to interrupt.
This change keeps the selector interactive until the user explicitly chooses to exit.

**### Changes**
Add an explicit Exit option in the model type menu.
Refactor model selection flow into a loop:
Reload config each round.
Allow repeated updates (route selection and add-model flow) in one run.
Exit only when user selects Exit.
Handle ExitPromptError gracefully to avoid unnecessary error output.
Add missing dependencies/types needed by the updated CLI path.