### PR TITLE
fix(vertex-gemini): add ?alt=sse for streaming endpoint

### DIFF
--- a/packages/core/src/transformer/vertex-gemini.transformer.ts
+++ b/packages/core/src/transformer/vertex-gemini.transformer.ts
@@ -58,7 +58,7 @@ export class VertexGeminiTransformer implements Transformer {
       body: buildRequestBody(request),
       config: {
         url: new URL(
-          `./v1beta1/projects/${projectId}/locations/${location}/publishers/google/models/${request.model}:${request.stream ? "streamGenerateContent" : "generateContent"}`,
+          `./v1beta1/projects/${projectId}/locations/${location}/publishers/google/models/${request.model}:${request.stream ? "streamGenerateContent?alt=sse" : "generateContent"}`,
             provider.baseUrl.endsWith('/') ? provider.baseUrl : provider.baseUrl + '/' || `https://${location}-aiplatform.googleapis.com`
         ),
         headers: {


### PR DESCRIPTION
Fixes #1315

Without `?alt=sse`, Vertex AI's `streamGenerateContent` endpoint returns JSON array format instead of SSE format, causing CCR's streaming parser to fail with a 500 error (TypeError: Cannot read properties of undefined (reading '0')).

One-line fix: append `?alt=sse` to the streaming URL in `vertex-gemini.transformer.ts`, consistent with the existing `gemini.transformer.ts` implementation.

Credit: @Matsubarai independently identified and fixed this issue in their fork (Matsubarai/claude-code-router#1).