### PR TITLE
fix: SSE stream reader drops usage chunk sent after finish_reason

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -402,7 +402,7 @@ export class AnthropicTransformer implements Transformer {
             buffer = lines.pop() || "";
 
             for (const line of lines) {
-              if (isClosed || hasFinished) break;
+              if (isClosed) break;
 
               if (!line.startsWith("data:")) continue;
               const data = line.slice(5).trim();
@@ -908,7 +908,7 @@ export class AnthropicTransformer implements Transformer {
                     };
                   }
 
-                  break;
+                  hasFinished = true;
                 }
               } catch (parseError: any) {
                 this.logger?.error(

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -91,6 +91,9 @@ export interface UnifiedChatRequest {
   max_tokens?: number;
   temperature?: number;
   stream?: boolean;
+  stream_options?: {
+    include_usage?: boolean;
+  };
   tools?: UnifiedTool[];
   tool_choice?:
     | "auto"


### PR DESCRIPTION
## Problem

The `AnthropicTransformer`'s SSE stream reader in `convertOpenAIStreamToAnthropic` exits immediately when it encounters a `finish_reason` in the OpenAI-format stream. This causes it to miss usage data that providers send in a **separate chunk after** the `finish_reason` chunk.

This affects providers that send usage information as a trailing chunk with `choices: []` and `usage: {...}` (e.g. DashScope with `stream_options.include_usage: true`, and OpenAI itself when `stream_options.include_usage` is enabled). As a result, the `message_delta` event emitted to Claude Code contains zero values for `input_tokens`, `output_tokens`, and `cache_read_input_tokens`, causing the context window usage display in Claude Code's status bar to show 0%.

### Root Cause

Two issues in the inner SSE line-parsing loop:

1. **Line 911**: When `finish_reason` is received, the code does `break` — immediately exiting the inner `for` loop. The outer `while` loop then reads the next chunk from the stream, but the inner loop's guard `if (isClosed || hasFinished) break` (with `hasFinished` never being set to `true`) causes it to skip all subsequent lines. In practice, the `break` at line 911 causes the reader to jump to `safeClose()` and never process any trailing data.

2. **Line 405**: The inner `for` loop guard `if (isClosed || hasFinished) break` would also prevent processing remaining lines in the current buffer after `hasFinished` is set.

## Fix

- **Line 911**: Replace `break` with `hasFinished = true` — this allows the outer `while` loop to continue reading from the stream until it naturally closes (`done === true`), picking up any trailing usage chunks.
- **Line 405**: Change `if (isClosed || hasFinished) break` to `if (isClosed) break` — this ensures remaining lines in the current buffer are still processed after `hasFinished` is set. The `hasFinished` flag is already checked in all content-emitting blocks (`!isClosed && !hasFinished`), so no duplicate content will be emitted.
- **Type definition**: Add `stream_options` field to `UnifiedChatRequest` interface for type safety, since `StreamOptionsTransformer` already sets this field at runtime.

## Impact

This fix is a safe, universal improvement to the SSE stream reader. It affects all providers routed through the `AnthropicTransformer`, not just DashScope. For providers that don't send trailing usage chunks, the behavior is unchanged — the outer loop simply exits on `done === true` as before.

## Test Plan

- [x] Verified `pnpm build:core` succeeds with no type errors
- [ ] Test with DashScope provider: confirm `message_delta` event now contains non-zero usage values
- [ ] Test with OpenAI provider: confirm no regression in normal streaming behavior
- [ ] Test with other providers (OpenRouter, Groq, etc.): confirm no regression