### PR TITLE
fix skip redundant Authorization header in bypass mode

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -334,8 +334,9 @@ async function sendRequestToProvider(
 
   // Send HTTP request
   // Prepare headers
+  // In bypass mode, auth is handled by transformer.auth() so skip the default Authorization header
   const requestHeaders: Record<string, string> = {
-    Authorization: `Bearer ${provider.apiKey}`,
+    ...(bypass ? {} : { Authorization: `Bearer ${provider.apiKey}` }),
     ...(config?.headers || {}),
   };
 


### PR DESCRIPTION
 ## Summary
  - In bypass mode (Anthropic transformer passthrough), the default `Authorization: Bearer` header was always added
  alongside `x-api-key` set by `transformer.auth()`, causing some relay APIs and upstream providers to reject requests
  with 502/403 errors
  - Skip the default `Authorization` header in bypass mode, letting `transformer.auth()` handle authentication
  exclusively

  ## Changes
  - `packages/core/src/api/routes.ts`: Conditionally skip `Authorization: Bearer` header when `bypass=true`

  ## Test Plan
  - [x] Configure an Anthropic-compatible relay provider with `"transformer": {"use": ["Anthropic"]}` and verify
  requests succeed
  - [x] Verify non-bypass providers (DeepSeek, OpenRouter, etc.) still include `Authorization: Bearer` header as before
  - [x] Verify official Anthropic API (`api.anthropic.com`) works correctly with the change