### PR TITLE
`fix(ui): center dialog modal and prevent save button from being cut off` / `修复(ui)：对话框居中显示并防止保存按钮被截断`

### DIFF
--- a/packages/ui/src/components/StatusLineConfigDialog.tsx
+++ b/packages/ui/src/components/StatusLineConfigDialog.tsx
@@ -769,7 +769,7 @@ export function StatusLineConfigDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl h-[90vh] overflow-hidden sm:max-w-5xl md:max-w-6xl lg:max-w-7xl animate-in fade-in-90 slide-in-from-bottom-10 duration-300 flex flex-col">
+      <DialogContent className="max-w-4xl sm:max-w-5xl md:max-w-6xl lg:max-w-7xl animate-in fade-in-90 duration-300 flex flex-col">
         <DialogHeader
           data-testid="statusline-config-dialog-header"
           className="border-b pb-4"

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<(
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -39,7 +39,7 @@ const DialogContent = React.forwardRef<(
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg animate-scale-in",
+        "fixed inset-0 z-50 grid w-full max-w-lg m-auto gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg max-h-[90vh] overflow-y-auto",
         className
       )}
       {...props}


### PR DESCRIPTION
### 问题 / Problem

弹窗（Modal）打开时位置偏移到右下角，无法居中显示，且内容较多时保存按钮被截断不可见。

---

The dialog modal was positioned off-center (shifted to the bottom-right) when opened, and the save button was cut off and invisible when the content was tall.

<img width="3837" height="1983" alt="image" src="https://github.com/user-attachments/assets/13b1298c-5faa-4de0-9e00-70b8692f2c64" />

### 根因 / Root Cause

`DialogContent` 使用 `left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]` 实现 CSS 居中定位，但 `tailwindcss-animate` 库的 `slide-in-from-left-1/2`、`slide-in-from-top-[48%]`、`slide-out-to-left-1/2`、`slide-out-to-top-[48%]` 等动画类会通过 `--tw-enter-translate-x/y` 和 `--tw-exit-translate-x/y` CSS 变量叠加偏移量到 `translate` 属性上，导致最终位置偏移而非居中。同时 `animate-scale-in` 的 `transform: scale()` 也会干扰 translate 定位。

此外，`StatusLineConfigDialog` 使用了固定高度 `h-[90vh]`，当弹窗本身已有垂直偏移时，底部保存按钮会被推出视口之外。

---

`DialogContent` used `left-[50%] top-[50%] translate-x/y-[-50%]` for CSS centering, but `tailwindcss-animate`'s `slide-in-from-*` and `slide-out-to-*` classes set `--tw-enter-translate-x/y` and `--tw-exit-translate-x/y` CSS variables that accumulate on top of the base `translate` property, causing the modal to shift away from center. The `animate-scale-in` animation also interfered with `translate`-based positioning via `transform: scale()`.

Additionally, `StatusLineConfigDialog` had a fixed `h-[90vh]` height, which combined with the vertical offset pushed the save button below the viewport.


### 修改 / Changes

**`packages/ui/src/components/ui/dialog.tsx`**

| 项目 / Item | 修改前 / Before | 修改后 / After |
|---|---|---|
| 居中方式 / Centering | `left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]` | `inset-0 m-auto` |
| 冲突动画 / Conflicting animations | `slide-in-from-*`, `slide-out-to-*`, `animate-scale-in` | 已移除 / Removed |
| 溢出控制 / Overflow | 无 / None | `max-h-[90vh] overflow-y-auto` |
| 动画时长 / Duration | `duration-300` | `duration-200` |

**`packages/ui/src/components/StatusLineConfigDialog.tsx`**

| 项目 / Item | 修改前 / Before | 修改后 / After |
|---|---|---|
| 容器高度 / Container height | `h-[90vh] overflow-hidden` | 移除（由基础组件 `max-h-[90vh]` 控制）/ Removed (handled by base `max-h-[90vh]`) |
| 入场动画 / Enter animation | `slide-in-from-bottom-10` | 已移除 / Removed |

---

### 技术说明 / Technical Notes

`inset-0` 设置 `top:0; right:0; bottom:0; left:0`，`m-auto` 让浏览器通过 margin 自动计算实现水平垂直居中，完全不依赖 `translate` 属性，从根本上避免了与 tailwindcss-animate 的 CSS 变量冲突。

---

`inset-0` sets `top:0; right:0; bottom:0; left:0`, and `m-auto` lets the browser compute margins automatically for horizontal and vertical centering. This approach doesn't use the `translate` property at all, fundamentally avoiding any conflict with `tailwindcss-animate`'s CSS variable-based animation system.
