### PR TITLE
fix(gemini): flush buffered content when thinking+content coexist in last chunk

### DIFF
--- a/packages/core/src/utils/gemini.util.ts
+++ b/packages/core/src/utils/gemini.util.ts
@@ -819,6 +819,41 @@ export async function transformResponseOut(
                 if (hasThinkingContent && textContent && !signatureSent) {
                   if (chunk.modelVersion.includes("3")) {
                     pendingContent += textContent;
+                    // If this is the last chunk (finishReason present), emit a synthetic
+                    // thinking signature to close the thinking block first, so the buffered
+                    // content gets flushed properly by the textContent handler below.
+                    if (candidate.finishReason) {
+                      const sigChunk = {
+                        choices: [
+                          {
+                            delta: {
+                              role: "assistant",
+                              content: null,
+                              thinking: {
+                                signature: `ccr_${+new Date()}`,
+                              },
+                            },
+                            finish_reason: null,
+                            index: contentIndex,
+                            logprobs: null,
+                          },
+                        ],
+                        created: parseInt(
+                          new Date().getTime() / 1000 + "",
+                          10
+                        ),
+                        id: chunk.responseId || "",
+                        model: chunk.modelVersion || "",
+                        object: "chat.completion.chunk",
+                        system_fingerprint: "fp_a49d71b8a1",
+                      };
+                      controller.enqueue(
+                        encoder.encode(
+                          `data: ${JSON.stringify(sigChunk)}\n\n`
+                        )
+                      );
+                      signatureSent = true;
+                    }
                     return;
                   } else {
                     const signatureChunk = {


### PR DESCRIPTION
## Problem

When using Gemini 3.x models (e.g. `gemini-3.1-pro-preview-pt`) with Claude Code through CCR, multi-turn conversations with tool use eventually fail with:

```
API Error: Content block not found
```

## Root Cause

In `gemini.util.ts`, the stream handler for Gemini 3.x has this logic:

```typescript
if (hasThinkingContent && textContent && !signatureSent) {
  if (chunk.modelVersion.includes("3")) {
    pendingContent += textContent;
    return;
  }
}
```

When Gemini 3.x returns thinking and content in the **same chunk**, the content is buffered into `pendingContent` and only flushed when a `thoughtSignature` arrives later. But if the **last chunk** has a `finishReason` but no `thoughtSignature`, the buffered content is silently dropped.

This causes the SSE stream to be incomplete (thinking block sent, but no content block), and Claude Code throws "Content block not found" when parsing the stream.

## Fix

When the chunk that triggers the buffer path also has a `finishReason`, emit a synthetic thinking signature to close the thinking block first, then let the normal `textContent` handler below flush `pendingContent` as a proper content chunk.

## Testing

Tested with `gemini-3.1-pro-preview-pt` via mify proxy:
- Single-round tool use: works
- Multi-round tool use: works (previously failed)
- Pure text conversation: works
- No regressions observed for Gemini 2.x (different code path)