### PR TITLE
Strip x-anthropic-* pseudo-headers to enable upstream prefix caching

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -15,6 +15,16 @@ import { getThinkLevel } from "@/utils/thinking";
 import { createApiError } from "@/api/middleware";
 import { formatBase64 } from "@/utils/image";
 
+// Claude Code embeds control metadata like
+// `x-anthropic-billing-header: ...; cch=<per-request-hash>;` inside the
+// system prompt. The hash changes every turn, defeating prefix caching on
+// any non-Anthropic backend. These pseudo-headers are only meaningful to
+// the real Anthropic API, so strip them once during translation.
+const ANTHROPIC_PSEUDO_HEADER_RE = /^x-anthropic-[a-z-]+:[^\n]*\n?/gim;
+function stripAnthropicPseudoHeaders(text: string): string {
+  return text.replace(ANTHROPIC_PSEUDO_HEADER_RE, "");
+}
+
 export class AnthropicTransformer implements Transformer {
   name = "Anthropic";
   endPoint = "/v1/messages";
@@ -53,14 +63,14 @@ export class AnthropicTransformer implements Transformer {
       if (typeof request.system === "string") {
         messages.push({
           role: "system",
-          content: request.system,
+          content: stripAnthropicPseudoHeaders(request.system),
         });
       } else if (Array.isArray(request.system) && request.system.length) {
         const textParts = request.system
           .filter((item: any) => item.type === "text" && item.text)
           .map((item: any) => ({
             type: "text" as const,
-            text: item.text,
+            text: stripAnthropicPseudoHeaders(item.text),
             cache_control: item.cache_control,
           }));
         messages.push({


### PR DESCRIPTION
## Problem

Claude Code embeds control metadata inside the **system prompt** as pseudo-headers, e.g.:

```
x-anthropic-billing-header: cc_version=2.1.114.76c; cc_entrypoint=cli; cch=ea6aa;
```

The \`cch=\` hash changes on **every request**. When CCR routes to a non-Anthropic backend that does prompt prefix caching (mlx-lm, vLLM, llama.cpp, ollama, etc.), this volatile hash sits early in the system prompt and invalidates the cached prefix on every turn — forcing a full re-prefill of the entire system prompt + tool schemas (~24K tokens) for every user message.

Repro on a local mlx-lm server:

```
2026-04-18 22:11:18 - Prompt processing progress: 2048/24102
2026-04-18 22:11:20 - Prompt processing progress: 4096/24102
... (every turn re-prefills all 24K tokens)
```

## Fix

These \`x-anthropic-*\` pseudo-headers are only meaningful to the real Anthropic API. Strip them once during Anthropic→Unified translation in \`AnthropicTransformer.transformRequestOut\`. ~12 lines, no config, no opt-in, applies automatically to every non-Anthropic provider.

After the fix, mlx-lm prefix cache hits and the second turn only prefills the new user tokens (~10s of tokens instead of 24K).

## Test plan

- [x] \`pnpm build\` clean
- [x] Verified locally with \`mlx_lm.server\` + \`google/gemma-4-e4b-it\`: two-turn conversation, second turn prefills only the delta
- [x] Verify no regression for users who actually route to Anthropic (no-op there since the AnthropicTransformer doesn't run for Anthropic-destined requests)