### PR TITLE
docs(readme): add Z.ai provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## ✨ Features
 
 - **Model Routing**: Route requests to different models based on your needs (e.g., background tasks, thinking, long context).
-- **Multi-Provider Support**: Supports various model providers like OpenRouter, DeepSeek, Ollama, Gemini, Volcengine, and SiliconFlow.
+- **Multi-Provider Support**: Supports various model providers like OpenRouter, DeepSeek, Ollama, Gemini, Volcengine, Z.ai, and SiliconFlow.
 - **Request/Response Transformation**: Customize requests and responses for different providers using transformers.
 - **Dynamic Model Switching**: Switch models on-the-fly within Claude Code using the `/model` command.
 - **CLI Model Management**: Manage models and providers directly from the terminal with `ccr model`.
@@ -192,6 +192,15 @@ Here is a comprehensive example:
         "claude-opus-4-20250514",
         "gemini-2.5-pro"
       ]
+    },
+    {
+      "name": "zai",
+      "api_base_url": "https://api.z.ai/api/anthropic/v1/messages",
+      "api_key": "${ZAI_API_KEY}",
+      "models": ["glm-4.6"],
+      "transformer": {
+        "use": ["Anthropic"]
+      }
     }
   ],
   "Router": {

--- a/README_zh.md
+++ b/README_zh.md
@@ -167,6 +167,15 @@ npm install -g @musistudio/claude-code-router
         "claude-opus-4-20250514",
         "gemini-2.5-pro"
       ]
+    },
+    {
+      "name": "zai",
+      "api_base_url": "https://api.z.ai/api/anthropic/v1/messages",
+      "api_key": "${ZAI_API_KEY}",
+      "models": ["glm-4.6"],
+      "transformer": {
+        "use": ["Anthropic"]
+      }
     }
   ],
   "Router": {


### PR DESCRIPTION
## Summary
- add Z.ai to the supported provider list in the README
- document a working Z.ai provider configuration example in the English README
- mirror the same JSON example in the Chinese README

## Testing
- not run (documentation-only change)

Closes #898