### PR TITLE
docs: fix router format separator (colon → comma) in zh-CN preset example

### DIFF
--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/preset.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/preset.md
@@ -148,7 +148,7 @@ ccr preset delete my-config
   ],
 
   "Router": {
-    "default": "openai:gpt-4"
+    "default": "openai,gpt-4"
   },
 
   "schema": [


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/preset.md`, the Router manifest example at line 151 uses a **colon** as the provider-model separator:

```json
"Router": {
  "default": "openai:gpt-4"
}
```

The CCR router system expects a **comma** as the separator (`provider,model`). A user copying this example into their `config.json` would silently get a non-functional router config — the router would fail to resolve the model and fall back or error, with no obvious indication of why.

The correct format, used consistently in the EN documentation and throughout the codebase, is:

```json
"Router": {
  "default": "openai,gpt-4"
}
```

## Fix

Changed `"openai:gpt-4"` → `"openai,gpt-4"` in the manifest example (one character, maximum impact for users copy-pasting the example).

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:6095d71866351b1ea0996b8ed38917b1811ce212567d0c5b3ef8a646c6b7862a"}]}
nlpm-metadata-end -->