### PR TITLE
docs: add /zh locale prefix to statusline zh-CN related-command links

### DIFF
--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/statusline.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/statusline.md
@@ -398,5 +398,5 @@ export COLORTERM=truecolor
 
 ## 相关命令
 
-- [ccr status](/docs/cli/commands/status) - 检查服务状态
-- [ccr preset](/docs/cli/commands/preset) - 管理带 statusline 主题的 presets
+- [ccr status](/zh/docs/cli/commands/status) - 检查服务状态
+- [ccr preset](/zh/docs/cli/commands/preset) - 管理带 statusline 主题的 presets

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/commands/statusline.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/commands/statusline.md
@@ -397,5 +397,5 @@ export COLORTERM=truecolor
 
 ## 相关命令
 
-- [ccr status](/docs/cli/commands/status) - 检查服务状态
-- [ccr preset](/docs/cli/commands/preset) - 管理带 statusline 主题的 presets
+- [ccr status](/zh/docs/cli/commands/status) - 检查服务状态
+- [ccr preset](/zh/docs/cli/commands/preset) - 管理带 statusline 主题的 presets


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Both zh-CN `statusline.md` files have "Related Commands" links that are missing the `/zh` locale prefix required by Docusaurus for localized pages:

```markdown
- [ccr status](/docs/cli/commands/status)   ← navigates to English page
- [ccr preset](/docs/cli/commands/preset)   ← navigates to English page
```

A zh-CN user clicking either link lands on the English documentation page instead of the Chinese version. The other zh-CN files in the same directory already use the correct `/zh/docs/...` prefix for their internal links (e.g. `start.md` links to `/zh/docs/cli/other-commands#ccr-stop`).

The bug appears in two files:
1. `docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/commands/statusline.md` (the live version)
2. `docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/statusline.md` (the backup copy)

Both files are identical at this location, suggesting the backup was copied before the locale fix was applied.

## Fix

Added `/zh` prefix to both links in both files (4 changes total). No other content was modified.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:789a4a2bcc3fab3a65aeccaccbb834a807d504c1e6806f13d0a6ce56411100d1"},{"rule_id":"BUG-broken-reference","fingerprint":"sha256:002d9c9d3f02971d82e5f4cb9ff286841ef89fad08be747202525a6d3b5c1bc6"}]}
nlpm-metadata-end -->