### PR TITLE
docs: fix default port in EN docs (8080 → 3456)

### DIFF
--- a/docs/docs/cli/commands/start.md
+++ b/docs/docs/cli/commands/start.md
@@ -16,7 +16,7 @@ ccr start [options]
 
 | Option | Alias | Description |
 |--------|-------|-------------|
-| `--port <number>` | `-p` | Port to listen on (default: 8080) |
+| `--port <number>` | `-p` | Port to listen on (default: 3456) |
 | `--config <path>` | `-c` | Path to configuration file |
 | `--daemon` | `-d` | Run as daemon (background process) |
 | `--log-level <level>` | `-l` | Log level (fatal/error/warn/info/debug/trace) |
@@ -70,8 +70,8 @@ You can also configure the server using environment variables:
 When started successfully, you'll see:
 
 ```
-Claude Code Router is running on http://localhost:8080
-API endpoint: http://localhost:8080/v1
+Claude Code Router is running on http://localhost:3456
+API endpoint: http://localhost:3456/v1
 ```
 
 ## Related Commands

--- a/docs/docs/cli/commands/status.md
+++ b/docs/docs/cli/commands/status.md
@@ -22,7 +22,7 @@ When the server is running:
 Claude Code Router Status: Running
 Version: 2.0.0
 PID: 12345
-Port: 8080
+Port: 3456
 Uptime: 2h 34m
 Configuration: /home/user/.claude-code-router/config.json
 ```
@@ -51,7 +51,7 @@ $ ccr status
 Claude Code Router Status: Running
 Version: 2.0.0
 PID: 12345
-Port: 8080
+Port: 3456
 Uptime: 2h 34m
 ```
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The EN documentation for `ccr start` and `ccr status` documented the default port as **8080**, while the actual CLI source code defaults to **3456**:

- `packages/cli/src/cli.ts`: `const port = globalConfig.PORT || 3456`
- `packages/cli/src/utils/index.ts`: `PORT: 3456`
- `packages/cli/src/utils/createEnvVariables.ts`: `const port = config.PORT || 3456`

The zh-CN docs correctly showed 3456; the EN docs had drifted. A user following the EN docs would expect the server at port 8080 and get a connection error.

## Fix

Updated `docs/docs/cli/commands/start.md` and `docs/docs/cli/commands/status.md` to show port 3456 in the options table and all output examples. No logic changes — documentation only.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"CC-terminology-drift","fingerprint":"sha256:e7f19b9065eff45460cf37ca2b742aa7de14879101e82eba23f45beafb7b91ff"},{"rule_id":"CC-terminology-drift","fingerprint":"sha256:2e8cd28acec42b1f46890f53d8a6dfd98ca5713f30f5ef1795d64d5380d3067b"},{"rule_id":"CC-terminology-drift","fingerprint":"sha256:23b1cb3b8e6086f80c780f67d53f99071bcb8910ee988ef18f9a376498dd2324"}]}
nlpm-metadata-end -->