### PR TITLE
docs: fix Router separator in zh-CN preset example (: → ,)

### DIFF
--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/preset.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/preset.md
@@ -148,7 +148,7 @@ ccr preset delete my-config
   ],
 
   "Router": {
-    "default": "openai:gpt-4"
+    "default": "openai,gpt-4"
   },
 
   "schema": [


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/preset.md` (line 151), the Router manifest example uses a **colon** as the provider/model separator:

```json
"Router": {
  "default": "openai:gpt-4"
}
```

CCR's actual router format uses a **comma** separator. Both the current zh-CN version and the EN version of `preset.md` correctly use `"openai,gpt-4"`. A user copying this example verbatim would produce an invalid router configuration that fails silently.

## Fix

Changed `"openai:gpt-4"` to `"openai,gpt-4"` on line 151. One character, one file.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:6095d71866351b1ea0996b8ed38917b1811ce212567d0c5b3ef8a646c6b7862a"}]}
nlpm-metadata-end -->