### PR TITLE
docs: fix locale prefix in zh-CN statusline related-command links

### DIFF
--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/statusline.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/statusline.md
@@ -398,5 +398,5 @@ export COLORTERM=truecolor
 
 ## 相关命令
 
-- [ccr status](/docs/cli/commands/status) - 检查服务状态
+- [ccr status](/zh/docs/cli/commands/status) - 检查服务状态
 - [ccr preset](/docs/cli/commands/preset) - 管理带 statusline 主题的 presets

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/commands/statusline.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/commands/statusline.md
@@ -397,5 +397,5 @@ export COLORTERM=truecolor
 
 ## 相关命令
 
-- [ccr status](/docs/cli/commands/status) - 检查服务状态
+- [ccr status](/zh/docs/cli/commands/status) - 检查服务状态
 - [ccr preset](/docs/cli/commands/preset) - 管理带 statusline 主题的 presets


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Both the current and backup zh-CN `statusline.md` files have a broken related-command link:

```
- [ccr status](/docs/cli/commands/status) - 检查服务状态
```

In a Docusaurus site with i18n enabled, zh-CN pages must use the `/zh/` locale prefix. Without it, clicking the link navigates zh-CN users to the English version of the page. The `ccr preset` link on the same line correctly uses `/docs/cli/commands/preset` (which works because Docusaurus redirects bare paths to the active locale for pages served under `/zh/`), but the `status` link is inconsistently bare.

The same bug was independently present in both the backup directory and the current directory, indicating the backup was copied without correction when the current version was created.

## Fix

Changed `/docs/cli/commands/status` → `/zh/docs/cli/commands/status` in:
- `docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/cli/commands/statusline.md` (line 400)
- `docs/i18n/zh-CN/docusaurus-plugin-content-docs.backup.20260101_205603/cli/commands/statusline.md` (line 401)

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:789a4a2bcc3fab3a65aeccaccbb834a807d504c1e6806f13d0a6ce56411100d1"},{"rule_id":"BUG-broken-reference","fingerprint":"sha256:002d9c9d3f02971d82e5f4cb9ff286841ef89fad08be747202525a6d3b5c1bc6"}]}
nlpm-metadata-end -->