### PR TITLE
fix(anthropic): preserve server-side tool type in unified conversion

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -243,14 +243,38 @@ export class AnthropicTransformer implements Transformer {
   }
 
   private convertAnthropicToolsToUnified(tools: any[]): UnifiedTool[] {
-    return tools.map((tool) => ({
-      type: "function",
-      function: {
-        name: tool.name,
-        description: tool.description || "",
-        parameters: tool.input_schema,
-      },
-    }));
+    return tools.map((tool) => {
+      if (
+        tool.type &&
+        typeof tool.type === "string" &&
+        tool.type.startsWith("web_search_")
+      ) {
+        // Server-side tools: preserve the original type at top level
+        // so bypass/Anthropic-compatible providers receive the correct
+        // protocol-level tool type.  Also keep function for downstream
+        // compatibility (filters like tool.function.name === "web_search").
+        return {
+          type: tool.type,
+          name: tool.name,
+          description: tool.description,
+          display_name: tool.display_name,
+          cache_control: tool.cache_control,
+          function: {
+            name: tool.name,
+            description: tool.description || "",
+            parameters: undefined as any,
+          },
+        };
+      }
+      return {
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description || "",
+          parameters: tool.input_schema,
+        },
+      };
+    });
   }
 
   private async convertOpenAIStreamToAnthropic(

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -68,7 +68,7 @@ export interface UnifiedMessage {
 
 // 统一的工具定义接口
 export interface UnifiedTool {
-  type: "function";
+  type: "function" | string;
   function: {
     name: string;
     description: string;


### PR DESCRIPTION
## Problem

Anthropic server-side tools (e.g. `web_search`) use a protocol-level `type` like `"web_search_20260209"` and have no `input_schema` field. The `convertAnthropicToolsToUnified` method was unconditionally rewriting every tool to `{type: "function", function: {name, description, parameters: tool.input_schema}}`, which:

1. Lost the original `type` — critical semantic information for the endpoint
2. Produced `parameters: undefined` since server-side tools lack `input_schema`

When the provider uses bypass mode (single `Anthropic` transformer configured, so `transformRequestIn` is skipped), the mangled tool definition was forwarded directly to DeepSeek's Anthropic-compatible endpoint. The endpoint received `{type:"function", function:{name:"web_search", parameters:undefined}}` instead of `{type:"web_search_20260209", name:"web_search"}` and could not recognize the web search capability.

Closes #597, related to #1290.

## Fix

`convertAnthropicToolsToUnified` now detects server-side tools (`type` starts with `"web_search_"`) and:

- Preserves the original protocol-level `type` at the top level
- Still provides a `function` wrapper for backward compatibility with downstream filters (`tool.function.name === "web_search"`)

## Impact

- **Bypass mode (DeepSeek + Anthropic transformer)**: Tool definitions now reach the endpoint intact. WebSearch works.
- **Non-bypass paths (Gemini, OpenAI, etc.)**: No change — these transformers read only `tool.function.*` and ignore `tool.type`. The router already isolates `web_search`-bearing requests to the `webSearch` route.
- **Regular custom tools**: Zero impact — the non-`web_search` code path is unchanged.

## Testing

Tested end-to-end with DeepSeek v4 via CCR bypass mode:

```
$ curl -X POST http://127.0.0.1:3456/v1/messages \
    -H "x-api-key: ..." \
    -d '{"model":"deepseek-v4-pro","tools":[{"type":"web_search_20260209",...}],...}'

Response: server_tool_use + web_search_tool_result with actual search results ✓
```