### PR TITLE
fix: pass args array directly to spawn, remove shell:true (DEP0190)

### DIFF
--- a/packages/cli/src/utils/codeCommand.ts
+++ b/packages/cli/src/utils/codeCommand.ts
@@ -5,8 +5,6 @@ import {
   incrementReferenceCount,
   closeService,
 } from "./processCheck";
-import { quote } from 'shell-quote';
-import minimist from "minimist";
 import { createEnvVariables } from "./createEnvVariables";
 
 export interface PresetConfig {
@@ -93,34 +91,18 @@ export async function executeCodeCommand(
   // Execute claude command
   const claudePath = config?.CLAUDE_PATH || process.env.CLAUDE_PATH || "claude";
 
-  const joinedArgs = args.length > 0 ? quote(args) : "";
-
   const stdioConfig: StdioOptions = config.NON_INTERACTIVE_MODE
     ? ["pipe", "inherit", "inherit"] // Pipe stdin for non-interactive
     : "inherit"; // Default inherited behavior
 
-  const argsObj = minimist(args)
-  const argsArr = []
-  for (const [argsObjKey, argsObjValue] of Object.entries(argsObj)) {
-    if (argsObjKey !== '_' && argsObj[argsObjKey]) {
-      const prefix = argsObjKey.length === 1 ? '-' : '--';
-      // For boolean flags, don't append the value
-      if (argsObjValue === true) {
-        argsArr.push(`${prefix}${argsObjKey}`);
-      } else {
-        argsArr.push(`${prefix}${argsObjKey} ${JSON.stringify(argsObjValue)}`);
-      }
-    }
-  }
   const claudeProcess = spawn(
     claudePath,
-    argsArr,
+    args,
     {
       env: {
         ...process.env,
       },
-      stdio: stdioConfig,
-      shell: true,
+      stdio: stdioConfig
     }
   );
 


### PR DESCRIPTION
## Problem

Running ccr code produces a Node.js DEP0190 deprecation warning:

DeprecationWarning: Passing args to a child process with shell option true
can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.

The root cause is in executeCodeCommand in packages/cli/src/utils/codeCommand.ts. The code takes the incoming args array (which is already correctly structured), feeds it through minimist to parse it into an object, then reconstructs a new array but does so incorrectly by joining each flag and its value into a single string:

```js
argsArr.push(`${prefix}${argsObjKey} ${JSON.stringify(argsObjValue)}`);
// produces: ['--settings "/tmp/path/file.json"']
// instead of: ['--settings', '/tmp/path/file.json']
```

This broken array cannot be passed directly to the OS, so shell: true was added to make the shell re-parse the concatenated string which is exactly what DEP0190 warns against.

This roundtrip also has two additional bugs:
- Positional arguments (e.g. ccr code "Write a Hello World") are silently dropped because minimist puts them in _ and the loop skips _ entirely, so the prompt never reaches claude.
- Short flags with values (e.g. -n helloworld) suffer the same single-string reconstruction bug as long flags.
// produces: ['-n "helloworld"']
// instead of: ['-n', 'helloworld']

## Fix

Remove the minimist roundtrip entirely and pass the original args array directly to spawn. 
The array is already correct, --settings and its value are already separate elements (added via args.push('--settings', settingsFile)). With a proper args array, shell: true is no longer needed and is removed.

// before
```js
const argsObj = minimist(args);
const argsArr = [];
for (const [key, val] of Object.entries(argsObj)) {
  if (key !== '_' && argsObj[key]) {
    const prefix = key.length === 1 ? '-' : '--';
    if (val === true)  {
      argsArr.push(`${prefix}${key}`);
    } else {
      argsArr.push(`${prefix}${key} ${JSON.stringify(val)}`);
    }
  }
}
const claudeProcess = spawn(claudePath, argsArr, { ..., shell: true });
```

// after
```js
const claudeProcess = spawn(claudePath, args, { ... });
```