### PR TITLE
fix(anthropic-transformer): backfill empty parameters & reset text-block flag

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -248,7 +248,10 @@ export class AnthropicTransformer implements Transformer {
       function: {
         name: tool.name,
         description: tool.description || "",
-        parameters: tool.input_schema,
+        // Some Anthropic tools (e.g. server-side tools, no-arg tools) omit
+        // input_schema. Strict OpenAI-spec providers (Together, etc.) reject
+        // tools without `parameters`, so backfill with an empty object schema.
+        parameters: tool.input_schema || { type: "object", properties: {} },
       },
     }));
   }
@@ -570,6 +573,7 @@ export class AnthropicTransformer implements Transformer {
                       )
                     );
                     currentContentBlockIndex = -1;
+                    hasTextContentStarted = false;
                   } else if (choice.delta.thinking.content) {
                     const thinkingChunk = {
                       type: "content_block_delta",
@@ -743,6 +747,15 @@ export class AnthropicTransformer implements Transformer {
                           )
                         );
                         currentContentBlockIndex = -1;
+                        // A non-text block (tool_use) is taking over. Without
+                        // this reset, a later text-content chunk would be
+                        // routed to the tool_use block as a text_delta and
+                        // crash the Anthropic client with
+                        // "Content block is not a text block". Reproduces with
+                        // OpenAI-format providers that interleave text and
+                        // tool_calls in separate stream chunks (e.g. Together
+                        // for DeepSeek).
+                        hasTextContentStarted = false;
                       }
 
                       const newContentBlockIndex = assignContentBlockIndex();


### PR DESCRIPTION
## Summary

Two related bugs in `AnthropicTransformer` cause request rejection or client crashes when routing to OpenAI-format providers (Together, OpenRouter for DeepSeek, etc.).

### Bug 1 — `tools[0].function: missing field parameters`

`convertAnthropicToolsToUnified` passes `tool.input_schema` straight through to `function.parameters`. When a tool omits `input_schema` (server-side tools, no-arg tools), the field becomes `undefined` and is dropped during JSON serialization. Strict OpenAI-spec providers then reject the request with `tools[0].function: missing field parameters`. Backfill with an empty object schema (`{ type: "object", properties: {} }`).

### Bug 2 — `Content block is not a text block`

`convertOpenAIStreamToAnthropic` uses `hasTextContentStarted` as "is the current open block a text block", but only ever flips it to `true`, never back to `false`. When a `tool_use` block takes over from a text block, `currentContentBlockIndex` is updated to the tool_use block's index but the flag stays `true`. A later `delta.content` chunk then takes the "no need to open a new text block" branch and emits `text_delta` events on the **tool_use block's index**. The Anthropic-format consumer (Claude Code) raises `Content block is not a text block` and aborts the stream (`stream closed prematurely`).

This reproduces consistently with Together for `deepseek-v4-pro`, which interleaves `delta.content` and `delta.tool_calls` across separate stream chunks. Reset the flag whenever the text block is implicitly closed by a thinking-signature stop or tool_use takeover.

### Repro (Bug 2)

Captured CCR debug log around the crash:

```
content_block_start  index=0  type=text          ← text block opens
content_block_delta  index=0  text_delta="\n\n"
content_block_stop   index=0
content_block_start  index=1  type=tool_use      ← tool_use takes over
... input_json_delta to index 1 ...
content_block_delta  index=1  text_delta="\n"    ← BUG: text_delta on tool_use block
"stream closed prematurely"
```

After the patch, the tool_use takeover resets `hasTextContentStarted = false`, so the next `delta.content` opens a fresh text block at a new index instead of routing onto the tool_use block.

## Test plan

- [x] `pnpm build:core` succeeds
- [x] Local `cli.js` patched with the same logic eliminates `tools[0].function: missing field parameters` for the no-`input_schema` case (Together provider)
- [x] Same local patch eliminates `Content block is not a text block` for the DeepSeek-v4 interleaved-stream case
- [ ] Maintainer-side: smoke test with a non-DeepSeek OpenAI-format provider to confirm no regression in the single-choice (text-only or tool-only) path