### PR TITLE
fix(openai): strip reasoning param and map to reasoning_effort for "/v1/chat/completions"

### DIFF
--- a/packages/core/src/transformer/openai.transformer.ts
+++ b/packages/core/src/transformer/openai.transformer.ts
@@ -1,6 +1,19 @@
+import { UnifiedChatRequest } from "@/types/llm";
 import { Transformer } from "@/types/transformer";
 
 export class OpenAITransformer implements Transformer {
   name = "OpenAI";
   endPoint = "/v1/chat/completions";
+
+  async transformRequestIn(
+    request: UnifiedChatRequest
+  ): Promise<UnifiedChatRequest> {
+    if (request.reasoning?.effort && request.reasoning.effort !== "none") {
+      (request as any).reasoning_effort = request.reasoning.effort;
+    }
+    delete request.reasoning;
+    delete (request as any).thinking;
+    delete (request as any).enable_thinking;
+    return request;
+  }
 }


### PR DESCRIPTION
## Summary
OpenAI's `/v1/chat/completions` rejects the unknown parameter `reasoning`, returning a 400:

Unknown parameter: 'reasoning'

This breaks every provider whose `transformer.use` includes `OpenAI` whenever Claude Code sends a thinking-enabled request    
(Plan Mode, *think harder*, etc.).

Closes #652
Related to #510, #668

## Fix
Add `transformRequestIn` to `OpenAITransformer` that:

1. Maps `reasoning.effort` → OpenAI's native `reasoning_effort` (the field actually accepted by o1/o3/o4/gpt-5 on
`/v1/chat/completions`) when an effort level is set and not `"none"`.
2. Strips `reasoning`, `thinking`, and `enable_thinking` so OpenAI's strict-parameter validation passes.

The `ThinkLevel` values produced by this codebase — `none | low | medium | high` (see `packages/core/src/utils/thinking.ts`) — are exactly the values OpenAI accepts for `reasoning_effort`, so the mapping is a 1:1 passthrough with no value-space        
conversion needed.

## Verification
- ✅ Reproduced the original `Unknown parameter: 'reasoning'` 400 against an OpenAI provider with Plan Mode enabled (before this change).
- ✅ With this change the same request succeeds; the outgoing payload contains `reasoning_effort` (when an effort is set) and 
no longer contains `reasoning` / `thinking` / `enable_thinking`.
- ✅ Non-thinking requests are unchanged.