### PR TITLE
fix deepseek v4 thinking compatible

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -161,12 +161,12 @@ export class AnthropicTransformer implements Transformer {
             }
 
             const thinkingPart = msg.content.find(
-              (c: any) => c.type === "thinking" && c.signature
+              (c: any) => c.type === "thinking"
             );
             if (thinkingPart) {
               assistantMessage.thinking = {
                 content: thinkingPart.thinking,
-                signature: thinkingPart.signature,
+                ...(thinkingPart.signature && { signature: thinkingPart.signature }),
               };
             }
 

--- a/packages/core/src/transformer/deepseek.transformer.ts
+++ b/packages/core/src/transformer/deepseek.transformer.ts
@@ -8,13 +8,36 @@ export class DeepseekTransformer implements Transformer {
     if (request.max_tokens && request.max_tokens > 8192) {
       request.max_tokens = 8192; // DeepSeek has a max token limit of 8192
     }
+    for (const message of request.messages) {
+      if (message.role === "assistant" && message.thinking) {
+        if (message.thinking.content) {
+          (message as any).reasoning_content = message.thinking.content;
+        }
+        delete message.thinking;
+      }
+    }
+    if (request.reasoning) {
+      (request as any).thinking = {
+        type: "enabled",
+      };
+      if (request.reasoning.effort) {
+        (request as any).reasoning_effort = request.reasoning.effort;
+      }
+      delete request.reasoning;
+    }
     return request;
   }
 
   async transformResponseOut(response: Response): Promise<Response> {
     if (response.headers.get("Content-Type")?.includes("application/json")) {
-      const jsonResponse = await response.json();
+      const jsonResponse: any = await response.json();
       // Handle non-streaming response if needed
+      if (jsonResponse.choices?.[0]?.message?.reasoning_content) {
+        jsonResponse.choices[0].message.thinking = {
+          content: jsonResponse.choices[0].message.reasoning_content,
+        };
+        delete jsonResponse.choices[0].message.reasoning_content;
+      }
       return new Response(JSON.stringify(jsonResponse), {
         status: response.status,
         statusText: response.statusText,


### PR DESCRIPTION
适配deepseek v4中思考模式的输入要求（https://api-docs.deepseek.com/zh-cn/guides/thinking_mode）

1. deepseek.transformer.ts — 请求方向转换缺失
- 问题：assistant 消息的 thinking 未转为 DeepSeek 所需的 reasoning_content；reasoning 参数未转为 thinking + reasoning_effort
- 修复：在 transformRequestIn 中添加 thinking → reasoning_content 和 reasoning → thinking + reasoning_effort 的转换
2. deepseek.transformer.ts — 非流式响应未转换
- 问题：transformResponseOut 对 JSON 响应原样透传，未将 reasoning_content 转为 thinking
- 修复：在 JSON 响应处理中添加 reasoning_content → thinking 的转换
3. anthropic.transformer.ts:164 — thinking 块因缺少 signature 被丢弃
- 问题：c.type === "thinking" && c.signature 条件要求 signature 必须存在，但 Claude Code 传回的 thinking 块 signature 可能为空
- 修复：放宽为 c.type === "thinking"，signature 有则保留、无则省略

配置要求
deepseek provider 必须配置 transformer（provider 级别）：
"transformer": { "use": ["deepseek"] }
否则 transformer 不会被执行。

关联Issue:
https://github.com/musistudio/claude-code-router/issues/1355