### PR TITLE
fix(deepseek): preserve reasoning_content across multi-turn agent loops

### DIFF
--- a/packages/core/src/transformer/deepseek.transformer.ts
+++ b/packages/core/src/transformer/deepseek.transformer.ts
@@ -1,6 +1,36 @@
 import { UnifiedChatRequest } from "../types/llm";
 import { Transformer } from "../types/transformer";
 
+// Stores reasoning_content captured from past responses so it can be reinjected
+// on subsequent requests. DeepSeek V4 thinking mode requires that the
+// reasoning_content from any assistant turn that performed tool calls be sent
+// back on the assistant message in every subsequent request — otherwise the
+// API returns 400 ("The `reasoning_content` in the thinking mode must be passed
+// back to the API."). Claude Code does not preserve thinking content across
+// turns, so we capture and reinject it ourselves.
+//
+// Keyed by sorted tool_call IDs joined by "|". Tool-call IDs round-trip
+// through Claude Code because tool_result messages reference them.
+const REASONING_STORE = new Map<string, string>();
+const REASONING_STORE_LIMIT = 1000;
+
+function storeReasoning(key: string, value: string): void {
+  if (REASONING_STORE.size >= REASONING_STORE_LIMIT) {
+    const firstKey = REASONING_STORE.keys().next().value;
+    if (firstKey !== undefined) REASONING_STORE.delete(firstKey);
+  }
+  REASONING_STORE.set(key, value);
+}
+
+function keyFromToolCalls(toolCalls: any): string | null {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return null;
+  const ids: string[] = toolCalls
+    .map((tc: any) => tc && tc.id)
+    .filter((id: any): id is string => typeof id === "string" && id.length > 0);
+  if (ids.length === 0) return null;
+  return ids.slice().sort().join("|");
+}
+
 export class DeepseekTransformer implements Transformer {
   name = "deepseek";
 
@@ -8,6 +38,19 @@ export class DeepseekTransformer implements Transformer {
     if (request.max_tokens && request.max_tokens > 8192) {
       request.max_tokens = 8192; // DeepSeek has a max token limit of 8192
     }
+
+    // Reinject reasoning_content for assistant messages that performed tool calls.
+    if (request && Array.isArray((request as any).messages)) {
+      for (const msg of (request as any).messages) {
+        if (!msg || msg.role !== "assistant") continue;
+        if (typeof msg.reasoning_content === "string" && msg.reasoning_content) continue;
+        const key = keyFromToolCalls(msg.tool_calls);
+        if (!key) continue;
+        const stored = REASONING_STORE.get(key);
+        if (stored) msg.reasoning_content = stored;
+      }
+    }
+
     return request;
   }
 
@@ -30,6 +73,20 @@ export class DeepseekTransformer implements Transformer {
       let reasoningContent = "";
       let isReasoningComplete = false;
       let buffer = ""; // 用于缓冲不完整的数据
+
+      // Tool-call IDs emitted by the assistant in this response. Used as the
+      // key for storing reasoningContent so a future request that re-includes
+      // this assistant turn can have its reasoning_content reinjected.
+      const collectedToolCallIds: string[] = [];
+      const captureToolCallIds = (data: any) => {
+        const tcArr = data?.choices?.[0]?.delta?.tool_calls;
+        if (!Array.isArray(tcArr)) return;
+        for (const tc of tcArr) {
+          if (tc && typeof tc.id === "string" && !collectedToolCallIds.includes(tc.id)) {
+            collectedToolCallIds.push(tc.id);
+          }
+        }
+      };
 
       const stream = new ReadableStream({
         async start(controller) {
@@ -66,6 +123,8 @@ export class DeepseekTransformer implements Transformer {
             ) {
               try {
                 const data = JSON.parse(line.slice(6));
+
+                captureToolCallIds(data);
 
                 // Extract reasoning_content from delta
                 if (data.choices?.[0]?.delta?.reasoning_content) {
@@ -195,6 +254,14 @@ export class DeepseekTransformer implements Transformer {
             console.error("Stream error:", error);
             controller.error(error);
           } finally {
+            // Persist captured reasoning so future requests that re-send this
+            // assistant turn (with tool_calls) can have it reinjected by
+            // transformRequestIn. Required by DeepSeek V4 thinking mode.
+            if (reasoningContent && collectedToolCallIds.length > 0) {
+              const key = collectedToolCallIds.slice().sort().join("|");
+              storeReasoning(key, reasoningContent);
+            }
+
             try {
               reader.releaseLock();
             } catch (e) {


### PR DESCRIPTION
## Summary

Fixes a 400 error from DeepSeek V4 thinking-mode in multi-turn agentic
workflows (Claude Code, OpenCode, etc.):

> The \`reasoning_content\` in the thinking mode must be passed back to the API.

The error occurs reliably on turn 2+ of any conversation that involves tool
calls.

## Root cause

DeepSeek V4 thinking-mode rule (per [official docs](https://api-docs.deepseek.com/guides/thinking_mode)):
when an assistant turn performed tool calls, the model's \`reasoning_content\`
from that turn must be sent back on the assistant message in **every**
subsequent request.

The bundled \`deepseek\` transformer already extracts \`reasoning_content\` from
the streaming response and converts it to Anthropic-style \`thinking\` blocks
for the client. But the client (Claude Code in our case) does not preserve
the thinking content across turns: in turn N+1, the assistant message
arrives at the transformer with \`tool_calls\` intact but no \`reasoning_content\`
and no \`thinking\` field. The data is gone before any downstream consumer
can see it, so DeepSeek refuses the request.

Empirically verified by capturing transformer-level request bodies in turn
2+ — see the standalone repo for the reproduction details.

## Fix

Close the loop inside the transformer itself:

- **On streaming response**: alongside the existing reasoning extraction,
  capture the assistant's emitted \`tool_call.id\`s. When the stream ends,
  persist the accumulated \`reasoning_content\` into a module-scoped \`Map\`
  keyed by the sorted tool_call IDs joined by \`|\`.
- **On request (\`transformRequestIn\`)**: walk \`messages\`, find each
  assistant message with \`tool_calls\`, regenerate the same key, and
  reinject \`reasoning_content\` if found.

The key works because tool_call IDs round-trip cleanly: \`tool_result\`
messages reference them, so the client must preserve them.

Storage is in-memory, capped at 1000 entries (oldest evicted when the cap
is hit). Stream byte forwarding is unchanged. No new dependencies.

The diff is +67 lines, all in \`packages/core/src/transformer/deepseek.transformer.ts\`.

## Verification

End-to-end against \`deepseek-v4-pro\` with three multi-turn agentic tasks:

| Task | Turns | 400s | Inject misses | Reasoning tokens |
|---|---|---|---|---|
| Debug Python bug + fix + verify | 4 | 0 | 0 | 193 |
| Read CSV + stats + write report | 4 | 0 | 0 | 201 |
| Generate module + tests + run | 5 | 0 | 0 | 99 |

Build passes (\`pnpm install && pnpm --filter @musistudio/llms build\`).

## Test plan

- [ ] CI green
- [ ] Manual smoke against \`deepseek-v4-pro\` with multi-turn agentic loop (no 400)
- [ ] Confirm reasoning_tokens > 0 per turn (real thinking still works)
- [ ] Confirm non-thinking models (\`deepseek-chat\`) unaffected

## Standalone version

For users who can't wait for this PR to land, the same logic is also
available as a drop-in custom transformer (no upstream changes needed):
https://github.com/marianomelo/ccr-deepseek-thinking-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)