### PR TITLE
fix(ui): preserve env var references when saving config through web UI

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,5 +1,5 @@
 import Server, { calculateTokenCount, TokenizerService } from "@musistudio/llms";
-import { readConfigFile, writeConfigFile, backupConfigFile } from "./utils";
+import { readConfigFile, readRawConfigFile, writeConfigFile, backupConfigFile } from "./utils";
 import { join } from "path";
 import fastifyStatic from "@fastify/static";
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, rmSync } from "fs";
@@ -82,9 +82,11 @@ export const createServer = async (config: any): Promise<any> => {
     return { "input_tokens": tokenCount }
   });
 
-  // Add endpoint to read config.json with access control
+  // Add endpoint to read config.json with access control.
+  // Returns the raw config (with $VAR references intact) so that a subsequent
+  // POST /api/config round-trips cleanly without overwriting env var placeholders.
   app.get("/api/config", async (req: any, reply: any) => {
-    return await readConfigFile();
+    return await readRawConfigFile();
   });
 
   app.get("/api/transformers", async (req: any, reply: any) => {

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -65,6 +65,21 @@ const confirm = async (query: string): Promise<boolean> => {
   return answer.toLowerCase() !== "n";
 };
 
+// Read config from disk without interpolating environment variables.
+// Use this when the raw config (with $VAR references intact) is needed,
+// e.g. when serving the config to the UI so that saves round-trip cleanly.
+export const readRawConfigFile = async (): Promise<any> => {
+  try {
+    const config = await fs.readFile(CONFIG_FILE, "utf-8");
+    return JSON5.parse(config);
+  } catch (readError: any) {
+    if (readError.code === "ENOENT") {
+      return { PORT: 3456, Providers: [], Router: {} };
+    }
+    throw readError;
+  }
+};
+
 export const readConfigFile = async () => {
   try {
     const config = await fs.readFile(CONFIG_FILE, "utf-8");


### PR DESCRIPTION
## Problem

Closes #1373

When users configure `api_key` fields with environment variable references (e.g. `${ZAI_API_KEY}`), opening the web UI and saving the config silently overwrites those references with the literal resolved values — permanently exposing API keys in `config.json`.

**Root cause:** `GET /api/config` called `readConfigFile()`, which runs `interpolateEnvVars()` before returning. The UI received the interpolated config (real key values), and `POST /api/config` wrote those literal values back to disk.

## Fix

Added `readRawConfigFile()` in `packages/server/src/utils/index.ts` — reads and parses `config.json` via JSON5 without calling `interpolateEnvVars()`. The `GET /api/config` endpoint now uses this function instead of `readConfigFile()`.

The existing `readConfigFile()` → `initConfig()` runtime path is completely unchanged, so server startup behaviour is unaffected.

## Changes

- `packages/server/src/utils/index.ts` — add `readRawConfigFile()` (exported)
- `packages/server/src/server.ts` — `GET /api/config` uses `readRawConfigFile()`

## Testing

1. Set `api_key: "${MY_KEY}"` in `config.json`
2. Start `ccr start` and open `ccr ui`
3. Make any change in the UI and save
4. Verify `config.json` still contains `${MY_KEY}` (not the resolved value)