### PR TITLE
feat(anthropic): translate output_config/output_format to response_format

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -205,6 +205,39 @@ export class AnthropicTransformer implements Transformer {
         result.tool_choice = request.tool_choice.type;
       }
     }
+
+    // Structured outputs: translate Anthropic's `output_config.format` (GA, since
+    // 2025-11-14) and `output_format` (beta, with `anthropic-beta:
+    // structured-outputs-2025-11-13`) into OpenAI's `response_format` so that
+    // OpenAI-compatible providers can honor the schema.
+    // Refs:
+    //   - https://platform.claude.com/docs/en/build-with-claude/structured-outputs
+    //   - https://platform.openai.com/docs/guides/structured-outputs
+    const structuredFormat =
+      request.output_config?.format ?? request.output_format;
+    if (structuredFormat?.type) {
+      if (
+        structuredFormat.type === "json_schema" &&
+        structuredFormat.schema
+      ) {
+        result.response_format = {
+          type: "json_schema",
+          json_schema: {
+            name: structuredFormat.name || "response",
+            schema: structuredFormat.schema,
+            strict: structuredFormat.strict !== false,
+            ...(structuredFormat.description
+              ? { description: structuredFormat.description }
+              : {}),
+          },
+        };
+      } else if (structuredFormat.type === "json_object") {
+        result.response_format = { type: "json_object" };
+      } else if (structuredFormat.type === "text") {
+        result.response_format = { type: "text" };
+      }
+    }
+
     return result;
   }
 

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -107,6 +107,18 @@ export interface UnifiedChatRequest {
 
     enabled?: boolean;
   };
+  response_format?:
+    | { type: "text" }
+    | { type: "json_object" }
+    | {
+        type: "json_schema";
+        json_schema: {
+          name: string;
+          schema: Record<string, any>;
+          strict?: boolean;
+          description?: string;
+        };
+      };
 }
 
 // 统一的响应接口


### PR DESCRIPTION
## Summary

Anthropic's Messages API gained structured outputs in GA on 2025-11-14 via `output_config.format`, with an earlier beta path using `output_format` (behind `anthropic-beta: structured-outputs-2025-11-13`). The `AnthropicTransformer` previously dropped both fields silently, so any client using structured outputs against an OpenAI-compatible backend (GLM, DeepSeek, Groq, vLLM, etc.) would degrade to free-form text.

This PR translates both shapes into the unified `response_format` field, matching OpenAI's structured-outputs schema, so existing provider transformers can pass it through unchanged.

## Changes

- `packages/core/src/transformer/anthropic.transformer.ts` — translate `request.output_config?.format ?? request.output_format` into `result.response_format`. Supports `json_schema`, `json_object`, and `text` types. `strict` defaults to `true` to mirror Anthropic's guarantee semantics; client can opt out with `strict: false`.
- `packages/core/src/types/llm.ts` — add optional `response_format` union to `UnifiedChatRequest`.

## Test plan

- [x] Type-check (`tsc --noEmit`) introduces zero new errors over master
- [x] `pnpm build` passes
- [ ] Manual smoke test against an OpenAI-compatible backend:

```bash
curl -X POST http://localhost:3456/v1/messages   -H 'Content-Type: application/json'   -H 'x-api-key: ...'   -d '{
    "model": "your-model",
    "max_tokens": 1024,
    "messages": [{"role":"user","content":"List 3 EU capitals."}],
    "output_config": {
      "format": {
        "type": "json_schema",
        "schema": {
          "type": "object",
          "additionalProperties": false,
          "required": ["capitals"],
          "properties": {
            "capitals": {
              "type": "array",
              "items": {
                "type": "object",
                "additionalProperties": false,
                "required": ["country","capital"],
                "properties": {
                  "country": {"type":"string"},
                  "capital": {"type":"string"}
                }
              }
            }
          }
        }
      }
    }
  }'
```

Expected: `content[0].text` is a JSON string parseable into an object matching the schema.

## Refs

- https://platform.claude.com/docs/en/build-with-claude/structured-outputs
- https://platform.openai.com/docs/guides/structured-outputs