### PR TITLE
fix(deepseek): preserve reasoning replay across turns

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -161,12 +161,14 @@ export class AnthropicTransformer implements Transformer {
             }
 
             const thinkingPart = msg.content.find(
-              (c: any) => c.type === "thinking" && c.signature
+              (c: any) =>
+                c.type === "thinking" &&
+                (typeof c.thinking === "string" || typeof c.signature === "string")
             );
             if (thinkingPart) {
               assistantMessage.thinking = {
-                content: thinkingPart.thinking,
-                signature: thinkingPart.signature,
+                content: thinkingPart.thinking || "",
+                signature: thinkingPart.signature || "",
               };
             }
 

--- a/packages/core/src/transformer/deepseek.transformer.ts
+++ b/packages/core/src/transformer/deepseek.transformer.ts
@@ -8,6 +8,21 @@ export class DeepseekTransformer implements Transformer {
     if (request.max_tokens && request.max_tokens > 8192) {
       request.max_tokens = 8192; // DeepSeek has a max token limit of 8192
     }
+
+    // DeepSeek V4 thinking mode requires replaying prior reasoning_content
+    // on subsequent turns. Claude-style requests carry this in message.thinking.
+    if (Array.isArray((request as any).messages)) {
+      for (const msg of (request as any).messages) {
+        if (
+          msg?.role === "assistant" &&
+          msg?.thinking?.content &&
+          !msg?.reasoning_content
+        ) {
+          msg.reasoning_content = msg.thinking.content;
+        }
+      }
+    }
+
     return request;
   }
 


### PR DESCRIPTION
## Summary\n- replay assistant thinking content as `reasoning_content` for DeepSeek requests\n- accept Anthropic thinking blocks even when signature is missing\n\n## Why\nDeepSeek thinking mode may return `reasoning_content` requirements on follow-up turns. In some multi-turn/tool flows, missing replay fields can trigger 400 errors.\n\n## Changes\n- `packages/core/src/transformer/deepseek.transformer.ts`\n  - map assistant `thinking.content` -> `reasoning_content` before provider request\n- `packages/core/src/transformer/anthropic.transformer.ts`\n  - capture thinking blocks by content/signature (not signature-only)\n  - default missing signature/content to empty strings for stable conversion\n\n## Verification\n- local build passed for core/server/cli\n- manual multi-turn DeepSeek request tests no longer hit replay-related 400 in the exercised path