### PR TITLE
fix Bearer header conflict when transformer sets x-api-key

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -344,7 +344,7 @@ async function sendRequestToProvider(
       delete requestHeaders[key];
     } else if (
       ["authorization", "Authorization"].includes(key) &&
-      requestHeaders[key]?.includes("undefined")
+      (requestHeaders[key]?.includes("undefined") || requestHeaders["x-api-key"])
     ) {
       delete requestHeaders[key];
     }


### PR DESCRIPTION
## Problem

When a transformer returns `{ "x-api-key": apiKey }` in its `auth()` config, ccr still sends the default `Authorization: Bearer <apiKey>` on top. The provider receives both auth schemes and often rejects the request as "Invalid API key" (observed with Anthropic-compatible endpoints).

Reproduction with the built-in Anthropic transformer pointing at an Anthropic-compatible endpoint that accepts `x-api-key`:

```json
{
  "Providers": [{
    "name": "anthropic-like",
    "api_base_url": "https://api.example.com/v1/messages",
    "api_key": "sk-...",
    "models": ["claude-something"],
    "transformer": { "use": ["Anthropic"] }
  }]
}
```

Root cause: the existing filter only strips `authorization` headers whose value `.includes("undefined")`. The transformer sets `authorization: undefined` (JS value), which `JSON.stringify` later drops, but the default `Authorization: Bearer ...` survives untouched.

## Fix

When an `x-api-key` is present in the final request headers, also strip the `Authorization` / `authorization` entries.

## Compatibility

Configs that intentionally send both Bearer and `x-api-key` to the same provider (uncommon) would lose Bearer. No such pattern observed in the documented usage.