### PR TITLE
preserve output_config in Anthropic transformer

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -187,6 +187,7 @@ export class AnthropicTransformer implements Transformer {
         ? this.convertAnthropicToolsToUnified(request.tools)
         : undefined,
       tool_choice: request.tool_choice,
+      output_config: request.output_config,
     };
     if (request.thinking) {
       result.reasoning = {

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -107,6 +107,13 @@ export interface UnifiedChatRequest {
 
     enabled?: boolean;
   };
+  // Optional pass-through field used by some clients (e.g. Claude Code) to
+  // carry output configuration like effort level. Preserved so downstream
+  // transformers can map it to provider-specific parameters.
+  output_config?: {
+    effort?: string;
+    [key: string]: any;
+  };
 }
 
 // 统一的响应接口


### PR DESCRIPTION
## Problem

Claude Code sends an `output_config: { effort: <level> }` field in the request body alongside `thinking`, to signal the desired effort level (low/medium/high/xhigh/max). The `AnthropicTransformer.transformRequestOut` rebuilds a `UnifiedChatRequest` and copies only the known fields, discarding `output_config`.

Result: downstream transformers (provider-specific ones in `transformer.use[]`) cannot see the effort level and have no way to map it to provider-specific parameters like `reasoning_effort` (DeepSeek V4, Kimi K2, etc.).

## Fix

- Add an optional `output_config` field to `UnifiedChatRequest`.
- Copy `request.output_config` through in `transformRequestOut`.

The field is optional so existing requests without it are unaffected.

## Use case

A custom transformer chained after `Anthropic` can now read `request.output_config?.effort` and translate it to its provider's effort vocabulary (e.g. DeepSeek `reasoning_effort: low|medium|high|max`, Kimi `reasoning_effort: minimal|low|medium|high|xhigh|none`).