### PR TITLE
fix [name, options] syntax for transformers registered as instances

### DIFF
--- a/packages/core/src/services/provider.ts
+++ b/packages/core/src/services/provider.ts
@@ -45,9 +45,15 @@ export class ProviderService {
               if (Array.isArray(providerConfig.transformer.use)) {
                 transformer.use = providerConfig.transformer.use.map((transformer) => {
                   if (Array.isArray(transformer) && typeof transformer[0] === 'string') {
-                    const Constructor = this.transformerService.getTransformer(transformer[0]);
-                    if (Constructor) {
-                      return new (Constructor as TransformerConstructor)(transformer[1]);
+                    const resolved = this.transformerService.getTransformer(transformer[0]);
+                    if (typeof resolved === 'function') {
+                      return new (resolved as TransformerConstructor)(transformer[1]);
+                    }
+                    if (resolved) {
+                      // Transformer was registered as an already-built instance
+                      // (no `static TransformerName`). Re-instantiate via its
+                      // constructor so the requested options take effect.
+                      return new (resolved.constructor as TransformerConstructor)(transformer[1]);
                     }
                   }
                   if (typeof transformer === 'string') {
@@ -64,9 +70,12 @@ export class ProviderService {
                 transformer[key] = {
                   use: providerConfig.transformer[key].use.map((transformer) => {
                     if (Array.isArray(transformer) && typeof transformer[0] === 'string') {
-                      const Constructor = this.transformerService.getTransformer(transformer[0]);
-                      if (Constructor) {
-                        return new (Constructor as TransformerConstructor)(transformer[1]);
+                      const resolved = this.transformerService.getTransformer(transformer[0]);
+                      if (typeof resolved === 'function') {
+                        return new (resolved as TransformerConstructor)(transformer[1]);
+                      }
+                      if (resolved) {
+                        return new (resolved.constructor as TransformerConstructor)(transformer[1]);
                       }
                     }
                     if (typeof transformer === 'string') {


### PR DESCRIPTION
## Problem

The configuration syntax `"use": [["TransformerName", { ...options }]]` is documented for passing options to a transformer constructor, and the built-in `AnthropicTransformer` exposes a `UseBearer` option through its constructor:

```ts
constructor(private readonly options?: TransformerOptions) {
  this.useBearer = this.options?.UseBearer ?? false;
}
```

However, attempting to use it from config:

```json
{
  "transformer": { "use": [["Anthropic", { "UseBearer": true }]] }
}
```

logs:

```
<providerName> provider registered error: TypeError: o is not a constructor
```

and the provider silently fails to load.

## Root cause

In `ProviderService.initializeFromProvidersArray`, the array form is handled by:

```ts
const Constructor = this.transformerService.getTransformer(transformer[0]);
if (Constructor) {
  return new (Constructor as TransformerConstructor)(transformer[1]);
}
```

But `getTransformer` returns either a class or an already-built instance, depending on how the transformer was registered:

```ts
// in registerDefaultTransformersInternal()
if ("TransformerName" in e && typeof e.TransformerName === "string") {
  this.registerTransformer(e.TransformerName, e);   // class
} else {
  const t = new e();
  this.registerTransformer(t.name, t);              // instance
}
```

Built-in transformers without a `static TransformerName` (Anthropic, Gemini, OpenAI, Deepseek, etc.) are registered as instances, so `new instance(options)` throws.

The string-only form already handled both cases with a `typeof === 'function'` check; the array-with-options form did not.

## Fix

Check whether the resolved value is a class (function) or an instance:
- Class: instantiate as before.
- Instance: build a fresh instance via its `.constructor` so the requested options take effect without mutating the shared instance registered globally.

Applied to both `transformer.use` and model-specific `transformer[model].use`.

## Use case

```json
{
  "transformer": { "use": [["Anthropic", { "UseBearer": true }]] }
}
```

Now correctly switches the Anthropic transformer to send `Authorization: Bearer ...` instead of `x-api-key`, useful for Anthropic-compatible endpoints whose auth scheme differs from Anthropic's official endpoint.