### PR TITLE
feat: add fallback configuration support to Web UI

### DIFF
--- a/packages/ui/src/components/ConfigProvider.tsx
+++ b/packages/ui/src/components/ConfigProvider.tsx
@@ -1,7 +1,35 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import type { ReactNode, Dispatch, SetStateAction } from 'react';
 import { api } from '@/lib/api';
-import type { Config, StatusLineConfig } from '@/types';
+import type { Config, FallbackConfig, FallbackScenario, StatusLineConfig } from '@/types';
+
+const FALLBACK_SCENARIOS: FallbackScenario[] = [
+  'default',
+  'background',
+  'think',
+  'longContext',
+  'webSearch',
+];
+
+// Coerce arbitrary input from config.json into a strict FallbackConfig: keep
+// only known scenarios, only string entries, and drop empty/invalid shapes
+// instead of forwarding garbage values to the backend.
+function sanitizeFallback(raw: unknown): FallbackConfig | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+  const out: FallbackConfig = {};
+  for (const scenario of FALLBACK_SCENARIOS) {
+    const list = (raw as Record<string, unknown>)[scenario];
+    if (Array.isArray(list)) {
+      const cleaned = list.filter((v): v is string => typeof v === 'string' && v.length > 0);
+      if (cleaned.length > 0) {
+        out[scenario] = cleaned;
+      }
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
 
 interface ConfigContextType {
   config: Config | null;
@@ -65,9 +93,12 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
       try {
         // Try to fetch config regardless of API key presence
         const data = await api.getConfig();
-        
-        // Validate the received data to ensure it has the expected structure
-        const validConfig = {
+
+        // Spread the raw config first so unknown keys (e.g. fallback, or any
+        // future backend additions) are preserved on save round-trips, then
+        // overlay UI-known fields with validated defaults.
+        const validConfig: Config = {
+          ...(data as Record<string, any>),
           LOG: typeof data.LOG === 'boolean' ? data.LOG : false,
           LOG_LEVEL: typeof data.LOG_LEVEL === 'string' ? data.LOG_LEVEL : 'debug',
           CLAUDE_PATH: typeof data.CLAUDE_PATH === 'string' ? data.CLAUDE_PATH : '',
@@ -83,7 +114,7 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
             currentStyle: typeof data.StatusLine.currentStyle === 'string' ? data.StatusLine.currentStyle : 'default',
             default: data.StatusLine.default && typeof data.StatusLine.default === 'object' && Array.isArray(data.StatusLine.default.modules) ? data.StatusLine.default : { modules: [] },
             powerline: data.StatusLine.powerline && typeof data.StatusLine.powerline === 'object' && Array.isArray(data.StatusLine.powerline.modules) ? data.StatusLine.powerline : { modules: [] }
-          } : { 
+          } : {
             enabled: false,
             currentStyle: 'default',
             default: { modules: [] },
@@ -106,9 +137,10 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
             webSearch: '',
             image: ''
           },
+          fallback: sanitizeFallback((data as Record<string, any>).fallback),
           CUSTOM_ROUTER_PATH: typeof data.CUSTOM_ROUTER_PATH === 'string' ? data.CUSTOM_ROUTER_PATH : ''
         };
-        
+
         setConfig(validConfig);
       } catch (err) {
         console.error('Failed to fetch config:', err);

--- a/packages/ui/src/components/Router.tsx
+++ b/packages/ui/src/components/Router.tsx
@@ -4,6 +4,16 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { useConfig } from "./ConfigProvider";
 import { Combobox } from "./ui/combobox";
+import { MultiCombobox } from "./ui/multi-combobox";
+import type { FallbackConfig, FallbackScenario } from "@/types";
+
+const FALLBACK_SCENARIOS: FallbackScenario[] = [
+  "default",
+  "background",
+  "think",
+  "longContext",
+  "webSearch",
+];
 
 export function Router() {
   const { t } = useTranslation();
@@ -43,6 +53,20 @@ export function Router() {
 
   const handleForceUseImageAgentChange = (value: boolean) => {
     setConfig({ ...config, forceUseImageAgent: value });
+  };
+
+  const fallbackConfig: FallbackConfig = config.fallback || {};
+
+  const handleFallbackChange = (scenario: FallbackScenario, models: string[]) => {
+    const nextFallback: FallbackConfig = { ...fallbackConfig };
+    if (models.length > 0) {
+      nextFallback[scenario] = models;
+    } else {
+      // Drop empty arrays so we don't write noise back to config.json.
+      delete nextFallback[scenario];
+    }
+    const hasAny = Object.keys(nextFallback).length > 0;
+    setConfig({ ...config, fallback: hasAny ? nextFallback : undefined });
   };
 
   // Handle case where config.Providers might be null or undefined
@@ -164,6 +188,30 @@ export function Router() {
               </select>
             </div>
           </div>
+        </div>
+        <div className="space-y-3 border-t pt-4">
+          <div>
+            <Label className="text-base">{t("router.fallback.title")}</Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t("router.fallback.description")}
+            </p>
+          </div>
+          {FALLBACK_SCENARIOS.map((scenario) => (
+            <div key={scenario} className="space-y-1">
+              <Label className="text-sm">
+                {t(`router.${scenario}`)}
+              </Label>
+              <MultiCombobox
+                options={modelOptions}
+                value={fallbackConfig[scenario] || []}
+                onChange={(value) => handleFallbackChange(scenario, value)}
+                placeholder={t("router.fallback.selectModels")}
+                searchPlaceholder={t("router.searchModel")}
+                emptyPlaceholder={t("router.noModelFound")}
+                reorderable
+              />
+            </div>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/packages/ui/src/components/ui/multi-combobox.tsx
+++ b/packages/ui/src/components/ui/multi-combobox.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Check, ChevronsUpDown, X } from "lucide-react"
+import { Check, ChevronsUpDown, GripVertical, X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -27,6 +27,10 @@ interface MultiComboboxProps {
   placeholder?: string;
   searchPlaceholder?: string;
   emptyPlaceholder?: string;
+  // When true, selected badges can be reordered via drag-and-drop. The new
+  // ordering is passed to onChange. Useful when order is semantically meaningful
+  // (e.g. fallback model priority lists).
+  reorderable?: boolean;
 }
 
 export function MultiCombobox({
@@ -36,9 +40,12 @@ export function MultiCombobox({
   placeholder = "Select options...",
   searchPlaceholder = "Search...",
   emptyPlaceholder = "No options found.",
+  reorderable = false,
 }: MultiComboboxProps) {
   const [open, setOpen] = React.useState(false)
-  
+  const [dragIndex, setDragIndex] = React.useState<number | null>(null)
+  const [overIndex, setOverIndex] = React.useState<number | null>(null)
+
   const handleSelect = (currentValue: string) => {
     if (value.includes(currentValue)) {
       onChange(value.filter(v => v !== currentValue))
@@ -46,27 +53,85 @@ export function MultiCombobox({
       onChange([...value, currentValue])
     }
   }
-  
+
   const removeValue = (val: string, e: React.MouseEvent) => {
     e.stopPropagation()
     onChange(value.filter(v => v !== val))
   }
 
+  const handleDragStart = (index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    setDragIndex(index)
+    e.dataTransfer.effectAllowed = "move"
+    // Firefox requires data to be set for drag to initiate.
+    e.dataTransfer.setData("text/plain", String(index))
+  }
+
+  const handleDragOver = (index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    if (dragIndex === null) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = "move"
+    if (overIndex !== index) {
+      setOverIndex(index)
+    }
+  }
+
+  const handleDrop = (index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    if (dragIndex === null || dragIndex === index) {
+      setDragIndex(null)
+      setOverIndex(null)
+      return
+    }
+    const next = [...value]
+    const [moved] = next.splice(dragIndex, 1)
+    next.splice(index, 0, moved)
+    setDragIndex(null)
+    setOverIndex(null)
+    onChange(next)
+  }
+
+  const handleDragEnd = () => {
+    setDragIndex(null)
+    setOverIndex(null)
+  }
+
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap gap-1">
-        {value.map((val) => {
+        {value.map((val, index) => {
           const option = options.find(opt => opt.value === val)
+          const isDragging = reorderable && dragIndex === index
+          const isOver = reorderable && overIndex === index && dragIndex !== null && dragIndex !== index
           return (
-            <Badge key={val} variant="outline" className="font-normal">
-              {option?.label || val}
-              <button
-                onClick={(e) => removeValue(val, e)}
-                className="ml-1 rounded-full hover:bg-gray-200"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </Badge>
+            <div
+              key={val}
+              draggable={reorderable}
+              onDragStart={reorderable ? handleDragStart(index) : undefined}
+              onDragOver={reorderable ? handleDragOver(index) : undefined}
+              onDrop={reorderable ? handleDrop(index) : undefined}
+              onDragEnd={reorderable ? handleDragEnd : undefined}
+              className={cn(
+                "transition-opacity",
+                isDragging && "opacity-50",
+                isOver && "ring-2 ring-primary rounded-md",
+              )}
+            >
+              <Badge variant="outline" className="font-normal">
+                {reorderable && (
+                  <GripVertical
+                    className="mr-1 h-3 w-3 cursor-grab text-muted-foreground active:cursor-grabbing"
+                    aria-hidden
+                  />
+                )}
+                {option?.label || val}
+                <button
+                  onClick={(e) => removeValue(val, e)}
+                  className="ml-1 rounded-full hover:bg-gray-200"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            </div>
           )
         })}
       </div>

--- a/packages/ui/src/locales/en.json
+++ b/packages/ui/src/locales/en.json
@@ -120,7 +120,12 @@
     "forceUseImageAgent": "Force Use Image Agent",
     "selectModel": "Select a model...",
     "searchModel": "Search model...",
-    "noModelFound": "No model found."
+    "noModelFound": "No model found.",
+    "fallback": {
+      "title": "Fallback Models",
+      "description": "If the primary model for a scenario fails, the listed backup models are tried in order until one responds successfully. Drag a chip to reorder.",
+      "selectModels": "Select fallback models..."
+    }
   },
   "json_editor": {
     "title": "JSON Editor",

--- a/packages/ui/src/locales/zh.json
+++ b/packages/ui/src/locales/zh.json
@@ -120,7 +120,12 @@
     "forceUseImageAgent": "强制使用图像代理",
     "selectModel": "选择一个模型...",
     "searchModel": "搜索模型...",
-    "noModelFound": "未找到模型."
+    "noModelFound": "未找到模型.",
+    "fallback": {
+      "title": "兜底模型",
+      "description": "当某个场景的主模型请求失败时，按顺序依次尝试下方备用模型，直到有模型成功响应。可拖动模型标签调整顺序。",
+      "selectModels": "选择兜底模型..."
+    }
   },
   "json_editor": {
     "title": "JSON 编辑器",

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -22,6 +22,17 @@ export interface RouterConfig {
     custom?: any;
 }
 
+export type FallbackScenario =
+  | 'default'
+  | 'background'
+  | 'think'
+  | 'longContext'
+  | 'webSearch';
+
+export type FallbackConfig = {
+  [K in FallbackScenario]?: string[];
+};
+
 export interface Transformer {
     name?: string;
     path: string;
@@ -55,6 +66,9 @@ export interface Config {
   transformers: Transformer[];
   StatusLine?: StatusLineConfig;
   forceUseImageAgent?: boolean;
+  // Per-scenario fallback model lists, applied when the primary model fails.
+  // Each entry is a "provider,model" string, tried in order until one succeeds.
+  fallback?: FallbackConfig;
   // Top-level settings
   LOG: boolean;
   LOG_LEVEL: string;


### PR DESCRIPTION
Expose per-scenario fallback model lists (default/background/think/longContext/webSearch) in the Router settings. Selected models can be drag-reordered to control retry order. Preserve unknown top-level config keys on save so previously hand-written fallback configuration is no longer stripped when saving from the UI.