### PR TITLE
 fix: preserve reasoning_content for assistant thinking history in OpenAI-compatible requests

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -168,6 +168,7 @@ export class AnthropicTransformer implements Transformer {
                 content: thinkingPart.thinking,
                 signature: thinkingPart.signature,
               };
+              assistantMessage.reasoning_content = thinkingPart.thinking;
             }
 
             messages.push(assistantMessage);

--- a/packages/core/src/transformer/reasoning.transformer.ts
+++ b/packages/core/src/transformer/reasoning.transformer.ts
@@ -12,6 +12,16 @@ export class ReasoningTransformer implements Transformer {
   async transformRequestIn(
     request: UnifiedChatRequest
   ): Promise<UnifiedChatRequest> {
+    request.messages.forEach((message) => {
+      if (
+        message.role === "assistant" &&
+        message.thinking?.content &&
+        !message.reasoning_content
+      ) {
+        message.reasoning_content = message.thinking.content;
+      }
+    });
+
     if (!this.enable) {
       request.thinking = {
         type: "disabled",

--- a/packages/core/src/types/llm.ts
+++ b/packages/core/src/types/llm.ts
@@ -48,6 +48,7 @@ export type MessageContent = TextContent | ImageContent;
 export interface UnifiedMessage {
   role: "user" | "assistant" | "system" | "tool";
   content: string | null | MessageContent[];
+  reasoning_content?: string;
   tool_calls?: Array<{
     id: string;
     type: "function";


### PR DESCRIPTION
#1400
## Summary

This PR fixes a reasoning-history compatibility issue for OpenAI-compatible providers such as Kimi.

CCR already preserves Claude/Anthropic thinking blocks internally as `thinking`, but in multi-turn tool-call flows that reasoning history was not always carried back into `reasoning_content` on assistant messages before sending the final upstream request.

Some providers are strict about this. For example, Kimi may reject the request with an error like:

thinking is enabled but reasoning_content is missing in assistant tool call message
What changed
1. Extend unified message structure
Added reasoning_content?: string to the unified message type so reasoning history can be preserved explicitly in the internal message model.

2. Preserve reasoning content during Anthropic -> unified conversion
When converting Anthropic/Claude assistant messages that contain thinking blocks, the extracted thinking content is now also stored in reasoning_content.

3. Add request-side fallback in the reasoning transformer
Before sending a request upstream, the reasoning transformer now checks assistant history messages and fills reasoning_content from thinking.content when it is missing.

This makes the behavior more robust even if earlier stages only preserved thinking.

Why this is needed
CCR already handles:

enabling/disabling reasoning mode on requests
converting provider reasoning_content back into CCR thinking on responses
But assistant reasoning history was not reliably restored into the OpenAI-compatible request format.

This becomes visible in providers that validate reasoning history for assistant tool-call messages.

Scope
This is not a Kimi-specific code path.

The fix is implemented in the shared message conversion / reasoning flow so that any OpenAI-compatible provider expecting reasoning_content can benefit.

Files changed
packages/core/src/types/llm.ts
packages/core/src/transformer/anthropic.transformer.ts
packages/core/src/transformer/reasoning.transformer.ts
Testing
Tested locally with Kimi reasoning mode in a tool-call flow.

Before this change:

follow-up requests could fail with missing reasoning_content on assistant tool-call history
After this change:

the same flow completes successfully
Notes
This change may slightly increase request payload size because preserved reasoning history can now exist in both thinking and reasoning_content forms internally / during request transformation.

However, this is intentional and improves compatibility with strict reasoning-capable providers.