### PR TITLE
fix: support Kimi web search routing via provider-specific transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Transformers allow you to modify the request and response payloads to ensure com
 - `Anthropic`:If you use only the `Anthropic` transformer, it will preserve the original request and response parameters(you can use it to connect directly to an Anthropic endpoint).
 - `deepseek`: Adapts requests/responses for DeepSeek API.
 - `gemini`: Adapts requests/responses for Gemini API.
+- `kimi`: Adapts Moonshot Kimi web search by mapping Claude Code's `web_search` tool to Kimi's builtin `$web_search` flow.
 - `openrouter`: Adapts requests/responses for OpenRouter API. It can also accept a `provider` routing parameter to specify which underlying providers OpenRouter should use. For more details, refer to the [OpenRouter documentation](https://openrouter.ai/docs/features/provider-routing). See an example below:
   ```json
     "transformer": {
@@ -447,6 +448,7 @@ The `Router` object defines which model to use for different scenarios:
 - `longContext`: A model for handling long contexts (e.g., > 60K tokens).
 - `longContextThreshold` (optional): The token count threshold for triggering the long context model. Defaults to 60000 if not specified.
 - `webSearch`: Used for handling web search tasks and this requires the model itself to support the feature. If you're using openrouter, you need to add the `:online` suffix after the model name.
+- If you're using Moonshot Kimi directly for `webSearch`, configure the provider with `"transformer": { "use": ["kimi"] }`.
 - `image` (beta): Used for handling image-related tasks (supported by CCR’s built-in agent). If the model does not support tool calling, you need to set the `config.forceUseImageAgent` property to `true`.
 
 - You can also switch models dynamically in Claude Code with the `/model` command:

--- a/README_zh.md
+++ b/README_zh.md
@@ -362,6 +362,7 @@ Transformers 允许您修改请求和响应负载，以确保与不同提供商 
 -   `Anthropic`: 如果你只使用这一个转换器，则会直接透传请求和响应(你可以用它来接入其他支持Anthropic端点的服务商)。
 -   `deepseek`: 适配 DeepSeek API 的请求/响应。
 -   `gemini`: 适配 Gemini API 的请求/响应。
+-   `kimi`: 适配 Moonshot Kimi 的联网搜索，将 Claude Code 的 `web_search` 工具映射到 Kimi 的内置 `$web_search` 流程。
 -   `openrouter`: 适配 OpenRouter API 的请求/响应。它还可以接受一个 `provider` 路由参数，以指定 OpenRouter 应使用哪些底层提供商。有关更多详细信息，请参阅 [OpenRouter 文档](https://openrouter.ai/docs/features/provider-routing)。请参阅下面的示例：
     ```json
       "transformer": {
@@ -419,6 +420,7 @@ Transformers 允许您修改请求和响应负载，以确保与不同提供商 
 -   `longContext`: 用于处理长上下文（例如，> 60K 令牌）的模型。
 -   `longContextThreshold` (可选): 触发长上下文模型的令牌数阈值。如果未指定，默认为 60000。
 -   `webSearch`: 用于处理网络搜索任务，需要模型本身支持。如果使用`openrouter`需要在模型后面加上`:online`后缀。
+-   如果直接使用 Moonshot Kimi 作为 `webSearch`，请给该 provider 配置 `"transformer": { "use": ["kimi"] }`。
 -   `image`(测试版): 用于处理图片类任务（采用CCR内置的agent支持），如果该模型不支持工具调用，需要将`config.forceUseImageAgent`属性设置为`true`。
 
 您还可以使用 `/model` 命令在 Claude Code 中动态切换模型：

--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -350,6 +350,35 @@ async function sendRequestToProvider(
     }
   }
 
+  const applicableTransformers: Transformer[] = [];
+  if (!bypass && provider.transformer?.use?.length) {
+    applicableTransformers.push(...provider.transformer.use);
+  }
+  if (!bypass && provider.transformer?.[requestBody.model]?.use?.length) {
+    applicableTransformers.push(...provider.transformer[requestBody.model].use);
+  }
+
+  const customRequestTransformer = [...applicableTransformers]
+    .reverse()
+    .find(
+      (providerTransformer) =>
+        providerTransformer
+        && typeof providerTransformer.sendRequest === "function"
+    );
+
+  if (customRequestTransformer?.sendRequest) {
+    return customRequestTransformer.sendRequest(
+      requestBody,
+      provider,
+      {
+        httpsProxy: fastify.configService.getHttpsProxy(),
+        ...config,
+        headers: JSON.parse(JSON.stringify(requestHeaders)),
+      },
+      context,
+    );
+  }
+
   const response = await sendUnifiedRequest(
     url,
     requestBody,

--- a/packages/core/src/transformer/index.ts
+++ b/packages/core/src/transformer/index.ts
@@ -19,6 +19,7 @@ import { CustomParamsTransformer } from "./customparams.transformer";
 import { VercelTransformer } from "./vercel.transformer";
 import { OpenAIResponsesTransformer } from "./openai.responses.transformer";
 import { ForceReasoningTransformer } from "./forcereasoning.transformer"
+import { KimiTransformer } from "./kimi.transformer";
 
 export default {
   AnthropicTransformer,
@@ -41,5 +42,6 @@ export default {
   CustomParamsTransformer,
   VercelTransformer,
   OpenAIResponsesTransformer,
-  ForceReasoningTransformer
+  ForceReasoningTransformer,
+  KimiTransformer
 };

--- a/packages/core/src/transformer/kimi.transformer.ts
+++ b/packages/core/src/transformer/kimi.transformer.ts
@@ -1,0 +1,190 @@
+import { LLMProvider, UnifiedChatRequest } from "@/types/llm";
+import { Transformer, TransformerContext } from "@/types/transformer";
+import { sendUnifiedRequest } from "@/utils/request";
+
+function buildStreamResponse(payload: any): Response {
+  const encoder = new TextEncoder();
+  const message = payload?.choices?.[0]?.message || {};
+  const content = message.content || "";
+  const id = payload?.id || `chatcmpl_${Date.now()}`;
+  const model = payload?.model || "";
+  const created = payload?.created || Math.floor(Date.now() / 1000);
+
+  const chunks = [
+    {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [
+        {
+          index: 0,
+          delta: { role: "assistant" },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [
+        {
+          index: 0,
+          delta: { content },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: "stop",
+        },
+      ],
+    },
+  ];
+
+  const stream = new ReadableStream({
+    start(controller) {
+      chunks.forEach((chunk) => {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      });
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+export class KimiTransformer implements Transformer {
+  name = "kimi";
+
+  async transformRequestIn(request: UnifiedChatRequest): Promise<Record<string, any>> {
+    const hasWebSearch = Array.isArray(request.tools)
+      && request.tools.some((tool) => tool.function?.name === "web_search");
+
+    if (!hasWebSearch) {
+      return request;
+    }
+
+    const nextRequest: any = { ...request };
+    const normalTools = (request.tools || []).filter(
+      (tool) => tool.function?.name !== "web_search"
+    );
+
+    nextRequest.tools = [
+      ...normalTools,
+      {
+        type: "builtin_function",
+        function: {
+          name: "$web_search",
+        },
+      },
+    ];
+
+    nextRequest.thinking = { type: "disabled" };
+    nextRequest.enable_thinking = false;
+    nextRequest.__kimi_web_search = true;
+
+    return nextRequest;
+  }
+
+  async sendRequest(
+    request: Record<string, any>,
+    provider: LLMProvider,
+    config: Record<string, any>,
+    context: TransformerContext,
+  ): Promise<Response> {
+    const rawRequest: any = { ...request };
+    const useWebSearch = rawRequest.__kimi_web_search === true;
+    delete rawRequest.__kimi_web_search;
+
+    if (!useWebSearch) {
+      return sendUnifiedRequest(
+        new URL(provider.baseUrl),
+        rawRequest as UnifiedChatRequest,
+        config,
+        context,
+        this.logger,
+      );
+    }
+
+    const wantsStream = rawRequest.stream === true;
+    const firstRequest: any = { ...rawRequest, stream: false };
+
+    const firstResponse = await sendUnifiedRequest(
+      new URL(provider.baseUrl),
+      firstRequest as UnifiedChatRequest,
+      config,
+      context,
+      this.logger,
+    );
+
+    if (!firstResponse.ok) {
+      return firstResponse;
+    }
+
+    const firstJson = await firstResponse.json();
+    const firstChoice = firstJson?.choices?.[0];
+    const toolCalls = firstChoice?.message?.tool_calls || [];
+    const hasBuiltinSearchCalls = toolCalls.some(
+      (toolCall: any) => toolCall?.function?.name === "$web_search"
+    );
+
+    if (!hasBuiltinSearchCalls) {
+      return wantsStream
+        ? buildStreamResponse(firstJson)
+        : new Response(JSON.stringify(firstJson), {
+            status: firstResponse.status,
+            statusText: firstResponse.statusText,
+            headers: { "Content-Type": "application/json" },
+          });
+    }
+
+    const secondRequest: any = {
+      ...firstRequest,
+      messages: [
+        ...(firstRequest.messages || []),
+        firstChoice.message,
+        ...toolCalls.map((toolCall: any) => ({
+          role: "tool",
+          tool_call_id: toolCall.id,
+          content: toolCall.function.arguments,
+        })),
+      ],
+    };
+
+    const secondResponse = await sendUnifiedRequest(
+      new URL(provider.baseUrl),
+      secondRequest as UnifiedChatRequest,
+      config,
+      context,
+      this.logger,
+    );
+
+    if (!secondResponse.ok) {
+      return secondResponse;
+    }
+
+    const secondJson = await secondResponse.json();
+
+    return wantsStream
+      ? buildStreamResponse(secondJson)
+      : new Response(JSON.stringify(secondJson), {
+          status: secondResponse.status,
+          statusText: secondResponse.statusText,
+          headers: { "Content-Type": "application/json" },
+        });
+  }
+}

--- a/packages/core/src/types/transformer.ts
+++ b/packages/core/src/types/transformer.ts
@@ -27,6 +27,12 @@ export type Transformer = {
     provider: LLMProvider,
     context: TransformerContext,
   ) => Promise<Record<string, any>>;
+  sendRequest?: (
+    request: Record<string, any>,
+    provider: LLMProvider,
+    config: Record<string, any>,
+    context: TransformerContext,
+  ) => Promise<Response>;
   transformResponseIn?: (response: Response, context?: TransformerContext) => Promise<Response>;
 
   // 将请求格式转换为通用的格式

--- a/packages/ui/config.example.json
+++ b/packages/ui/config.example.json
@@ -38,7 +38,12 @@
       "api_key": "sk-",
       "models": [
         "kimi-k2-0711-preview"
-      ]
+      ],
+      "transformer": {
+        "use": [
+          "kimi"
+        ]
+      }
     },
     {
       "name": "groq",


### PR DESCRIPTION
## Summary

This PR fixes Kimi web search routing in Claude Code Router.

Previously, when `Router.webSearch` was configured to use a Moonshot Kimi model, requests were routed to Kimi correctly, but web search still returned empty or ineffective results because the request format did not match Kimi's required web search protocol.

## Problem

Claude Code Router detects web search requests correctly and switches to `Router.webSearch`, but Kimi web search is not OpenAI-compatible at the tool protocol level.

Claude Code sends a `web_search` tool request, while Moonshot Kimi expects:

- `tools: [{ "type": "builtin_function", "function": { "name": "$web_search" } }]`
- `thinking: { "type": "disabled" }`

In addition, Kimi web search requires a two-step tool roundtrip:
1. the first response returns a `$web_search` tool call
2. the client must feed the tool call result back as a `tool` message
3. the second request returns the final answer

Without this adaptation, routing succeeds but actual web search does not work.

## Changes

### 1. Add a Kimi-specific transformer

Introduced a new built-in `kimi` transformer that:

- maps Claude Code's `web_search` tool to Kimi's builtin `$web_search`
- disables thinking for Kimi web search requests
- only applies this logic when a `web_search` tool is present
- leaves normal Kimi requests unchanged

### 2. Add an optional transformer-level request hook

Extended the transformer interface with an optional `sendRequest` method.

This allows provider-specific transformers to take over request execution when needed, while remaining fully backward-compatible for all existing transformers.

### 3. Implement Kimi web search roundtrip handling

The `kimi` transformer uses the new request hook to execute Kimi's required two-step web search flow automatically:

- first request triggers `$web_search`
- tool call arguments are fed back as a `tool` message
- second request returns the final answer

### 4. Update example config and docs

- registered the new `kimi` transformer
- updated `config.example.json` to show how to enable it for a Kimi provider
- updated English and Chinese README documentation

## Compatibility

This change is intended to be backward-compatible.

- providers other than Kimi are unaffected
- Kimi providers without `"transformer": { "use": ["kimi"] }` keep their current behavior
- the new `sendRequest` hook is optional and does not change existing transformer behavior
- Kimi-specific logic is only activated for requests that actually use `web_search`

## Testing

Tested locally with a Kimi provider configured as the `webSearch` route.

Verified that:

- web search requests are routed to Kimi
- Kimi web search returns non-empty results
- normal requests remain unaffected
- core package build succeeds

## Example config

```json
{
  "name": "kimi",
  "api_base_url": "https://api.moonshot.cn/v1/chat/completions",
  "api_key": "sk-***",
  "models": ["kimi-k2.5"],
  "transformer": {
    "use": ["kimi"]
  }
}