### PR TITLE
Fix OpenAI Responses tool args and context-limit errors

### DIFF
--- a/packages/cli/src/utils/codeCommand.ts
+++ b/packages/cli/src/utils/codeCommand.ts
@@ -59,15 +59,17 @@ export async function executeCodeCommand(
     }
   }
 
-  // Merge claudeCodeSettings from preset into settingsFlag
-  if (presetConfig?.claudeCodeSettings) {
+  const claudeCodeSettings = presetConfig?.claudeCodeSettings || config?.claudeCodeSettings;
+
+  // Merge claudeCodeSettings from preset/global config into settingsFlag
+  if (claudeCodeSettings) {
     settingsFlag = {
       ...settingsFlag,
-      ...presetConfig.claudeCodeSettings,
+      ...claudeCodeSettings,
       // Deep merge env
       env: {
         ...settingsFlag.env,
-        ...presetConfig.claudeCodeSettings.env,
+        ...claudeCodeSettings.env,
       } as ClaudeSettingsFlag['env']
     };
   }

--- a/packages/core/scripts/openaiResponsesTransformer.test.ts
+++ b/packages/core/scripts/openaiResponsesTransformer.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { OpenAIResponsesTransformer } from "../src/transformer/openai.responses.transformer";
+
+const readStream = async (stream: ReadableStream<Uint8Array>) => {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  output += decoder.decode();
+  return output;
+};
+
+const parseSseData = (output: string) =>
+  output
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice("data: ".length).trim())
+    .filter((line) => line && line !== "[DONE]")
+    .map((line) => JSON.parse(line));
+
+describe("OpenAIResponsesTransformer", () => {
+  it("preserves streaming usage from response.completed", async () => {
+    const upstream = [
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_123",
+          model: "gpt-5.5",
+          output: [{ type: "message" }],
+          usage: {
+            input_tokens: 12345,
+            output_tokens: 67,
+            total_tokens: 12412,
+          },
+        },
+      },
+    ]
+      .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+      .join("");
+
+    const response = new Response(upstream, {
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+    const transformed =
+      await new OpenAIResponsesTransformer().transformResponseOut(response);
+    assert.ok(transformed.body);
+
+    const chunks = parseSseData(await readStream(transformed.body));
+    const doneChunk = chunks.find(
+      (chunk) => chunk.choices?.[0]?.finish_reason === "stop"
+    );
+
+    assert.deepEqual(doneChunk?.usage, {
+      prompt_tokens: 12345,
+      completion_tokens: 67,
+      total_tokens: 12412,
+    });
+  });
+});

--- a/packages/core/scripts/providerError.test.ts
+++ b/packages/core/scripts/providerError.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classifyProviderError } from "../src/api/providerError";
+
+describe("classifyProviderError", () => {
+  it("maps upstream context-window errors to a non-retryable 413", () => {
+    const error = classifyProviderError(
+      "openai-responses",
+      "gpt-5.5",
+      502,
+      JSON.stringify({
+        error: {
+          message:
+            "Your input exceeds the context window of this model. Please adjust your input and try again.",
+          type: "upstream_error",
+        },
+      })
+    );
+
+    assert.equal(error.statusCode, 413);
+    assert.equal(error.code, "context_length_exceeded");
+    assert.match(error.message, /Reduce the conversation\/tool context/);
+    assert.match(error.message, /Router\.longContext/);
+  });
+
+  it("preserves ordinary provider failures", () => {
+    const error = classifyProviderError(
+      "openai-responses",
+      "gpt-5.5",
+      502,
+      "bad gateway"
+    );
+
+    assert.equal(error.statusCode, 502);
+    assert.equal(error.code, "provider_response_error");
+    assert.match(error.message, /Error from provider/);
+  });
+});

--- a/packages/core/src/api/providerError.ts
+++ b/packages/core/src/api/providerError.ts
@@ -1,0 +1,62 @@
+export interface ProviderErrorClassification {
+  message: string;
+  statusCode: number;
+  code: string;
+}
+
+const CONTEXT_LIMIT_PATTERNS = [
+  /context window/i,
+  /context length/i,
+  /context_length_exceeded/i,
+  /maximum context/i,
+  /maximum.*tokens/i,
+  /token limit/i,
+  /too many tokens/i,
+  /input exceeds.*context/i,
+  /prompt is too long/i,
+];
+
+function parseProviderErrorMessage(errorText: string): string {
+  try {
+    const parsed = JSON.parse(errorText);
+    if (typeof parsed?.error?.message === "string") {
+      return parsed.error.message;
+    }
+    if (typeof parsed?.message === "string") {
+      return parsed.message;
+    }
+  } catch {
+    // Fall through to the raw provider body.
+  }
+
+  return errorText;
+}
+
+export function classifyProviderError(
+  providerName: string,
+  modelName: string,
+  upstreamStatus: number,
+  errorText: string
+): ProviderErrorClassification {
+  const providerMessage = parseProviderErrorMessage(errorText);
+  const isContextLimitError = CONTEXT_LIMIT_PATTERNS.some((pattern) =>
+    pattern.test(providerMessage)
+  );
+
+  if (isContextLimitError) {
+    return {
+      message:
+        `Request exceeds the context window for provider(${providerName},${modelName}). ` +
+        `Reduce the conversation/tool context or configure Router.longContext to use a larger-context model. ` +
+        `Provider response(${upstreamStatus}): ${errorText}`,
+      statusCode: 413,
+      code: "context_length_exceeded",
+    };
+  }
+
+  return {
+    message: `Error from provider(${providerName},${modelName}: ${upstreamStatus}): ${errorText}`,
+    statusCode: upstreamStatus,
+    code: "provider_response_error",
+  };
+}

--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -7,6 +7,7 @@ import {
 import { RegisterProviderRequest, LLMProvider } from "@/types/llm";
 import { sendUnifiedRequest } from "@/utils/request";
 import { createApiError } from "./middleware";
+import { classifyProviderError } from "./providerError";
 import { version } from "../../package.json";
 import { ConfigService } from "@/services/config";
 import { ProviderService } from "@/services/provider";
@@ -91,7 +92,7 @@ async function handleTransformerEndpoint(
     return formatResponse(finalResponse, reply, body);
   } catch (error: any) {
     // Handle fallback if error occurs
-    if (error.code === 'provider_response_error') {
+    if (error.code === 'provider_response_error' || error.code === 'context_length_exceeded') {
       const fallbackResult = await handleFallback(req, reply, fastify, transformer, error);
       if (fallbackResult) {
         return fallbackResult;
@@ -365,13 +366,17 @@ async function sendRequestToProvider(
   // Handle request errors
   if (!response.ok) {
     const errorText = await response.text();
-    fastify.log.error(
-      `[provider_response_error] Error from provider(${provider.name},${requestBody.model}: ${response.status}): ${errorText}`,
-    );
-    throw createApiError(
-      `Error from provider(${provider.name},${requestBody.model}: ${response.status}): ${errorText}`,
+    const providerError = classifyProviderError(
+      provider.name,
+      requestBody.model,
       response.status,
-      "provider_response_error"
+      errorText
+    );
+    fastify.log.error(`[${providerError.code}] ${providerError.message}`);
+    throw createApiError(
+      providerError.message,
+      providerError.statusCode,
+      providerError.code
     );
   }
 

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -966,7 +966,7 @@ export class AnthropicTransformer implements Transformer {
         throw new Error("No choices found in OpenAI response");
       }
       const content: any[] = [];
-      if (choice.message.annotations) {
+      if (choice.message.annotations?.length) {
         const id = `srvtoolu_${uuidv4()}`;
         content.push({
           type: "server_tool_use",

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -61,6 +61,11 @@ interface ResponsesStreamEvent {
     output?: Array<{
       type: string;
     }>;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+    };
   };
   arguments?: string;
   reasoning_summary?: string; // 添加推理摘要支持
@@ -550,6 +555,16 @@ export class OpenAIResponsesTransformer implements Transformer {
                               finish_reason: finishReason,
                             },
                           ],
+                          usage: data.response?.usage
+                            ? {
+                                prompt_tokens:
+                                  data.response.usage.input_tokens || 0,
+                                completion_tokens:
+                                  data.response.usage.output_tokens || 0,
+                                total_tokens:
+                                  data.response.usage.total_tokens || 0,
+                              }
+                            : undefined,
                         };
 
                         controller.enqueue(

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -46,6 +46,7 @@ interface ResponsesStreamEvent {
     type?: string;
     call_id?: string;
     name?: string;
+    arguments?: string;
     content?: Array<{
       type: string;
       text?: string;
@@ -61,6 +62,7 @@ interface ResponsesStreamEvent {
       type: string;
     }>;
   };
+  arguments?: string;
   reasoning_summary?: string; // 添加推理摘要支持
 }
 
@@ -76,10 +78,20 @@ export class OpenAIResponsesTransformer implements Transformer {
 
     // 处理 reasoning 参数
     if (request.reasoning) {
-      (request as any).reasoning = {
-        effort: request.reasoning.effort,
-        summary: "detailed",
-      };
+      const reasoning = request.reasoning as Record<string, unknown>;
+      const openAIReasoning: Record<string, unknown> = {};
+      if (reasoning.effort) {
+        openAIReasoning.effort = reasoning.effort;
+      }
+      if (reasoning.summary) {
+        openAIReasoning.summary = reasoning.summary;
+      }
+
+      if (Object.keys(openAIReasoning).length > 0) {
+        (request as any).reasoning = openAIReasoning;
+      } else {
+        delete (request as any).reasoning;
+      }
     }
 
     const input: any[] = [];
@@ -147,6 +159,10 @@ export class OpenAIResponsesTransformer implements Transformer {
           });
         });
         return;
+      }
+
+      if (message.role === "assistant" && (message as any).thinking) {
+        delete (message as any).thinking;
       }
 
       input.push(message);
@@ -244,6 +260,59 @@ export class OpenAIResponsesTransformer implements Transformer {
           // 索引跟踪变量，只有在事件类型切换时才增加索引
           let currentIndex = -1;
           let lastEventType = "";
+          const functionCallArguments = new Map<string, string>();
+
+          // Responses delta/done events may omit or change item_id, while
+          // output_index stays stable for a single function call.
+          const getFunctionCallKey = (data: ResponsesStreamEvent) =>
+            String(data.output_index ?? data.item_id ?? 0);
+
+          const emitFunctionCallArguments = (
+            data: ResponsesStreamEvent,
+            args: string,
+            replaceIfMissing: boolean = false
+          ) => {
+            if (!args) return;
+
+            const key = getFunctionCallKey(data);
+            const previous = functionCallArguments.get(key) || "";
+            let delta = args;
+
+            if (replaceIfMissing && previous) {
+              if (!args.startsWith(previous)) return;
+              delta = args.slice(previous.length);
+              if (!delta) return;
+            }
+
+            functionCallArguments.set(key, previous + delta);
+
+            const functionCallChunk = {
+              id: data.item_id || "chatcmpl-" + Date.now(),
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: data.response?.model || "gpt-5-codex-",
+              choices: [
+                {
+                  index: getCurrentIndex("response.function_call_arguments"),
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: data.output_index ?? 0,
+                        function: {
+                          arguments: delta,
+                        },
+                      },
+                    ],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            };
+
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(functionCallChunk)}\n\n`)
+            );
+          };
 
           // 获取当前应该使用的索引的函数
           const getCurrentIndex = (eventType: string) => {
@@ -335,7 +404,7 @@ export class OpenAIResponsesTransformer implements Transformer {
                                 role: "assistant",
                                 tool_calls: [
                                   {
-                                    index: 0,
+                                    index: data.output_index ?? 0,
                                     id: data.item.call_id || data.item.id,
                                     function: {
                                       name: data.item.name || "",
@@ -440,34 +509,26 @@ export class OpenAIResponsesTransformer implements Transformer {
                       } else if (
                         data.type === "response.function_call_arguments.delta"
                       ) {
-                        // 处理function call参数增量
-                        const functionCallChunk = {
-                          id: data.item_id || "chatcmpl-" + Date.now(),
-                          object: "chat.completion.chunk",
-                          created: Math.floor(Date.now() / 1000),
-                          model: data.response?.model || "gpt-5-codex-",
-                          choices: [
-                            {
-                              index: getCurrentIndex(data.type),
-                              delta: {
-                                tool_calls: [
-                                  {
-                                    index: 0,
-                                    function: {
-                                      arguments: data.delta || "",
-                                    },
-                                  },
-                                ],
-                              },
-                              finish_reason: null,
-                            },
-                          ],
-                        };
-
-                        controller.enqueue(
-                          encoder.encode(
-                            `data: ${JSON.stringify(functionCallChunk)}\n\n`
-                          )
+                        emitFunctionCallArguments(
+                          data,
+                          typeof data.delta === "string" ? data.delta : ""
+                        );
+                      } else if (
+                        data.type === "response.function_call_arguments.done"
+                      ) {
+                        emitFunctionCallArguments(
+                          data,
+                          data.arguments || "",
+                          true
+                        );
+                      } else if (
+                        data.type === "response.output_item.done" &&
+                        data.item?.type === "function_call"
+                      ) {
+                        emitFunctionCallArguments(
+                          data,
+                          data.item.arguments || "",
+                          true
                         );
                       } else if (data.type === "response.completed") {
                         // 发送结束标记 - 检查是否是tool_calls完成
@@ -500,57 +561,16 @@ export class OpenAIResponsesTransformer implements Transformer {
                       } else if (
                         data.type === "response.reasoning_summary_text.delta"
                       ) {
-                        // 处理推理文本，将其转换为 thinking delta 格式
-                        const thinkingChunk = {
-                          id: data.item_id || "chatcmpl-" + Date.now(),
-                          object: "chat.completion.chunk",
-                          created: Math.floor(Date.now() / 1000),
-                          model: data.response?.model,
-                          choices: [
-                            {
-                              index: getCurrentIndex(data.type),
-                              delta: {
-                                thinking: {
-                                  content: data.delta || "",
-                                },
-                              },
-                              finish_reason: null,
-                            },
-                          ],
-                        };
-
-                        controller.enqueue(
-                          encoder.encode(
-                            `data: ${JSON.stringify(thinkingChunk)}\n\n`
-                          )
-                        );
+                        // OpenAI reasoning summaries are not Anthropic thinking
+                        // blocks. Forwarding them as thinking makes Claude Code
+                        // persist thinking-only messages that can break later
+                        // content block handling, so keep them internal.
+                        continue;
                       } else if (
                         data.type === "response.reasoning_summary_part.done" &&
                         data.part
                       ) {
-                        const thinkingChunk = {
-                          id: data.item_id || "chatcmpl-" + Date.now(),
-                          object: "chat.completion.chunk",
-                          created: Math.floor(Date.now() / 1000),
-                          model: data.response?.model,
-                          choices: [
-                            {
-                              index: currentIndex,
-                              delta: {
-                                thinking: {
-                                  signature: data.item_id,
-                                },
-                              },
-                              finish_reason: null,
-                            },
-                          ],
-                        };
-
-                        controller.enqueue(
-                          encoder.encode(
-                            `data: ${JSON.stringify(thinkingChunk)}\n\n`
-                          )
-                        );
+                        continue;
                       }
                     } catch (e) {
                       // 如果JSON解析失败，传递原始行
@@ -669,15 +689,6 @@ export class OpenAIResponsesTransformer implements Transformer {
 
     let messageContent: string | MessageContent[] | null = null;
     let toolCalls = null;
-    let thinking = null;
-
-    // 处理推理内容
-    if (messageOutput && messageOutput.reasoning) {
-      thinking = {
-        content: messageOutput.reasoning,
-      };
-    }
-
     if (messageOutput && messageOutput.content) {
       // 分离文本和图片内容
       const textParts: string[] = [];
@@ -750,7 +761,6 @@ export class OpenAIResponsesTransformer implements Transformer {
             role: "assistant",
             content: messageContent || null,
             tool_calls: toolCalls,
-            thinking: thinking,
             annotations: annotations,
           },
           logprobs: null,


### PR DESCRIPTION
## Summary
- Preserve OpenAI Responses function-call arguments when converting back to Claude tool calls.
- Classify provider context-window failures as `context_length_exceeded` / HTTP 413 instead of forwarding transient-looking 5xx errors that clients retry.
- Apply global `claudeCodeSettings` to plain `ccr code` sessions, not only preset sessions.

## Verification
- `pnpm --filter @musistudio/llms tsx --test scripts/providerError.test.ts`
- `pnpm build`