### PR TITLE
fix(ui): remove hover scaling

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -278,7 +278,7 @@ function App() {
         <div className="flex items-center gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" onClick={() => setIsSettingsOpen(true)} className="transition-all-ease hover:scale-110">
+              <Button variant="ghost" size="icon" onClick={() => setIsSettingsOpen(true)} className="transition-all-ease">
                 <Settings className="h-5 w-5" />
               </Button>
             </TooltipTrigger>
@@ -288,7 +288,7 @@ function App() {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" onClick={() => setIsJsonEditorOpen(true)} className="transition-all-ease hover:scale-110">
+              <Button variant="ghost" size="icon" onClick={() => setIsJsonEditorOpen(true)} className="transition-all-ease">
                 <FileJson className="h-5 w-5" />
               </Button>
             </TooltipTrigger>
@@ -298,7 +298,7 @@ function App() {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" onClick={() => setIsLogViewerOpen(true)} className="transition-all-ease hover:scale-110">
+              <Button variant="ghost" size="icon" onClick={() => setIsLogViewerOpen(true)} className="transition-all-ease">
                 <FileText className="h-5 w-5" />
               </Button>
             </TooltipTrigger>
@@ -308,7 +308,7 @@ function App() {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" onClick={() => navigate('/presets')} className="transition-all-ease hover:scale-110">
+              <Button variant="ghost" size="icon" onClick={() => navigate('/presets')} className="transition-all-ease">
                 <FileCog className="h-5 w-5" />
               </Button>
             </TooltipTrigger>
@@ -318,7 +318,7 @@ function App() {
           </Tooltip>
           <Popover>
             <PopoverTrigger asChild>
-              <Button variant="ghost" size="icon" className="transition-all-ease hover:scale-110">
+              <Button variant="ghost" size="icon" className="transition-all-ease">
                 <Languages className="h-5 w-5" />
               </Button>
             </PopoverTrigger>
@@ -326,14 +326,14 @@ function App() {
               <div className="space-y-1">
                 <Button
                   variant={i18n.language.startsWith('en') ? 'default' : 'ghost'}
-                  className="w-full justify-start transition-all-ease hover:scale-[1.02]"
+                  className="w-full justify-start transition-all-ease"
                   onClick={() => i18n.changeLanguage('en')}
                 >
                   English
                 </Button>
                 <Button
                   variant={i18n.language.startsWith('zh') ? 'default' : 'ghost'}
-                  className="w-full justify-start transition-all-ease hover:scale-[1.02]"
+                  className="w-full justify-start transition-all-ease"
                   onClick={() => i18n.changeLanguage('zh')}
                 >
                   中文
@@ -350,7 +350,7 @@ function App() {
                   size="icon"
                   onClick={() => checkForUpdates(true)}
                   disabled={isCheckingUpdate}
-                  className="transition-all-ease hover:scale-110 relative"
+                  className="transition-all-ease relative"
                 >
                   <div className="relative">
                     <CircleArrowUp className="h-5 w-5" />
@@ -370,11 +370,11 @@ function App() {
               </TooltipContent>
             </Tooltip>
           )}
-          <Button onClick={saveConfig} variant="outline" className="transition-all-ease hover:scale-[1.02] active:scale-[0.98]">
+          <Button onClick={saveConfig} variant="outline" className="transition-all-ease">
             <Save className="mr-2 h-4 w-4" />
             {t('app.save')}
           </Button>
-          <Button onClick={saveConfigAndRestart} className="transition-all-ease hover:scale-[1.02] active:scale-[0.98]">
+          <Button onClick={saveConfigAndRestart} className="transition-all-ease">
             <RefreshCw className="mr-2 h-4 w-4" />
             {t('app.save_and_restart')}
           </Button>

--- a/packages/ui/src/components/ProviderList.tsx
+++ b/packages/ui/src/components/ProviderList.tsx
@@ -33,10 +33,10 @@ export function ProviderList({ providers, onEdit, onRemove }: ProviderListProps)
                 <p className="text-sm text-gray-500">Provider data is missing</p>
               </div>
               <div className="ml-4 flex flex-shrink-0 items-center gap-2">
-                <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease hover:scale-110" disabled>
+                <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease" disabled>
                   <Pencil className="h-4 w-4" />
                 </Button>
-                <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200 hover:scale-110">
+                <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200">
                   <Trash2 className="h-4 w-4 text-current transition-colors duration-200" />
                 </Button>
               </div>
@@ -68,10 +68,10 @@ export function ProviderList({ providers, onEdit, onRemove }: ProviderListProps)
               </div>
             </div>
             <div className="ml-4 flex flex-shrink-0 items-center gap-2">
-              <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease hover:scale-110">
+              <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease">
                 <Pencil className="h-4 w-4" />
               </Button>
-              <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200 hover:scale-110">
+              <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200">
                 <Trash2 className="h-4 w-4 text-current transition-colors duration-200" />
               </Button>
             </div>

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -72,7 +72,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
             />
             <Label
               htmlFor="log"
-              className="transition-all-ease hover:scale-[1.02] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.log")}
             </Label>
@@ -88,7 +88,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
                 />
                 <Label
                   htmlFor="statusline"
-                  className="transition-all-ease hover:scale-[1.02] cursor-pointer"
+                  className="transition-all-ease cursor-pointer"
                 >
                   {t("statusline.title")}
                 </Label>
@@ -97,7 +97,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
                 variant="outline"
                 size="sm"
                 onClick={openStatusLineConfig}
-                className="transition-all-ease hover:scale-[1.02] active:scale-[0.98]"
+                className="transition-all-ease"
                 data-testid="statusline-config-button"
               >
                 {t("app.settings")}
@@ -105,7 +105,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
             </div>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="log-level" className="transition-all-ease hover:scale-[1.01] cursor-pointer">{t("toplevel.log_level")}</Label>
+            <Label htmlFor="log-level" className="transition-all-ease cursor-pointer">{t("toplevel.log_level")}</Label>
             <Combobox
               options={[
                 { label: "fatal", value: "fatal" },
@@ -122,7 +122,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
           <div className="space-y-2">
             <Label
               htmlFor="claude-path"
-              className="transition-all-ease hover:scale-[1.01] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.claude_path")}
             </Label>
@@ -136,7 +136,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
           <div className="space-y-2">
             <Label
               htmlFor="host"
-              className="transition-all-ease hover:scale-[1.01] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.host")}
             </Label>
@@ -150,7 +150,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
           <div className="space-y-2">
             <Label
               htmlFor="port"
-              className="transition-all-ease hover:scale-[1.01] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.port")}
             </Label>
@@ -167,7 +167,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
           <div className="space-y-2">
             <Label
               htmlFor="timeout"
-              className="transition-all-ease hover:scale-[1.01] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.timeout")}
             </Label>
@@ -183,7 +183,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
           <div className="space-y-2">
             <Label
               htmlFor="proxy-url"
-              className="transition-all-ease hover:scale-[1.01] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.proxy_url")}
             </Label>
@@ -200,7 +200,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
           <div className="space-y-2">
             <Label
               htmlFor="apikey"
-              className="transition-all-ease hover:scale-[1.01] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.apikey")}
             </Label>
@@ -215,7 +215,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
           <div className="space-y-2">
             <Label
               htmlFor="custom-router-path"
-              className="transition-all-ease hover:scale-[1.01] cursor-pointer"
+              className="transition-all-ease cursor-pointer"
             >
               {t("toplevel.custom_router_path")}
             </Label>
@@ -231,7 +231,7 @@ export function SettingsDialog({ isOpen, onOpenChange }: SettingsDialogProps) {
         <DialogFooter className="p-4 pt-0">
           <Button
             onClick={() => onOpenChange(false)}
-            className="transition-all-ease hover:scale-[1.02] active:scale-[0.98]"
+            className="transition-all-ease"
           >
             {t("app.save")}
           </Button>

--- a/packages/ui/src/components/StatusLineConfigDialog.tsx
+++ b/packages/ui/src/components/StatusLineConfigDialog.tsx
@@ -1235,14 +1235,14 @@ export function StatusLineConfigDialog({
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}
-            className="transition-all hover:scale-105"
+            className="transition-all"
           >
             {t("app.cancel")}
           </Button>
           <Button
             onClick={handleSave}
             data-testid="save-statusline-config"
-            className="transition-all hover:scale-105"
+            className="transition-all"
           >
             {t("app.save")}
           </Button>

--- a/packages/ui/src/components/StatusLineImportExport.tsx
+++ b/packages/ui/src/components/StatusLineImportExport.tsx
@@ -205,7 +205,7 @@ export function StatusLineImportExport({ config, onImport, onShowToast }: Status
             <Button 
               onClick={handleExport} 
               variant="outline" 
-              className="transition-all hover:scale-105"
+              className="transition-all"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
@@ -219,7 +219,7 @@ export function StatusLineImportExport({ config, onImport, onShowToast }: Status
               onClick={() => fileInputRef.current?.click()} 
               variant="outline" 
               disabled={isImporting}
-              className="transition-all hover:scale-105"
+              className="transition-all"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
@@ -234,7 +234,7 @@ export function StatusLineImportExport({ config, onImport, onShowToast }: Status
             <Button 
               onClick={handleBackup} 
               variant="outline" 
-              className="transition-all hover:scale-105"
+              className="transition-all"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
@@ -256,7 +256,7 @@ export function StatusLineImportExport({ config, onImport, onShowToast }: Status
                 restoreInput.click();
               }} 
               variant="outline" 
-              className="transition-all hover:scale-105"
+              className="transition-all"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
                 <path d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"/>
@@ -268,7 +268,7 @@ export function StatusLineImportExport({ config, onImport, onShowToast }: Status
           <Button 
             onClick={handleDownloadTemplate} 
             variant="outline" 
-            className="transition-all hover:scale-105 sm:col-span-2"
+            className="transition-all sm:col-span-2"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>

--- a/packages/ui/src/components/TransformerList.tsx
+++ b/packages/ui/src/components/TransformerList.tsx
@@ -32,10 +32,10 @@ export function TransformerList({ transformers, onEdit, onRemove }: TransformerL
                 <p className="text-sm text-gray-500">Transformer data is missing</p>
               </div>
               <div className="ml-4 flex flex-shrink-0 items-center gap-2">
-                <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease hover:scale-110" disabled>
+                <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease" disabled>
                   <Pencil className="h-4 w-4" />
                 </Button>
-                <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200 hover:scale-110">
+                <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200">
                   <Trash2 className="h-4 w-4 text-current transition-colors duration-200" />
                 </Button>
               </div>
@@ -77,10 +77,10 @@ export function TransformerList({ transformers, onEdit, onRemove }: TransformerL
               {renderParameters()}
             </div>
             <div className="ml-4 flex flex-shrink-0 items-center gap-2">
-              <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease hover:scale-110">
+              <Button variant="ghost" size="icon" onClick={() => onEdit(index)} className="transition-all-ease">
                 <Pencil className="h-4 w-4" />
               </Button>
-              <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200 hover:scale-110">
+              <Button variant="destructive" size="icon" onClick={() => onRemove(index)} className="transition-all duration-200">
                 <Trash2 className="h-4 w-4 text-current transition-colors duration-200" />
               </Button>
             </div>

--- a/packages/ui/src/components/ui/color-picker.tsx
+++ b/packages/ui/src/components/ui/color-picker.tsx
@@ -68,7 +68,7 @@ export function ColorPicker({
           <Button
             variant="outline"
             className={cn(
-              "w-full justify-start text-left font-normal h-10 transition-all hover:scale-[1.02] active:scale-[0.98]",
+              "w-full justify-start text-left font-normal h-10 transition-all",
               !value && "text-muted-foreground"
             )}
           >

--- a/packages/ui/src/components/ui/combobox.tsx
+++ b/packages/ui/src/components/ui/combobox.tsx
@@ -47,7 +47,7 @@ export function Combobox({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-full justify-between transition-all-ease hover:scale-[1.02] active:scale-[0.98]"
+          className="w-full justify-between transition-all-ease"
         >
           {selectedOption ? selectedOption.label : placeholder}
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50 transition-transform duration-200 group-data-[state=open]:rotate-180" />

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -45,7 +45,7 @@ const DialogContent = React.forwardRef<(
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground transition-all-ease hover:scale-110">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground transition-all-ease">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/ui/src/components/ui/multi-combobox.tsx
+++ b/packages/ui/src/components/ui/multi-combobox.tsx
@@ -76,7 +76,7 @@ export function MultiCombobox({
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-full justify-between transition-all-ease hover:scale-[1.02] active:scale-[0.98]"
+            className="w-full justify-between transition-all-ease"
           >
             {value.length > 0 ? `${value.length} selected` : placeholder}
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50 transition-transform duration-200 group-data-[state=open]:rotate-180" />


### PR DESCRIPTION
## Summary

- remove annoying hover/active scale effects from UI controls
- keep non-control animations such as card hover and dialog transitions

## Testing

- manually verified in local UI dev server