### PR TITLE
Add Tuning Engines provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ Here is a comprehensive example:
       }
     },
     {
+      "name": "tuningengines",
+      "api_base_url": "https://api.tuningengines.com/v1/chat/completions",
+      "api_key": "sk-te-your-api-key",
+      "models": ["llama-3.3-70b-fp8", "qwen-2.5-coder-32b"],
+      "transformer": { "use": ["anthropic"] }
+    },
+    {
       "name": "ollama",
       "api_base_url": "http://localhost:11434/v1/chat/completions",
       "api_key": "ollama",

--- a/docs/docs/server/config/providers.md
+++ b/docs/docs/server/config/providers.md
@@ -56,6 +56,18 @@ Detailed guide for configuring LLM providers.
 }
 ```
 
+### Tuning Engines
+
+```json
+{
+  "NAME": "tuningengines",
+  "HOST": "https://api.tuningengines.com/v1",
+  "APIKEY": "sk-te-your-api-key",
+  "MODELS": ["llama-3.3-70b-fp8", "qwen-2.5-coder-32b"],
+  "transformers": ["anthropic"]
+}
+```
+
 ## Provider Configuration Options
 
 | Field | Type | Required | Description |


### PR DESCRIPTION
Adds Tuning Engines as an OpenAI-compatible provider option.

This includes the Tuning Engines API base URL, key placeholder, and starter model IDs where this project exposes provider presets, examples, or configuration docs.

Validation:
- git diff --check
