### PR TITLE
docs: fix DeepSeek webSearch example + document Anthropic bypass pattern

### DIFF
--- a/docs/docs/server/config/routing.md
+++ b/docs/docs/server/config/routing.md
@@ -64,10 +64,41 @@ Route web search tasks:
 ```json
 {
   "Router": {
-    "webSearch": "deepseek,deepseek-chat"
+    "webSearch": "gemini,gemini-2.5-flash"
   }
 }
 ```
+
+:::tip DeepSeek + Web Search
+
+DeepSeek's Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`) **natively supports** `server_tool_use` and `web_search_tool_result` content blocks (see [DeepSeek Anthropic API docs](https://api-docs.deepseek.com/guides/anthropic_api)). 
+
+To use web search with DeepSeek, configure a dedicated provider pointing to the Anthropic endpoint. The `"Anthropic"` transformer name triggers CCR's bypass mechanism, passing requests through unmodified in native Anthropic format:
+
+```json
+{
+  "Providers": [
+    {
+      "name": "deepseek-anthropic",
+      "api_base_url": "https://api.deepseek.com/anthropic/v1/messages",
+      "api_key": "$DEEPSEEK_API_KEY",
+      "models": ["deepseek-v4-pro"],
+      "transformer": {
+        "use": ["Anthropic"]
+      }
+    }
+  ],
+  "Router": {
+    "webSearch": "deepseek-anthropic,deepseek-v4-pro"
+  }
+}
+```
+
+**Why this works**: When the provider's `transformer.use` contains exactly one transformer whose name matches the endpoint transformer (`"Anthropic"`), CCR's `shouldBypassTransformers()` skips all request/response conversion. The Anthropic-format request — including the `web_search_20250305` tool definition — reaches DeepSeek's Anthropic endpoint unmodified, and DeepSeek executes the search natively.
+
+This bypass pattern also works for other Anthropic server tools routed to Anthropic-compatible endpoints.
+
+:::
 
 ### Image Tasks
 


### PR DESCRIPTION
## Summary

Two changes to `docs/docs/server/config/routing.md`:

### 1. Fix misleading webSearch example

The existing `"webSearch": "deepseek,deepseek-chat"` routes web search to DeepSeek's OpenAI-format endpoint (`/chat/completions`). CCR's `AnthropicTransformer.convertAnthropicToolsToUnified()` then silently drops the `web_search_20250305` tool definition — so web search silently fails without error.

Replaced with `"gemini,gemini-2.5-flash"` — a provider where web search actually works through CCR.

### 2. Document DeepSeek Anthropic endpoint + bypass pattern

DeepSeek's Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`) officially supports `server_tool_use` and `web_search_tool_result` (see [DeepSeek docs](https://api-docs.deepseek.com/guides/anthropic_api)).

Added a `:::tip` box showing how to configure a dedicated DeepSeek provider using the Anthropic bypass pattern. When `transformer.use` contains exactly one transformer whose name matches the endpoint transformer (`"Anthropic"`), CCR's `shouldBypassTransformers()` skips conversion entirely, passing the Anthropic-format request through unmodified.

This pattern also works for other Anthropic server tools (code execution, MCP tools, etc.) routed to Anthropic-compatible endpoints.

## Related

- Issue [#1419](https://github.com/musistudio/claude-code-router/issues/1419) — Root cause analysis of the server tool dropping
- Issue [#1290](https://github.com/musistudio/claude-code-router/issues/1290) — User-facing manifestation