### PR TITLE
feat: improve Responses API compatibility and streaming stability

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -91,7 +91,7 @@ async function handleTransformerEndpoint(
     return formatResponse(finalResponse, reply, body);
   } catch (error: any) {
     // Handle fallback if error occurs
-    if (error.code === 'provider_response_error') {
+    if (isProviderRequestError(error)) {
       const fallbackResult = await handleFallback(req, reply, fastify, transformer, error);
       if (fallbackResult) {
         return fallbackResult;
@@ -350,32 +350,102 @@ async function sendRequestToProvider(
     }
   }
 
-  const response = await sendUnifiedRequest(
-    url,
-    requestBody,
-    {
-      httpsProxy: fastify.configService.getHttpsProxy(),
-      ...config,
-      headers: JSON.parse(JSON.stringify(requestHeaders)),
-    },
-    context,
-    fastify.log
-  );
+  const requestUrl = url instanceof URL ? url.toString() : String(url);
+  const model = requestBody?.model || context?.model || "unknown";
+  let response: Response;
+  try {
+    response = await sendUnifiedRequest(
+      url,
+      requestBody,
+      {
+        httpsProxy: fastify.configService.getHttpsProxy(),
+        ...config,
+        headers: JSON.parse(JSON.stringify(requestHeaders)),
+      },
+      context,
+      fastify.log
+    );
+  } catch (error: any) {
+    const providerErrorType = classifyProviderRequestFailure(error);
+    const statusCode = providerErrorType === "provider_timeout" ? 504 : 502;
+    const errorMessage =
+      error instanceof Error ? error.message : String(error || "unknown");
+    fastify.log.error(
+      {
+        errorType: providerErrorType,
+        provider: provider.name,
+        model,
+        requestUrl,
+        errorName: error?.name,
+        errorMessage,
+      },
+      `[provider_request_error] ${providerErrorType}: provider(${provider.name}, ${model}) request failed at ${requestUrl}`,
+    );
+    throw createApiError(
+      `${providerErrorType}: provider(${provider.name}, model=${model}) request failed at ${requestUrl}: ${errorMessage}`,
+      statusCode,
+      providerErrorType
+    );
+  }
 
   // Handle request errors
   if (!response.ok) {
     const errorText = await response.text();
+    const providerErrorType = classifyProviderHttpStatus(response.status);
     fastify.log.error(
-      `[provider_response_error] Error from provider(${provider.name},${requestBody.model}: ${response.status}): ${errorText}`,
+      {
+        errorType: providerErrorType,
+        provider: provider.name,
+        model,
+        status: response.status,
+        requestUrl,
+        responseBody: errorText,
+      },
+      `[provider_response_error] ${providerErrorType}: provider(${provider.name}, ${model}) HTTP ${response.status} at ${requestUrl}`,
     );
     throw createApiError(
-      `Error from provider(${provider.name},${requestBody.model}: ${response.status}): ${errorText}`,
+      `${providerErrorType}: provider(${provider.name}, model=${model}) returned HTTP ${response.status} at ${requestUrl}: ${errorText}`,
       response.status,
-      "provider_response_error"
+      providerErrorType
     );
   }
 
   return response;
+}
+
+function isProviderRequestError(error: any): boolean {
+  return (
+    error?.code === "provider_response_error" ||
+    typeof error?.code === "string" && error.code.startsWith("provider_")
+  );
+}
+
+function classifyProviderHttpStatus(status: number): string {
+  if (status === 400) {
+    return "provider_bad_request";
+  }
+  if (status === 422) {
+    return "provider_unprocessable_entity";
+  }
+  if (status >= 500 && status <= 599) {
+    return "provider_5xx";
+  }
+  return "provider_http_error";
+}
+
+function classifyProviderRequestFailure(error: any): string {
+  const name = String(error?.name || "").toLowerCase();
+  const message = String(error?.message || error || "").toLowerCase();
+  if (
+    name.includes("abort") ||
+    name.includes("timeout") ||
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("aborted")
+  ) {
+    return "provider_timeout";
+  }
+  return "provider_request_failed";
 }
 
 /**

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -270,6 +270,7 @@ export class AnthropicTransformer implements Transformer {
         let hasFinished = false;
         const toolCalls = new Map<number, any>();
         const toolCallIndexToContentBlockIndex = new Map<number, number>();
+        const flushedToolCallInputs = new Set<number>();
         let totalChunks = 0;
         let contentChunks = 0;
         let toolCallChunks = 0;
@@ -318,6 +319,7 @@ export class AnthropicTransformer implements Transformer {
             try {
               // Close any remaining open content block
               if (currentContentBlockIndex >= 0) {
+                flushToolInputForBlock(currentContentBlockIndex);
                 const contentBlockStop = {
                   type: "content_block_stop",
                   index: currentContentBlockIndex,
@@ -380,6 +382,58 @@ export class AnthropicTransformer implements Transformer {
               } else {
                 throw error;
               }
+            }
+          }
+        };
+
+        const parseToolInput = (argumentsValue: string) => {
+          try {
+            return argumentsValue ? JSON.parse(argumentsValue) : {};
+          } catch {
+            return {};
+          }
+        };
+
+        const flushToolInputForIndex = (toolCallIndex: number) => {
+          if (flushedToolCallInputs.has(toolCallIndex)) {
+            return;
+          }
+
+          const toolCall = toolCalls.get(toolCallIndex);
+          const blockIndex = toolCallIndexToContentBlockIndex.get(toolCallIndex);
+          if (!toolCall || blockIndex === undefined) {
+            return;
+          }
+
+          const input = sanitizeToolInput(
+            toolCall.name,
+            parseToolInput(toolCall.arguments || "")
+          );
+          const anthropicChunk = {
+            type: "content_block_delta",
+            index: blockIndex,
+            delta: {
+              type: "input_json_delta",
+              partial_json: JSON.stringify(input || {}),
+            },
+          };
+          safeEnqueue(
+            encoder.encode(
+              `event: content_block_delta\ndata: ${JSON.stringify(
+                anthropicChunk
+              )}\n\n`
+            )
+          );
+          flushedToolCallInputs.add(toolCallIndex);
+        };
+
+        const flushToolInputForBlock = (blockIndex: number) => {
+          for (const [
+            toolCallIndex,
+            toolBlockIndex,
+          ] of toolCallIndexToContentBlockIndex.entries()) {
+            if (toolBlockIndex === blockIndex) {
+              flushToolInputForIndex(toolCallIndex);
             }
           }
         };
@@ -733,6 +787,7 @@ export class AnthropicTransformer implements Transformer {
                     if (isUnknownIndex) {
                       // Close any previous content block if open
                       if (currentContentBlockIndex >= 0) {
+                        flushToolInputForBlock(currentContentBlockIndex);
                         const contentBlockStop = {
                           type: "content_block_stop",
                           index: currentContentBlockIndex,
@@ -800,58 +855,10 @@ export class AnthropicTransformer implements Transformer {
                       !isClosed &&
                       !hasFinished
                     ) {
-                      const blockIndex =
-                        toolCallIndexToContentBlockIndex.get(toolCallIndex);
-                      if (blockIndex === undefined) {
-                        continue;
-                      }
                       const currentToolCall = toolCalls.get(toolCallIndex);
                       if (currentToolCall) {
                         currentToolCall.arguments +=
                           toolCall.function.arguments;
-                      }
-
-                      try {
-                        const anthropicChunk = {
-                          type: "content_block_delta",
-                          index: blockIndex,
-                          delta: {
-                            type: "input_json_delta",
-                            partial_json: toolCall.function.arguments,
-                          },
-                        };
-                        safeEnqueue(
-                          encoder.encode(
-                            `event: content_block_delta\ndata: ${JSON.stringify(
-                              anthropicChunk
-                            )}\n\n`
-                          )
-                        );
-                      } catch {
-                        try {
-                          const fixedArgument = toolCall.function.arguments
-                            .replace(/[\x00-\x1F\x7F-\x9F]/g, "")
-                            .replace(/\\/g, "\\\\")
-                            .replace(/"/g, '\\"');
-
-                          const fixedChunk = {
-                            type: "content_block_delta",
-                            index: blockIndex, // Use the correct content block index
-                            delta: {
-                              type: "input_json_delta",
-                              partial_json: fixedArgument,
-                            },
-                          };
-                          safeEnqueue(
-                            encoder.encode(
-                              `event: content_block_delta\ndata: ${JSON.stringify(
-                                fixedChunk
-                              )}\n\n`
-                            )
-                          );
-                        } catch (fixError) {
-                          console.error(fixError);
-                        }
                       }
                     }
                   }
@@ -866,6 +873,7 @@ export class AnthropicTransformer implements Transformer {
 
                   // Close any remaining open content block
                   if (currentContentBlockIndex >= 0) {
+                    flushToolInputForBlock(currentContentBlockIndex);
                     const contentBlockStop = {
                       type: "content_block_stop",
                       index: currentContentBlockIndex,

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -14,6 +14,8 @@ import { v4 as uuidv4 } from "uuid";
 import { getThinkLevel } from "@/utils/thinking";
 import { createApiError } from "@/api/middleware";
 import { formatBase64 } from "@/utils/image";
+import { normalizeToolInputSchema } from "@/utils/tool-schema";
+import { sanitizeToolInput } from "@/utils/tool-sanitizer";
 
 export class AnthropicTransformer implements Transformer {
   name = "Anthropic";
@@ -248,7 +250,7 @@ export class AnthropicTransformer implements Transformer {
       function: {
         name: tool.name,
         description: tool.description || "",
-        parameters: tool.input_schema,
+        parameters: normalizeToolInputSchema(tool.name, tool.input_schema),
       },
     }));
   }
@@ -996,9 +998,10 @@ export class AnthropicTransformer implements Transformer {
       }
       if (choice.message.tool_calls && choice.message.tool_calls.length > 0) {
         choice.message.tool_calls.forEach((toolCall) => {
+          const toolFunction = (toolCall as any).function || {};
           let parsedInput = {};
           try {
-            const argumentsStr = toolCall.function.arguments || "{}";
+            const argumentsStr = toolFunction.arguments || "{}";
 
             if (typeof argumentsStr === "object") {
               parsedInput = argumentsStr;
@@ -1006,14 +1009,14 @@ export class AnthropicTransformer implements Transformer {
               parsedInput = JSON.parse(argumentsStr);
             }
           } catch {
-            parsedInput = { text: toolCall.function.arguments || "" };
+            parsedInput = { text: toolFunction.arguments || "" };
           }
 
           content.push({
             type: "tool_use",
             id: toolCall.id,
-            name: toolCall.function.name,
-            input: parsedInput,
+            name: toolFunction.name,
+            input: sanitizeToolInput(toolFunction.name, parsedInput),
           });
         });
       }

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -115,13 +115,14 @@ export class OpenAIResponsesTransformer implements Transformer {
     delete request.temperature;
     delete request.max_tokens;
 
-    // 处理 reasoning 参数
-    if (request.reasoning) {
-      (request as any).reasoning = {
-        effort: request.reasoning.effort,
-        summary: "detailed",
-      };
-    }
+    // Align with CC-Adapter defaults so Responses backends keep producing visible text
+    (request as any).reasoning = {
+      effort: request.reasoning?.effort || "medium",
+      summary: "auto",
+    };
+    (request as any).text = {
+      verbosity: "medium",
+    };
 
     const input: any[] = [];
 

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -1,18 +1,22 @@
 import { UnifiedChatRequest, MessageContent } from "@/types/llm";
 import { Transformer } from "@/types/transformer";
+import { normalizeToolInputSchema } from "@/utils/tool-schema";
+import { sanitizeToolInput } from "@/utils/tool-sanitizer";
 
 interface ResponsesAPIOutputItem {
   type: string;
   id?: string;
   call_id?: string;
+  tool_call_id?: string;
   name?: string;
-  arguments?: string;
+  arguments?: unknown;
   content?: Array<{
     type: string;
-    text?: string;
+    text?: unknown;
     image_url?: string;
     mime_type?: string;
     image_base64?: string;
+    annotations?: Array<Record<string, any>>;
   }>;
   reasoning?: string;
 }
@@ -31,6 +35,7 @@ interface ResponsesAPIPayload {
 }
 
 interface ResponsesStreamEvent {
+  [key: string]: any;
   type: string;
   item_id?: string;
   output_index?: number;
@@ -45,10 +50,12 @@ interface ResponsesStreamEvent {
     id?: string;
     type?: string;
     call_id?: string;
+    tool_call_id?: string;
     name?: string;
+    arguments?: unknown;
     content?: Array<{
       type: string;
-      text?: string;
+      text?: unknown;
       image_url?: string;
       mime_type?: string;
     }>;
@@ -59,6 +66,7 @@ interface ResponsesStreamEvent {
     model?: string;
     output?: Array<{
       type: string;
+      [key: string]: any;
     }>;
   };
   reasoning_summary?: string; // 添加推理摘要支持
@@ -67,6 +75,7 @@ interface ResponsesStreamEvent {
 export class OpenAIResponsesTransformer implements Transformer {
   name = "openai-responses";
   endPoint = "/v1/responses";
+  logger?: any;
 
   async transformRequestIn(
     request: UnifiedChatRequest
@@ -163,8 +172,16 @@ export class OpenAIResponsesTransformer implements Transformer {
       (request as any).tools = request.tools
         .filter((tool) => tool.function.name !== "web_search")
         .map((tool) => {
+          let parameters = normalizeToolInputSchema(
+            tool.function.name,
+            tool.function.parameters
+          );
           if (tool.function.name === "WebSearch") {
-            delete tool.function.parameters.properties.allowed_domains;
+            parameters = {
+              ...parameters,
+              properties: { ...parameters.properties },
+            };
+            delete parameters.properties.allowed_domains;
           }
           if (tool.function.name === "Edit") {
             return {
@@ -172,7 +189,7 @@ export class OpenAIResponsesTransformer implements Transformer {
               name: tool.function.name,
               description: tool.function.description,
               parameters: {
-                ...tool.function.parameters,
+                ...parameters,
                 required: [
                   "file_path",
                   "old_string",
@@ -187,7 +204,7 @@ export class OpenAIResponsesTransformer implements Transformer {
             type: tool.type,
             name: tool.function.name,
             description: tool.function.description,
-            parameters: tool.function.parameters,
+            parameters,
           };
         });
 
@@ -198,7 +215,7 @@ export class OpenAIResponsesTransformer implements Transformer {
       }
     }
 
-    request.parallel_tool_calls = false;
+    (request as any).parallel_tool_calls = false;
 
     return request;
   }
@@ -253,6 +270,84 @@ export class OpenAIResponsesTransformer implements Transformer {
             }
             return currentIndex;
           };
+          const pendingToolCalls = new Map<string, any>();
+          const completedToolCallIds = new Set<string>();
+          let hasToolCall = false;
+          let pendingEventType = "";
+
+          const dataModel = (item: any) =>
+            item?.response?.model || item?.model || "gpt-5-codex";
+
+          const enqueueChatChunk = (chunk: Record<string, any>) => {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)
+            );
+          };
+
+          const enqueueToolCallChunk = (
+            item: any,
+            index: number,
+            argumentsOverride?: unknown
+          ) => {
+            const toolCall = transformer.buildToolCallFromOutputItem(
+              item,
+              argumentsOverride
+            );
+            if (!toolCall) {
+              return;
+            }
+
+            hasToolCall = true;
+            completedToolCallIds.add(toolCall.id);
+            enqueueChatChunk({
+              id:
+                item?.call_id ||
+                item?.id ||
+                item?.tool_call_id ||
+                "chatcmpl-" + Date.now(),
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: dataModel(item),
+              choices: [
+                {
+                  index,
+                  delta: {
+                    role: "assistant",
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: toolCall.id,
+                        function: {
+                          name: toolCall.function.name,
+                          arguments: toolCall.function.arguments,
+                        },
+                        type: "function",
+                      },
+                    ],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            });
+          };
+
+          const rememberPendingToolCall = (item: any) => {
+            const pending = {
+              ...item,
+              arguments:
+                typeof item?.arguments === "string" ? item.arguments : "",
+            };
+            for (const id of [
+              item?.call_id,
+              item?.id,
+              item?.tool_call_id,
+              item?.item_id,
+            ]) {
+              if (typeof id === "string" && id.length > 0) {
+                pendingToolCalls.set(id, pending);
+              }
+            }
+          };
 
           try {
             while (true) {
@@ -279,6 +374,7 @@ export class OpenAIResponsesTransformer implements Transformer {
                 try {
                   if (line.startsWith("event: ")) {
                     // 处理事件行，暂存以便与下一行数据配对
+                    pendingEventType = line.slice(7).trim();
                     continue;
                   } else if (line.startsWith("data: ")) {
                     const dataStr = line.slice(5).trim(); // 移除 "data: " 前缀
@@ -290,6 +386,9 @@ export class OpenAIResponsesTransformer implements Transformer {
 
                     try {
                       const data: ResponsesStreamEvent = JSON.parse(dataStr);
+                      if (!data.type && pendingEventType) {
+                        data.type = pendingEventType;
+                      }
 
                       // 根据不同的事件类型转换为chat格式
                       if (data.type === "response.output_text.delta") {
@@ -319,42 +418,18 @@ export class OpenAIResponsesTransformer implements Transformer {
                         data.type === "response.output_item.added" &&
                         data.item?.type === "function_call"
                       ) {
-                        // 处理function call开始 - 创建初始的tool call chunk
-                        const functionCallChunk = {
-                          id:
-                            data.item.call_id ||
-                            data.item.id ||
-                            "chatcmpl-" + Date.now(),
-                          object: "chat.completion.chunk",
-                          created: Math.floor(Date.now() / 1000),
-                          model: data.response?.model || "gpt-5-codex-",
-                          choices: [
-                            {
-                              index: getCurrentIndex(data.type),
-                              delta: {
-                                role: "assistant",
-                                tool_calls: [
-                                  {
-                                    index: 0,
-                                    id: data.item.call_id || data.item.id,
-                                    function: {
-                                      name: data.item.name || "",
-                                      arguments: "",
-                                    },
-                                    type: "function",
-                                  },
-                                ],
-                              },
-                              finish_reason: null,
-                            },
-                          ],
-                        };
-
-                        controller.enqueue(
-                          encoder.encode(
-                            `data: ${JSON.stringify(functionCallChunk)}\n\n`
-                          )
-                        );
+                        const id =
+                          data.item.call_id ||
+                          data.item.id ||
+                          data.item.tool_call_id ||
+                          data.item_id ||
+                          `call_${Date.now()}`;
+                        rememberPendingToolCall({
+                          ...data.item,
+                          call_id: data.item.call_id || id,
+                          response: data.response,
+                        });
+                        getCurrentIndex(data.type);
                       } else if (
                         data.type === "response.output_item.added" &&
                         data.item?.type === "message"
@@ -440,39 +515,86 @@ export class OpenAIResponsesTransformer implements Transformer {
                       } else if (
                         data.type === "response.function_call_arguments.delta"
                       ) {
-                        // 处理function call参数增量
-                        const functionCallChunk = {
-                          id: data.item_id || "chatcmpl-" + Date.now(),
-                          object: "chat.completion.chunk",
-                          created: Math.floor(Date.now() / 1000),
-                          model: data.response?.model || "gpt-5-codex-",
-                          choices: [
-                            {
-                              index: getCurrentIndex(data.type),
-                              delta: {
-                                tool_calls: [
-                                  {
-                                    index: 0,
-                                    function: {
-                                      arguments: data.delta || "",
-                                    },
-                                  },
-                                ],
-                              },
-                              finish_reason: null,
-                            },
-                          ],
+                        const id = data.item_id || data.output_index?.toString() || "call_unknown";
+                        const existing = pendingToolCalls.get(id) || {
+                          call_id: id,
+                          arguments: "",
+                          response: data.response,
                         };
-
-                        controller.enqueue(
-                          encoder.encode(
-                            `data: ${JSON.stringify(functionCallChunk)}\n\n`
-                          )
+                        existing.arguments = `${existing.arguments || ""}${
+                          typeof data.delta === "string" ? data.delta : ""
+                        }`;
+                        existing.response = existing.response || data.response;
+                        pendingToolCalls.set(id, existing);
+                        getCurrentIndex(data.type);
+                      } else if (
+                        data.type === "response.output_item.done" &&
+                        (data.item?.type === "function_call" ||
+                          data.item?.type === "tool_call" ||
+                          data.item?.type === "custom_tool_call")
+                      ) {
+                        const id =
+                          data.item.call_id ||
+                          data.item.id ||
+                          data.item.tool_call_id ||
+                          data.item_id ||
+                          `call_${Date.now()}`;
+                        const pending = pendingToolCalls.get(id);
+                        const item = {
+                          ...pending,
+                          ...data.item,
+                          response: data.response || pending?.response,
+                        };
+                        enqueueToolCallChunk(
+                          item,
+                          getCurrentIndex("response.output_item.done"),
+                          item.arguments
                         );
+                        pendingToolCalls.delete(id);
                       } else if (data.type === "response.completed") {
+                        const responseOutput = data.response?.output || [];
+                        responseOutput
+                          .filter((item: any) =>
+                            transformer.isFunctionCallOutputItem(item)
+                          )
+                          .forEach((item: any) => {
+                            const id =
+                              item.call_id ||
+                              item.id ||
+                              item.tool_call_id ||
+                              `call_${Date.now()}`;
+                            if (!completedToolCallIds.has(id)) {
+                              enqueueToolCallChunk(
+                                { ...item, response: data.response },
+                                getCurrentIndex("response.output_item.done"),
+                                item.arguments
+                              );
+                            }
+                          });
+
+                        const uniquePendingToolCalls = new Set(
+                          pendingToolCalls.values()
+                        );
+                        for (const item of uniquePendingToolCalls) {
+                          const id =
+                            item.call_id ||
+                            item.id ||
+                            item.tool_call_id ||
+                            `call_${Date.now()}`;
+                          if (!completedToolCallIds.has(id)) {
+                            enqueueToolCallChunk(
+                              item,
+                              getCurrentIndex("response.output_item.done"),
+                              item.arguments
+                            );
+                          }
+                        }
+                        pendingToolCalls.clear();
+
                         // 发送结束标记 - 检查是否是tool_calls完成
-                        const finishReason = data.response?.output?.some(
-                          (item: any) => item.type === "function_call"
+                        const finishReason = hasToolCall ||
+                        responseOutput.some((item: any) =>
+                          transformer.isFunctionCallOutputItem(item)
                         )
                           ? "tool_calls"
                           : "stop";
@@ -640,9 +762,6 @@ export class OpenAIResponsesTransformer implements Transformer {
     const messageOutput = responseData.output?.find(
       (item) => item.type === "message"
     );
-    const functionCallOutput = responseData.output?.find(
-      (item) => item.type === "function_call"
-    );
     let annotations;
     if (
       messageOutput?.content?.length &&
@@ -684,8 +803,8 @@ export class OpenAIResponsesTransformer implements Transformer {
       const imageParts: MessageContent[] = [];
 
       messageOutput.content.forEach((item: any) => {
-        if (item.type === "output_text") {
-          textParts.push(item.text || "");
+        if (item.type === "output_text" || item.type === "text") {
+          textParts.push(this.extractTextValue(item.text));
         } else if (item.type === "output_image") {
           const imageContent = this.buildImageContent({
             url: item.image_url,
@@ -723,19 +842,10 @@ export class OpenAIResponsesTransformer implements Transformer {
       }
     }
 
-    if (functionCallOutput) {
-      // 处理function_call类型的输出
-      toolCalls = [
-        {
-          id: functionCallOutput.call_id || functionCallOutput.id,
-          function: {
-            name: functionCallOutput.name,
-            arguments: functionCallOutput.arguments,
-          },
-          type: "function",
-        },
-      ];
-    }
+    toolCalls = (responseData.output || [])
+      .filter((item) => this.isFunctionCallOutputItem(item))
+      .map((item) => this.buildToolCallFromOutputItem(item))
+      .filter((toolCall): toolCall is Record<string, any> => Boolean(toolCall));
 
     // 构建chat格式的响应
     const chatResponse = {
@@ -788,5 +898,77 @@ export class OpenAIResponsesTransformer implements Transformer {
     }
 
     return null;
+  }
+
+  private isFunctionCallOutputItem(item: any): boolean {
+    return (
+      item?.type === "function_call" ||
+      item?.type === "tool_call" ||
+      item?.type === "custom_tool_call"
+    );
+  }
+
+  private buildToolCallFromOutputItem(
+    item: any,
+    argumentsOverride?: unknown
+  ): Record<string, any> | null {
+    if (!this.isFunctionCallOutputItem(item)) {
+      return null;
+    }
+
+    const name = typeof item.name === "string" ? item.name : "";
+    const id =
+      item.call_id ||
+      item.id ||
+      item.tool_call_id ||
+      `call_${Date.now()}`;
+    const rawArguments =
+      argumentsOverride !== undefined ? argumentsOverride : item.arguments;
+    const parsedInput = this.parseToolArguments(rawArguments);
+    const sanitizedInput = sanitizeToolInput(name, parsedInput);
+
+    return {
+      id,
+      function: {
+        name,
+        arguments: JSON.stringify(sanitizedInput || {}),
+      },
+      type: "function",
+    };
+  }
+
+  private parseToolArguments(rawArguments: unknown): unknown {
+    if (rawArguments === undefined || rawArguments === null) {
+      return {};
+    }
+
+    if (typeof rawArguments === "object") {
+      return rawArguments;
+    }
+
+    if (typeof rawArguments !== "string") {
+      return {};
+    }
+
+    const trimmed = rawArguments.trim();
+    if (!trimmed) {
+      return {};
+    }
+
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return {};
+    }
+  }
+
+  private extractTextValue(text: unknown): string {
+    if (typeof text === "string") {
+      return text;
+    }
+    if (text && typeof text === "object" && typeof (text as any).value === "string") {
+      return (text as any).value;
+    }
+    return "";
   }
 }

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -10,14 +10,16 @@ interface ResponsesAPIOutputItem {
   tool_call_id?: string;
   name?: string;
   arguments?: unknown;
-  content?: Array<{
-    type: string;
-    text?: unknown;
-    image_url?: string;
-    mime_type?: string;
-    image_base64?: string;
-    annotations?: Array<Record<string, any>>;
-  }>;
+  content?:
+    | Array<{
+        type: string;
+        text?: unknown;
+        image_url?: string;
+        mime_type?: string;
+        image_base64?: string;
+        annotations?: Array<Record<string, any>>;
+      }>
+    | Record<string, any>;
   reasoning?: string;
 }
 
@@ -26,11 +28,23 @@ interface ResponsesAPIPayload {
   object: string;
   model: string;
   created_at: number;
+  status?: string;
+  incomplete_details?: {
+    reason?: string;
+  };
   output: ResponsesAPIOutputItem[];
   usage?: {
-    input_tokens: number;
-    output_tokens: number;
-    total_tokens: number;
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    input_tokens_details?: {
+      cached_tokens?: number;
+    };
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+    };
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
   };
 }
 
@@ -62,8 +76,25 @@ interface ResponsesStreamEvent {
     reasoning?: string; // 添加 reasoning 字段支持
   };
   response?: {
+    status?: string;
+    incomplete_details?: {
+      reason?: string;
+    };
     id?: string;
     model?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+      input_tokens_details?: {
+        cached_tokens?: number;
+      };
+      prompt_tokens_details?: {
+        cached_tokens?: number;
+      };
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
     output?: Array<{
       type: string;
       [key: string]: any;
@@ -76,6 +107,7 @@ export class OpenAIResponsesTransformer implements Transformer {
   name = "openai-responses";
   endPoint = "/v1/responses";
   logger?: any;
+  private readonly defaultInstructions = "You are a helpful assistant.";
 
   async transformRequestIn(
     request: UnifiedChatRequest
@@ -97,22 +129,32 @@ export class OpenAIResponsesTransformer implements Transformer {
       (msg) => msg.role === "system"
     );
     if (systemMessages.length > 0) {
-      const firstSystem = systemMessages[0];
-      if (Array.isArray(firstSystem.content)) {
-        firstSystem.content.forEach((item) => {
-          let text = "";
-          if (typeof item === "string") {
-            text = item;
-          } else if (item && typeof item === "object" && "text" in item) {
-            text = (item as { text: string }).text;
-          }
-          input.push({
-            role: "system",
-            content: text,
+      const instructionParts: string[] = [];
+      systemMessages.forEach((systemMessage) => {
+        if (Array.isArray(systemMessage.content)) {
+          systemMessage.content.forEach((item) => {
+            let text = "";
+            if (typeof item === "string") {
+              text = item;
+            } else if (item && typeof item === "object" && "text" in item) {
+              text = (item as { text: string }).text;
+            }
+            if (text.trim()) {
+              instructionParts.push(text);
+            }
           });
-        });
-      } else {
-        (request as any).instructions = firstSystem.content;
+        } else {
+          let text = "";
+          if (typeof systemMessage.content === "string") {
+            text = systemMessage.content;
+          }
+          if (text.trim()) {
+            instructionParts.push(text);
+          }
+        }
+      });
+      if (instructionParts.length > 0) {
+        (request as any).instructions = instructionParts.join("\n\n");
       }
     }
 
@@ -163,6 +205,12 @@ export class OpenAIResponsesTransformer implements Transformer {
 
     (request as any).input = input;
     delete (request as any).messages;
+
+    if (!(request as any).instructions?.trim?.()) {
+      (request as any).instructions = this.defaultInstructions;
+    }
+
+    (request as any).store = false;
 
     if (Array.isArray(request.tools)) {
       const webSearch = request.tools.find(
@@ -272,6 +320,7 @@ export class OpenAIResponsesTransformer implements Transformer {
           };
           const pendingToolCalls = new Map<string, any>();
           const completedToolCallIds = new Set<string>();
+          let hasContent = false;
           let hasToolCall = false;
           let pendingEventType = "";
 
@@ -282,6 +331,33 @@ export class OpenAIResponsesTransformer implements Transformer {
             controller.enqueue(
               encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)
             );
+          };
+
+          const enqueueTextChunk = (
+            text: string,
+            eventType: string,
+            id?: string,
+            model?: string
+          ) => {
+            if (!text) {
+              return;
+            }
+            hasContent = true;
+            enqueueChatChunk({
+              id: id || "chatcmpl-" + Date.now(),
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model,
+              choices: [
+                {
+                  index: getCurrentIndex(eventType),
+                  delta: {
+                    content: text,
+                  },
+                  finish_reason: null,
+                },
+              ],
+            });
           };
 
           const enqueueToolCallChunk = (
@@ -392,27 +468,28 @@ export class OpenAIResponsesTransformer implements Transformer {
 
                       // 根据不同的事件类型转换为chat格式
                       if (data.type === "response.output_text.delta") {
-                        // 将output_text.delta转换为chat格式
-                        const chatChunk = {
-                          id: data.item_id || "chatcmpl-" + Date.now(),
-                          object: "chat.completion.chunk",
-                          created: Math.floor(Date.now() / 1000),
-                          model: data.response?.model,
-                          choices: [
-                            {
-                              index: getCurrentIndex(data.type),
-                              delta: {
-                                content: data.delta || "",
-                              },
-                              finish_reason: null,
-                            },
-                          ],
-                        };
-
-                        controller.enqueue(
-                          encoder.encode(
-                            `data: ${JSON.stringify(chatChunk)}\n\n`
-                          )
+                        enqueueTextChunk(
+                          transformer.extractTextValue(data.delta),
+                          data.type,
+                          data.item_id,
+                          data.response?.model
+                        );
+                      } else if (data.type === "response.output_text.done") {
+                        enqueueTextChunk(
+                          transformer.extractTextValue(data.text),
+                          data.type,
+                          data.item_id,
+                          data.response?.model
+                        );
+                      } else if (
+                        data.type === "response.content_part.done" &&
+                        data.part
+                      ) {
+                        enqueueTextChunk(
+                          transformer.extractTextFromContentPart(data.part),
+                          data.type,
+                          data.item_id,
+                          data.response?.model
                         );
                       } else if (
                         data.type === "response.output_item.added" &&
@@ -551,8 +628,23 @@ export class OpenAIResponsesTransformer implements Transformer {
                           item.arguments
                         );
                         pendingToolCalls.delete(id);
-                      } else if (data.type === "response.completed") {
+                      } else if (
+                        data.type === "response.completed" ||
+                        data.type === "response.done"
+                      ) {
                         const responseOutput = data.response?.output || [];
+                        if (!hasContent) {
+                          const recoveredText =
+                            transformer.collectVisibleTextFromResponseValue(
+                              data.response || data
+                            );
+                          enqueueTextChunk(
+                            recoveredText,
+                            "response.output_text.done",
+                            data.response?.id,
+                            data.response?.model
+                          );
+                        }
                         responseOutput
                           .filter((item: any) =>
                             transformer.isFunctionCallOutputItem(item)
@@ -597,7 +689,10 @@ export class OpenAIResponsesTransformer implements Transformer {
                           transformer.isFunctionCallOutputItem(item)
                         )
                           ? "tool_calls"
-                          : "stop";
+                          : transformer.responsesStatusToFinishReason(
+                              data.response?.status,
+                              data.response?.incomplete_details?.reason
+                            );
 
                         const endChunk = {
                           id: data.response?.id || "chatcmpl-" + Date.now(),
@@ -611,6 +706,11 @@ export class OpenAIResponsesTransformer implements Transformer {
                               finish_reason: finishReason,
                             },
                           ],
+                          usage: data.response?.usage
+                            ? transformer.responsesUsageToChatUsage(
+                                data.response.usage
+                              )
+                            : undefined,
                         };
 
                         controller.enqueue(
@@ -763,11 +863,17 @@ export class OpenAIResponsesTransformer implements Transformer {
       (item) => item.type === "message"
     );
     let annotations;
+    const messageContentParts = Array.isArray(messageOutput?.content)
+      ? messageOutput.content
+      : messageOutput?.content
+      ? [messageOutput.content]
+      : [];
+
     if (
-      messageOutput?.content?.length &&
-      messageOutput?.content[0].annotations
+      messageContentParts.length &&
+      messageContentParts[0].annotations
     ) {
-      annotations = messageOutput.content[0].annotations.map((item) => {
+      annotations = messageContentParts[0].annotations.map((item: any) => {
         return {
           type: "url_citation",
           url_citation: {
@@ -787,7 +893,7 @@ export class OpenAIResponsesTransformer implements Transformer {
     });
 
     let messageContent: string | MessageContent[] | null = null;
-    let toolCalls = null;
+    let toolCalls: Record<string, any>[] = [];
     let thinking = null;
 
     // 处理推理内容
@@ -797,12 +903,12 @@ export class OpenAIResponsesTransformer implements Transformer {
       };
     }
 
-    if (messageOutput && messageOutput.content) {
+    if (messageOutput && messageContentParts.length) {
       // 分离文本和图片内容
       const textParts: string[] = [];
       const imageParts: MessageContent[] = [];
 
-      messageOutput.content.forEach((item: any) => {
+      messageContentParts.forEach((item: any) => {
         if (item.type === "output_text" || item.type === "text") {
           textParts.push(this.extractTextValue(item.text));
         } else if (item.type === "output_image") {
@@ -847,6 +953,15 @@ export class OpenAIResponsesTransformer implements Transformer {
       .map((item) => this.buildToolCallFromOutputItem(item))
       .filter((toolCall): toolCall is Record<string, any> => Boolean(toolCall));
 
+    if (
+      (!messageContent ||
+        (typeof messageContent === "string" && !messageContent.trim())) &&
+      toolCalls.length === 0
+    ) {
+      const recoveredText = this.collectVisibleTextFromResponseValue(responseData);
+      messageContent = recoveredText || messageContent;
+    }
+
     // 构建chat格式的响应
     const chatResponse = {
       id: responseData.id || "chatcmpl-" + Date.now(),
@@ -859,20 +974,22 @@ export class OpenAIResponsesTransformer implements Transformer {
           message: {
             role: "assistant",
             content: messageContent || null,
-            tool_calls: toolCalls,
+            tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
             thinking: thinking,
             annotations: annotations,
           },
           logprobs: null,
-          finish_reason: toolCalls ? "tool_calls" : "stop",
+          finish_reason:
+            toolCalls.length > 0
+              ? "tool_calls"
+              : this.responsesStatusToFinishReason(
+                  responseData.status,
+                  responseData.incomplete_details?.reason
+                ),
         },
       ],
       usage: responseData.usage
-        ? {
-            prompt_tokens: responseData.usage.input_tokens || 0,
-            completion_tokens: responseData.usage.output_tokens || 0,
-            total_tokens: responseData.usage.total_tokens || 0,
-          }
+        ? this.responsesUsageToChatUsage(responseData.usage)
         : null,
     };
 
@@ -898,6 +1015,75 @@ export class OpenAIResponsesTransformer implements Transformer {
     }
 
     return null;
+  }
+
+  private collectVisibleTextFromResponseValue(responseValue: any): string {
+    const output = Array.isArray(responseValue?.output)
+      ? responseValue.output
+      : responseValue?.output && typeof responseValue.output === "object"
+      ? [responseValue.output]
+      : [];
+    const parts: string[] = [];
+
+    for (const item of output) {
+      if (this.isFunctionCallOutputItem(item)) {
+        continue;
+      }
+
+      if (item?.type === "reasoning") {
+        parts.push(this.extractTextValue(item.summary));
+        if (Array.isArray(item.summary)) {
+          item.summary.forEach((part: any) => {
+            parts.push(this.extractTextValue(part?.text));
+          });
+        }
+        continue;
+      }
+
+      const contentParts = Array.isArray(item?.content)
+        ? item.content
+        : item?.content && typeof item.content === "object"
+        ? [item.content]
+        : [];
+      if (contentParts.length) {
+        contentParts.forEach((part: any) => {
+          parts.push(this.extractTextFromContentPart(part));
+        });
+      }
+
+      parts.push(this.extractTextValue(item?.text));
+      parts.push(this.extractTextValue(item?.output_text));
+    }
+
+    const visibleText = parts.filter(Boolean).join("");
+    if (visibleText.trim()) {
+      return visibleText;
+    }
+
+    return this.collectLongestAssistiveText(
+      responseValue,
+      this.extractOutputTokens(responseValue)
+    );
+  }
+
+  private extractTextFromContentPart(part: any): string {
+    if (!part) {
+      return "";
+    }
+
+    if (
+      part.type === "text" ||
+      part.type === "output_text" ||
+      part.type === "summary_text"
+    ) {
+      return this.extractTextValue(part.text);
+    }
+
+    return (
+      this.extractTextValue(part.output_text) ||
+      this.extractTextValue(part.value) ||
+      this.extractTextValue(part.content)
+    );
   }
 
   private isFunctionCallOutputItem(item: any): boolean {
@@ -966,9 +1152,181 @@ export class OpenAIResponsesTransformer implements Transformer {
     if (typeof text === "string") {
       return text;
     }
+    if (Array.isArray(text)) {
+      return text.map((item) => this.extractTextValue(item)).join("");
+    }
     if (text && typeof text === "object" && typeof (text as any).value === "string") {
       return (text as any).value;
     }
+    if (text && typeof text === "object" && typeof (text as any).text === "string") {
+      return (text as any).text;
+    }
     return "";
+  }
+
+  private collectLongestAssistiveText(
+    value: unknown,
+    outputTokens: number
+  ): string {
+    let best = "";
+    const minChars = this.plausibleMinCharsForFallback(outputTokens);
+
+    const consider = (candidate: unknown) => {
+      if (typeof candidate !== "string") {
+        return;
+      }
+      const trimmed = candidate.trim();
+      if (!trimmed || this.isAssistiveNoiseToken(trimmed)) {
+        return;
+      }
+      if (trimmed.length < minChars) {
+        return;
+      }
+      if (candidate.length > best.length) {
+        best = candidate;
+      }
+    };
+
+    const visit = (
+      current: unknown,
+      depth: number,
+      parentKey = "",
+      insideArguments = false
+    ) => {
+      if (depth > 20 || insideArguments || current == null) {
+        return;
+      }
+      if (Array.isArray(current)) {
+        current.forEach((item) =>
+          visit(item, depth + 1, parentKey, insideArguments)
+        );
+        return;
+      }
+      if (typeof current !== "object") {
+        if (
+          [
+            "text",
+            "summary",
+            "refusal",
+            "thinking",
+            "content",
+            "value",
+            "body",
+            "markdown",
+            "delta",
+            "output_text",
+          ].includes(parentKey)
+        ) {
+          consider(current);
+        }
+        return;
+      }
+
+      for (const [key, child] of Object.entries(current as Record<string, any>)) {
+        if (
+          [
+            "encrypted_content",
+            "ciphertext",
+            "encryption_key",
+            "encryption_nonce",
+            "instructions",
+            "input",
+            "input_schema",
+            "schema",
+            "definitions",
+            "properties",
+            "usage",
+            "verbosity",
+            "effort",
+            "format",
+          ].includes(key)
+        ) {
+          continue;
+        }
+        if (
+          [
+            "text",
+            "summary",
+            "refusal",
+            "thinking",
+            "content",
+            "value",
+            "body",
+            "markdown",
+            "delta",
+            "output_text",
+          ].includes(key)
+        ) {
+          consider(child);
+        }
+        visit(child, depth + 1, key, insideArguments || key === "arguments");
+      }
+    };
+
+    visit(value, 0);
+    return best;
+  }
+
+  private extractOutputTokens(responseValue: any): number {
+    return Number(responseValue?.usage?.output_tokens || 0);
+  }
+
+  private plausibleMinCharsForFallback(outputTokens: number): number {
+    if (outputTokens <= 12) {
+      return 2;
+    }
+    return Math.max(18, Math.min(200, Math.floor((outputTokens * 11) / 20)));
+  }
+
+  private isAssistiveNoiseToken(value: string): boolean {
+    return [
+      "detailed",
+      "medium",
+      "low",
+      "high",
+      "xhigh",
+      "auto",
+      "minimal",
+      "none",
+      "default",
+      "verbose",
+      "concise",
+      "text",
+      "json",
+      "markdown",
+    ].includes(value.toLowerCase());
+  }
+
+  private responsesStatusToFinishReason(
+    status?: string,
+    incompleteReason?: string
+  ): "stop" | "length" {
+    if (status === "incomplete" || status === "truncated") {
+      if (
+        !incompleteReason ||
+        incompleteReason === "max_output_tokens" ||
+        incompleteReason === "max_tokens"
+      ) {
+        return "length";
+      }
+    }
+    return "stop";
+  }
+
+  private responsesUsageToChatUsage(usage: any) {
+    const promptTokens = usage.input_tokens || 0;
+    const completionTokens = usage.output_tokens || 0;
+    return {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: usage.total_tokens || promptTokens + completionTokens,
+      prompt_tokens_details: {
+        cached_tokens:
+          usage.cache_read_input_tokens ||
+          usage.input_tokens_details?.cached_tokens ||
+          usage.prompt_tokens_details?.cached_tokens ||
+          0,
+      },
+    };
   }
 }

--- a/packages/core/src/transformer/openai.responses.transformer.ts
+++ b/packages/core/src/transformer/openai.responses.transformer.ts
@@ -321,6 +321,8 @@ export class OpenAIResponsesTransformer implements Transformer {
           };
           const pendingToolCalls = new Map<string, any>();
           const completedToolCallIds = new Set<string>();
+          const textDeltaKeys = new Set<string>();
+          const textDoneKeys = new Set<string>();
           let hasContent = false;
           let hasToolCall = false;
           let pendingEventType = "";
@@ -359,6 +361,33 @@ export class OpenAIResponsesTransformer implements Transformer {
                 },
               ],
             });
+          };
+
+          const textEventKey = (data: ResponsesStreamEvent) =>
+            [
+              data.item_id,
+              data.output_index,
+              data.content_index,
+            ]
+              .filter((value) => value !== undefined && value !== null)
+              .join(":") || data.type;
+
+          const enqueueFinalTextIfNeeded = (
+            data: ResponsesStreamEvent,
+            text: string,
+            eventType: string
+          ) => {
+            const key = textEventKey(data);
+            if (textDeltaKeys.has(key) || textDoneKeys.has(key)) {
+              return;
+            }
+            textDoneKeys.add(key);
+            enqueueTextChunk(
+              text,
+              eventType,
+              data.item_id,
+              data.response?.model
+            );
           };
 
           const enqueueToolCallChunk = (
@@ -469,6 +498,7 @@ export class OpenAIResponsesTransformer implements Transformer {
 
                       // 根据不同的事件类型转换为chat格式
                       if (data.type === "response.output_text.delta") {
+                        textDeltaKeys.add(textEventKey(data));
                         enqueueTextChunk(
                           transformer.extractTextValue(data.delta),
                           data.type,
@@ -476,21 +506,19 @@ export class OpenAIResponsesTransformer implements Transformer {
                           data.response?.model
                         );
                       } else if (data.type === "response.output_text.done") {
-                        enqueueTextChunk(
+                        enqueueFinalTextIfNeeded(
+                          data,
                           transformer.extractTextValue(data.text),
-                          data.type,
-                          data.item_id,
-                          data.response?.model
+                          data.type
                         );
                       } else if (
                         data.type === "response.content_part.done" &&
                         data.part
                       ) {
-                        enqueueTextChunk(
+                        enqueueFinalTextIfNeeded(
+                          data,
                           transformer.extractTextFromContentPart(data.part),
-                          data.type,
-                          data.item_id,
-                          data.response?.model
+                          data.type
                         );
                       } else if (
                         data.type === "response.output_item.added" &&

--- a/packages/core/src/utils/converter.ts
+++ b/packages/core/src/utils/converter.ts
@@ -10,6 +10,8 @@ import {
   AnthropicChatRequest,
   ConversionOptions,
 } from "../types/llm";
+import { normalizeToolInputSchema } from "./tool-schema";
+import { sanitizeToolInput } from "./tool-sanitizer";
 
 // Simple logger function
 function log(...args: any[]) {
@@ -34,7 +36,10 @@ export function convertToolsToAnthropic(tools: UnifiedTool[]): AnthropicTool[] {
   return tools.map((tool) => ({
     name: tool.function.name,
     description: tool.function.description,
-    input_schema: tool.function.parameters,
+    input_schema: normalizeToolInputSchema(
+      tool.function.name,
+      tool.function.parameters
+    ),
   }));
 }
 
@@ -59,7 +64,7 @@ export function convertToolsFromAnthropic(
     function: {
       name: tool.name,
       description: tool.description || "",
-      parameters: tool.input_schema as any,
+      parameters: normalizeToolInputSchema(tool.name, tool.input_schema),
     },
   }));
 }
@@ -196,7 +201,7 @@ export function convertFromOpenAI(
           type: "function" as const,
           function: {
             name: call.name,
-            arguments: JSON.stringify(call.input || {}),
+            arguments: JSON.stringify(sanitizeToolInput(call.name, call.input || {})),
           },
         }));
 
@@ -313,7 +318,9 @@ export function convertFromAnthropic(
             type: "function" as const,
             function: {
               name: block.name,
-              arguments: JSON.stringify(block.input || {}),
+              arguments: JSON.stringify(
+                sanitizeToolInput(block.name, block.input || {})
+              ),
             },
           });
         } else if (block.type === "tool_result") {

--- a/packages/core/src/utils/tool-sanitizer.ts
+++ b/packages/core/src/utils/tool-sanitizer.ts
@@ -1,0 +1,76 @@
+export function sanitizeToolInput(toolName: string, input: unknown): unknown {
+  if (!isPlainObject(input)) {
+    return input;
+  }
+
+  const sanitized: Record<string, any> = { ...input };
+  removeTopLevelNulls(sanitized);
+
+  if (toolName === "Read") {
+    sanitizeReadInput(sanitized);
+  }
+
+  if (toolName === "TodoWrite") {
+    sanitizeTodoWriteInput(sanitized);
+  }
+
+  return sanitized;
+}
+
+function removeTopLevelNulls(input: Record<string, any>) {
+  for (const key of Object.keys(input)) {
+    if (input[key] === null) {
+      delete input[key];
+    }
+  }
+}
+
+function sanitizeReadInput(input: Record<string, any>) {
+  if (input.pages === "") {
+    delete input.pages;
+    return;
+  }
+
+  const filePath = typeof input.file_path === "string" ? input.file_path : "";
+  const isPdf = filePath.toLowerCase().endsWith(".pdf");
+  if (!isPdf) {
+    delete input.pages;
+  }
+}
+
+function sanitizeTodoWriteInput(input: Record<string, any>) {
+  if (!Array.isArray(input.todos)) {
+    return;
+  }
+
+  for (const todo of input.todos) {
+    if (!isPlainObject(todo)) {
+      continue;
+    }
+
+    const content =
+      typeof todo.content === "string" && todo.content.length > 0
+        ? todo.content
+        : undefined;
+    const activeForm =
+      typeof todo.activeForm === "string" && todo.activeForm.length > 0
+        ? todo.activeForm
+        : undefined;
+
+    if (!content && activeForm) {
+      todo.content = activeForm;
+    }
+
+    if (!activeForm && content) {
+      todo.activeForm = content;
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}

--- a/packages/core/src/utils/tool-schema.ts
+++ b/packages/core/src/utils/tool-schema.ts
@@ -1,0 +1,62 @@
+export type JsonObjectSchema = {
+  type: "object";
+  properties: Record<string, any>;
+  required?: string[];
+  additionalProperties?: boolean;
+  $schema?: string;
+};
+
+export function normalizeToolInputSchema(
+  toolName: string,
+  inputSchema: unknown
+): JsonObjectSchema {
+  if (isObjectSchema(inputSchema)) {
+    return inputSchema;
+  }
+
+  if (toolName === "WebSearch") {
+    return {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        allowed_domains: {
+          type: "array",
+          items: { type: "string" },
+        },
+        blocked_domains: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["query"],
+      additionalProperties: true,
+    };
+  }
+
+  if (toolName === "WebFetch") {
+    return {
+      type: "object",
+      properties: {
+        url: { type: "string" },
+        prompt: { type: "string" },
+      },
+      required: ["url"],
+      additionalProperties: true,
+    };
+  }
+
+  return {
+    type: "object",
+    properties: {},
+    additionalProperties: true,
+  };
+}
+
+function isObjectSchema(value: unknown): value is JsonObjectSchema {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as any).type === "object"
+  );
+}


### PR DESCRIPTION
## Summary

Improve CCR compatibility for OpenAI Responses API providers when serving Claude Code through the Anthropic Messages API surface.

This PR focuses on request/response conversion stability, streaming behavior, tool schema compatibility, tool input sanitization, and provider error observability.

## Changes

- Add shared tool input sanitization for converted tool calls.
- Add tool schema normalization for tools with missing `input_schema`, including `WebSearch`, `WebFetch`, and unknown tools.
- Improve Responses API request conversion with safer defaults:
  - non-empty `instructions`
  - `store=false`
  - `reasoning.summary=auto`
  - `text.verbosity=medium`
- Expand Responses JSON and SSE conversion support:
  - multiple function/tool calls
  - `response.done`
  - `response.output_text.done`
  - `response.content_part.done`
  - usage mapping
  - incomplete/max-token finish reason mapping
- Sanitize accumulated streaming tool arguments before emitting Anthropic `input_json_delta`.
- Improve provider error classification and logs for HTTP errors, timeouts, and request failures.
- Avoid duplicate final text when Responses streams emit both deltas and final full-text events.

## Testing

- Built `@CCR/shared`.
- Built `packages/core` successfully.
- Ran behavior checks for:
  - Responses JSON conversion
  - Responses SSE conversion
  - tool call sanitization
  - missing tool schema normalization
  - Chat Completions streaming tool argument accumulation
  - duplicate Responses final text prevention
- Verified mock Responses integration through CCR `/v1/messages`.
- Verified Claude Code CLI against a mock Responses upstream through CCR.
- Verified Claude Code CLI against a real OpenAI-compatible `/v1/responses` upstream through CCR.

## Notes

The text recovery fallback is intentionally conservative to avoid treating metadata, schemas, usage fields, or tool arguments as assistant-visible text.