### PR TITLE
feat(cli): load API keys from an env/secrets file before interpolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Example env file for Claude Code Router.
+#
+# Copy to ~/.claude-code-router/.env (loaded automatically), or point at it via
+# the "ENV_FILE" config key or the CCR_ENV_FILE environment variable.
+#
+# Values here populate the process environment BEFORE config.json interpolation,
+# so ${VAR} / $VAR placeholders in config.json resolve from this file. Variables
+# already exported in your shell take precedence over this file.
+#
+# Format: standard KEY=value lines. A leading `export `, surrounding single or
+# double quotes, blank lines, and `#` comments are all tolerated — so an existing
+# shell secrets file (export KEY='value') can be reused as-is.
+
+OPENAI_API_KEY=sk-your-openai-key
+OPENROUTER_API_KEY=sk-or-v1-your-openrouter-key
+GEMINI_API_KEY=your-gemini-key
+
+# `export` and quotes are fine too:
+# export DEEPSEEK_API_KEY='sk-your-deepseek-key'

--- a/README.md
+++ b/README.md
@@ -86,6 +86,34 @@ Claude Code Router supports environment variable interpolation for secure API ke
 
 This allows you to keep sensitive API keys in environment variables instead of hardcoding them in configuration files. The interpolation works recursively through nested objects and arrays.
 
+##### Loading variables from an env file
+
+By default the variables referenced above must already be present in the process
+environment (e.g. exported in your shell). To avoid exporting every key, Claude
+Code Router can load an env file into the environment **before** interpolation:
+
+- It automatically loads `~/.claude-code-router/.env` if it exists.
+- Override the location with the `ENV_FILE` config key, which accepts a single
+  path or a list of paths (loaded in order):
+
+  ```json
+  {
+    "ENV_FILE": ["~/.secrets", "~/.claude-code-router/.env"],
+    "Providers": [
+      { "name": "openai", "api_key": "${OPENAI_API_KEY}", "...": "..." }
+    ]
+  }
+  ```
+
+- Or set the `CCR_ENV_FILE` environment variable to a path.
+
+The file uses standard `KEY=value` lines. A leading `export `, surrounding
+single/double quotes, blank lines, and `#` comments are all tolerated, so an
+existing shell secrets file (`export KEY='value'`) can be reused directly.
+Variables already present in the process environment take precedence over the
+file, so anything exported in your shell still wins. A `~` prefix expands to your
+home directory. See [`.env.example`](.env.example).
+
 Here is a comprehensive example:
 
 ```json

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import os from "node:os";
 import {
   CONFIG_FILE,
+  ENV_FILE,
   HOME_DIR, PID_FILE,
   PLUGINS_DIR,
   PRESETS_DIR,
@@ -37,6 +38,60 @@ const interpolateEnvVars = (obj: any): any => {
     return result;
   }
   return obj;
+};
+
+// Expand a leading ~ to the user's home directory.
+const expandHome = (p: string): string =>
+  p.startsWith("~/") || p === "~" ? path.join(os.homedir(), p.slice(1)) : p;
+
+// Parse a dotenv-style / shell-style file into key/value pairs. Tolerates a
+// leading `export `, surrounding single or double quotes, blank lines, and
+// `#` comments — so an existing shell `~/.secrets` (export KEY='val') works.
+const parseEnvContent = (content: string): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) continue;
+    let value = match[2].trim();
+    const quote = value[0];
+    if ((quote === '"' || quote === "'") && value[value.length - 1] === quote) {
+      value = value.slice(1, -1);
+    }
+    out[match[1]] = value;
+  }
+  return out;
+};
+
+// Load one or more env files into process.env before config interpolation.
+// Existing process.env values win, so a var exported in the shell overrides
+// the file (preserving prior behavior for users who already export keys).
+const loadEnvFiles = (envFileSetting?: string | string[]): void => {
+  const fromSetting = Array.isArray(envFileSetting)
+    ? envFileSetting
+    : envFileSetting
+    ? [envFileSetting]
+    : [];
+  const fromEnv = process.env.CCR_ENV_FILE ? [process.env.CCR_ENV_FILE] : [];
+  // Setting/env override the default; the default ~/.claude-code-router/.env is
+  // only used when nothing else is specified.
+  const files = fromSetting.length || fromEnv.length
+    ? [...fromSetting, ...fromEnv]
+    : [ENV_FILE];
+
+  for (const file of files) {
+    const resolved = expandHome(file);
+    if (!existsSync(resolved)) continue;
+    try {
+      const parsed = parseEnvContent(readFileSync(resolved, "utf-8"));
+      for (const [key, value] of Object.entries(parsed)) {
+        if (!(key in process.env)) process.env[key] = value;
+      }
+    } catch (error) {
+      console.warn(`Failed to load env file ${resolved}:`, (error as Error).message);
+    }
+  }
 };
 
 const ensureDir = async (dir_path: string) => {
@@ -82,6 +137,10 @@ export const readConfigFile = async () => {
     try {
       // Try to parse with JSON5 first (which also supports standard JSON)
       const parsedConfig = JSON5.parse(config);
+      // Load env file(s) into process.env before interpolation so ${VAR}
+      // placeholders can resolve from a secrets file instead of requiring the
+      // user to export every key into the shell first.
+      loadEnvFiles(parsedConfig.ENV_FILE);
       // Interpolate environment variables in the parsed config
       return interpolateEnvVars(parsedConfig);
     } catch (parseError) {

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -2,9 +2,12 @@ import fs from "node:fs/promises";
 import readline from "node:readline";
 import JSON5 from "json5";
 import path from "node:path";
+import os from "node:os";
+import { existsSync, readFileSync } from "node:fs";
 import {
   CONFIG_FILE,
   DEFAULT_CONFIG,
+  ENV_FILE,
   HOME_DIR,
   PLUGINS_DIR,
 } from "@CCR/shared";
@@ -27,6 +30,60 @@ const interpolateEnvVars = (obj: any): any => {
     return result;
   }
   return obj;
+};
+
+// Expand a leading ~ to the user's home directory.
+const expandHome = (p: string): string =>
+  p.startsWith("~/") || p === "~" ? path.join(os.homedir(), p.slice(1)) : p;
+
+// Parse a dotenv-style / shell-style file into key/value pairs. Tolerates a
+// leading `export `, surrounding single or double quotes, blank lines, and
+// `#` comments — so an existing shell `~/.secrets` (export KEY='val') works.
+const parseEnvContent = (content: string): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const match = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) continue;
+    let value = match[2].trim();
+    const quote = value[0];
+    if ((quote === '"' || quote === "'") && value[value.length - 1] === quote) {
+      value = value.slice(1, -1);
+    }
+    out[match[1]] = value;
+  }
+  return out;
+};
+
+// Load one or more env files into process.env before config interpolation.
+// Existing process.env values win, so a var exported in the shell overrides
+// the file (preserving prior behavior for users who already export keys).
+const loadEnvFiles = (envFileSetting?: string | string[]): void => {
+  const fromSetting = Array.isArray(envFileSetting)
+    ? envFileSetting
+    : envFileSetting
+    ? [envFileSetting]
+    : [];
+  const fromEnv = process.env.CCR_ENV_FILE ? [process.env.CCR_ENV_FILE] : [];
+  // Setting/env override the default; the default ~/.claude-code-router/.env is
+  // only used when nothing else is specified.
+  const files = fromSetting.length || fromEnv.length
+    ? [...fromSetting, ...fromEnv]
+    : [ENV_FILE];
+
+  for (const file of files) {
+    const resolved = expandHome(file);
+    if (!existsSync(resolved)) continue;
+    try {
+      const parsed = parseEnvContent(readFileSync(resolved, "utf-8"));
+      for (const [key, value] of Object.entries(parsed)) {
+        if (!(key in process.env)) process.env[key] = value;
+      }
+    } catch (error) {
+      console.warn(`Failed to load env file ${resolved}:`, (error as Error).message);
+    }
+  }
 };
 
 const ensureDir = async (dir_path: string) => {
@@ -71,6 +128,10 @@ export const readConfigFile = async () => {
     try {
       // Try to parse with JSON5 first (which also supports standard JSON)
       const parsedConfig = JSON5.parse(config);
+      // Load env file(s) into process.env before interpolation so ${VAR}
+      // placeholders can resolve from a secrets file instead of requiring the
+      // user to export every key into the shell first.
+      loadEnvFiles(parsedConfig.ENV_FILE);
       // Interpolate environment variables in the parsed config
       return interpolateEnvVars(parsedConfig);
     } catch (parseError) {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,6 +5,10 @@ export const HOME_DIR = path.join(os.homedir(), ".claude-code-router");
 
 export const CONFIG_FILE = path.join(HOME_DIR, "config.json");
 
+// Default env file loaded into process.env before config interpolation.
+// Override with the `ENV_FILE` config key (string or string[]) or $CCR_ENV_FILE.
+export const ENV_FILE = path.join(HOME_DIR, ".env");
+
 export const PLUGINS_DIR = path.join(HOME_DIR, "plugins");
 
 export const PRESETS_DIR = path.join(HOME_DIR, "presets");


### PR DESCRIPTION
## Problem

`config.json` already supports `${VAR}` / `$VAR` interpolation, but the variables must already be present in the process environment. In practice users still have to `export` every key (or `source` a secrets file) before launching `ccr` — otherwise interpolation keeps the literal `"${VAR}"` string, which then fails upstream with no obvious cause.

The `useEnvFile`/`envPath` machinery in `packages/core/src/services/config.ts` looks like it would solve this, but `useEnvFile` defaults to `false` and is never enabled anywhere, and `envPath` isn't configurable — so there's no supported way to load a secrets file today.

## Change

Load an env file into `process.env` **before** interpolation runs in `readConfigFile`:

- Auto-loads `~/.claude-code-router/.env` if it exists (no-op otherwise — zero behavior change for existing users).
- `"ENV_FILE"` config key overrides the location; accepts a single path or an array of paths (loaded in order).
- `CCR_ENV_FILE` environment variable also overrides.

The parser tolerates a leading `export `, surrounding single/double quotes, blank lines and `#` comments, so an **existing shell secrets file** (`export KEY='value'`) can be reused directly:

```json
{
  "ENV_FILE": ["~/.secrets"],
  "Providers": [
    { "name": "openai", "api_key": "${OPENAI_API_KEY}", "...": "..." }
  ]
}
```

Variables already present in `process.env` take precedence over the file, so anything exported in the shell still wins (preserving current behavior). A leading `~` expands to the home directory.

## Files

- `packages/shared/src/constants.ts` — new `ENV_FILE` default constant.
- `packages/cli/src/utils/index.ts` — `parseEnvContent` / `loadEnvFiles` helpers, called before `interpolateEnvVars`.
- `.env.example` — example file (matches the existing `*.example.*` convention).
- `README.md` — docs under the Environment Variable Interpolation section.

## Notes

- No new dependencies; the parser is dependency-free.
- Backward compatible: if no env file exists and none is configured, behavior is unchanged.
- The `cli`/`shared` packages build cleanly with this change. (A pre-existing `bigint`/`ReactNode` type error in `packages/ui` and pre-existing implicit-any issues in `preset/install-github.ts` are unrelated to this PR.)