### PR TITLE
fix(server): prevent path traversal in log file endpoints

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,6 @@
 import Server, { calculateTokenCount, TokenizerService } from "@musistudio/llms";
 import { readConfigFile, writeConfigFile, backupConfigFile } from "./utils";
-import { join } from "path";
+import { join, resolve } from "path";
 import fastifyStatic from "@fastify/static";
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, rmSync } from "fs";
 import { homedir } from "os";
@@ -28,6 +28,8 @@ import AdmZip from "adm-zip";
 export const createServer = async (config: any): Promise<any> => {
   const server = new Server(config);
   const app = server.app;
+
+  const LOG_DIR = join(homedir(), ".claude-code-router", "logs");
 
   app.register(fastifyMultipart, {
     limits: {
@@ -128,7 +130,7 @@ export const createServer = async (config: any): Promise<any> => {
   // Get log file list endpoint
   app.get("/api/logs/files", async (req: any, reply: any) => {
     try {
-      const logDir = join(homedir(), ".claude-code-router", "logs");
+      const logDir = LOG_DIR;
       const logFiles: Array<{ name: string; path: string; size: number; lastModified: string }> = [];
 
       if (existsSync(logDir)) {
@@ -166,11 +168,15 @@ export const createServer = async (config: any): Promise<any> => {
       let logFilePath: string;
 
       if (filePath) {
-        // If file path is specified, use the specified path
-        logFilePath = filePath;
+        // Resolve to absolute path and verify it stays within the log directory
+        logFilePath = resolve(LOG_DIR, filePath);
+        if (!logFilePath.startsWith(resolve(LOG_DIR) + "/") && logFilePath !== resolve(LOG_DIR)) {
+          reply.status(403).send({ error: "Access denied: path outside log directory" });
+          return;
+        }
       } else {
         // If file path is not specified, use default log file path
-        logFilePath = join(homedir(), ".claude-code-router", "logs", "app.log");
+        logFilePath = join(LOG_DIR, "app.log");
       }
 
       if (!existsSync(logFilePath)) {
@@ -194,11 +200,15 @@ export const createServer = async (config: any): Promise<any> => {
       let logFilePath: string;
 
       if (filePath) {
-        // If file path is specified, use the specified path
-        logFilePath = filePath;
+        // Resolve to absolute path and verify it stays within the log directory
+        logFilePath = resolve(LOG_DIR, filePath);
+        if (!logFilePath.startsWith(resolve(LOG_DIR) + "/") && logFilePath !== resolve(LOG_DIR)) {
+          reply.status(403).send({ error: "Access denied: path outside log directory" });
+          return;
+        }
       } else {
         // If file path is not specified, use default log file path
-        logFilePath = join(homedir(), ".claude-code-router", "logs", "app.log");
+        logFilePath = join(LOG_DIR, "app.log");
       }
 
       if (existsSync(logFilePath)) {


### PR DESCRIPTION
## Summary

The `GET /api/logs` and `DELETE /api/logs` endpoints in `packages/server/src/server.ts` accept a `?file=` query parameter that is used directly as a filesystem path with no validation. This is a path traversal vulnerability (CWE-22) that allows reading arbitrary files via `readFileSync` and truncating arbitrary files to empty via `writeFileSync`.

## Vulnerability Details

**Affected file:** `packages/server/src/server.ts` (lines 163–210 on `main`)
**Affected endpoints:** `GET /api/logs?file=<path>` and `DELETE /api/logs?file=<path>`
**CWE:** CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)

The `file` query parameter flows directly into `readFileSync()` and `writeFileSync()` with no path containment:

```typescript
// GET /api/logs handler (line 165 on main)
const filePath = (req.query as any).file as string;
// ...
logFilePath = filePath;  // ← user input used directly
// ...
const logContent = readFileSync(logFilePath, 'utf8');  // arbitrary file read
```

```typescript
// DELETE /api/logs handler (line 193 on main)
const filePath = (req.query as any).file as string;
// ...
logFilePath = filePath;  // ← user input used directly
// ...
writeFileSync(logFilePath, '', 'utf8');  // arbitrary file truncation to empty
```

### Authentication context

The auth middleware in `packages/server/src/middleware/auth.ts` skips authentication entirely when no providers are configured:

```typescript
const providers = config.Providers || config.providers || [];
if (!providers || providers.length === 0) {
  return done(); // No providers configured, skip authentication
}
```

And in `packages/server/src/index.ts` (lines 107–109), the server binds to `0.0.0.0` in this state:

```typescript
} else {
  HOST = "0.0.0.0";
  console.log("No providers configured. Listening on 0.0.0.0 without authentication.");
}
```

This means during initial setup (before any provider is configured), the server is network-accessible on all interfaces with zero authentication — making this vulnerability exploitable by any host on the network.

Even after providers are configured, if `APIKEY` is not set, the server falls back to CORS-based origin checking (localhost only), which is trivially bypassed by any non-browser client (curl, scripts, other processes on the machine).

## Proof of Concept

Against a claude-code-router instance in initial setup (no providers configured, listening on `0.0.0.0:3456`):

**Read arbitrary file:**
```bash
# Read /etc/passwd via path traversal
curl -s "http://<host>:3456/api/logs?file=/etc/passwd"

# Or using relative traversal from any working directory context
curl -s "http://<host>:3456/api/logs?file=../../../etc/passwd"
```

**Truncate arbitrary file to empty:**
```bash
# Truncate a target file to zero bytes
curl -s -X DELETE "http://<host>:3456/api/logs?file=/etc/hostname"
```

Both requests return 200 with the file contents (GET) or `{"success":true}` (DELETE). No authentication header is needed during initial setup.

## Fix Description

This PR adds path containment validation to both endpoints:

1. **Defines a canonical `LOG_DIR`** constant (`~/.claude-code-router/logs`) once at server creation, avoiding repetition.

2. **Resolves the user-supplied path** against `LOG_DIR` using `path.resolve(LOG_DIR, filePath)`, which normalizes traversal sequences like `../`.

3. **Validates containment** by checking that the resolved path starts with the resolved `LOG_DIR` + `/`. If the path escapes the log directory, the endpoint returns `403 Access denied`.

4. The same validation is applied to both `GET /api/logs` and `DELETE /api/logs`.

The fix is minimal (18 insertions, 8 deletions in a single file) and preserves the existing behavior for legitimate log file access within the log directory.

## Testing

We verified the fix by reviewing the patched code paths:

- `path.resolve(LOG_DIR, "../../etc/passwd")` resolves to `/etc/passwd`, which does NOT start with the resolved `LOG_DIR` path, so the request is correctly blocked with 403.
- `path.resolve(LOG_DIR, "app.log")` resolves to `~/.claude-code-router/logs/app.log`, which starts with `LOG_DIR`, so legitimate access continues to work.
- `path.resolve(LOG_DIR, "/etc/passwd")` (absolute path injection) resolves to `/etc/passwd`, which is also correctly blocked.
- The default path (no `?file=` parameter) continues to use `join(LOG_DIR, "app.log")` and is unaffected.

## Adversarial Review

Before submitting, we attempted to disprove this finding by examining whether existing protections would prevent exploitation. The `apiKeyAuth` middleware does gate API endpoints — but it explicitly skips authentication when no providers are configured (`providers.length === 0`), and the server binds to `0.0.0.0` in that state. Even with providers configured, omitting `APIKEY` only enforces CORS origin checks, which don't apply to non-browser clients. The path traversal itself has no other mitigation — `req.query.file` flows directly to `readFileSync`/`writeFileSync` with no sanitization, allowlist, or path normalization anywhere in the call chain.