### PR TITLE
fix(reasoning): handle reasoning_details + reasoning fields (opt-in flag)

### DIFF
--- a/packages/core/src/transformer/reasoning.transformer.ts
+++ b/packages/core/src/transformer/reasoning.transformer.ts
@@ -1,12 +1,72 @@
 import { UnifiedChatRequest } from "@/types/llm";
 import { Transformer, TransformerOptions } from "../types/transformer";
 
+// Bifrost normalizes vLLM/Anthropic reasoning into delta.reasoning_details[] (array of objects).
+// vLLM with --reasoning-parser also emits a flat delta.reasoning (string). Older
+// OpenAI-compatible servers used delta.reasoning_content (string). When `handleReasoningDetails`
+// is enabled, drain all three shapes and DELETE the consumed fields in place so downstream
+// consumers (e.g. Fastify reply.send) only see the rendered thinking block, never raw
+// object-arrays they can't serialize.
+function extractReasoningFromDelta(delta: any): { text: string; signature: string | null } {
+  let text = "";
+  let signature: string | null = null;
+  if (delta && typeof delta === "object") {
+    if (typeof delta.reasoning_content === "string") {
+      text += delta.reasoning_content;
+      delete delta.reasoning_content;
+    }
+    if (typeof delta.reasoning === "string") {
+      text += delta.reasoning;
+      delete delta.reasoning;
+    }
+    if (Array.isArray(delta.reasoning_details)) {
+      for (const item of delta.reasoning_details) {
+        if (item && typeof item === "object") {
+          if (typeof item.text === "string") text += item.text;
+          if (typeof item.signature === "string") signature = item.signature;
+        }
+      }
+      delete delta.reasoning_details;
+    }
+  }
+  return { text, signature };
+}
+
+function extractReasoningFromMessage(message: any): { text: string; signature: string | null } {
+  let text = "";
+  let signature: string | null = null;
+  if (message && typeof message === "object") {
+    if (typeof message.reasoning_content === "string") {
+      text += message.reasoning_content;
+    }
+    if (typeof message.reasoning === "string") {
+      text += message.reasoning;
+    }
+    if (Array.isArray(message.reasoning_details)) {
+      for (const item of message.reasoning_details) {
+        if (item && typeof item === "object") {
+          if (typeof item.text === "string") text += item.text;
+          if (typeof item.signature === "string") signature = item.signature;
+        }
+      }
+    }
+  }
+  return { text, signature };
+}
+
 export class ReasoningTransformer implements Transformer {
   static TransformerName = "reasoning";
   enable: any;
+  handleReasoningDetails: boolean;
 
   constructor(private readonly options?: TransformerOptions) {
     this.enable = this.options?.enable ?? true;
+    // Opt-in: when true, the transformer drains delta.reasoning + delta.reasoning_details[]
+    // (in addition to delta.reasoning_content) and produces a thinking block. When false
+    // (default), behaviour is unchanged. Default off so this is a purely additive change
+    // for existing config.
+    this.handleReasoningDetails =
+      (this.options as any)?.handleReasoningDetails ?? false;
   }
 
   async transformRequestIn(
@@ -32,14 +92,29 @@ export class ReasoningTransformer implements Transformer {
 
   async transformResponseOut(response: Response): Promise<Response> {
     if (!this.enable) return response;
+    const handleDetails = this.handleReasoningDetails;
     if (response.headers.get("Content-Type")?.includes("application/json")) {
       const jsonResponse = await response.json();
-      if (jsonResponse.choices[0]?.message.reasoning_content) {
-        jsonResponse.thinking = {
-          content: jsonResponse.choices[0]?.message.reasoning_content
+      if (handleDetails) {
+        const msg = jsonResponse.choices?.[0]?.message;
+        const { text: reasoningText, signature } = extractReasoningFromMessage(msg);
+        if (msg) {
+          // Strip raw fields so downstream consumers don't see object-arrays.
+          delete msg.reasoning_content;
+          delete msg.reasoning;
+          delete msg.reasoning_details;
+          if (reasoningText) {
+            jsonResponse.thinking = signature
+              ? { content: reasoningText, signature }
+              : { content: reasoningText };
+          }
         }
+      } else if (jsonResponse.choices[0]?.message.reasoning_content) {
+        // Original behaviour: only handle reasoning_content (string).
+        jsonResponse.thinking = {
+          content: jsonResponse.choices[0]?.message.reasoning_content,
+        };
       }
-      // Handle non-streaming response if needed
       return new Response(JSON.stringify(jsonResponse), {
         status: response.status,
         statusText: response.statusText,
@@ -53,6 +128,7 @@ export class ReasoningTransformer implements Transformer {
       const decoder = new TextDecoder();
       const encoder = new TextEncoder();
       let reasoningContent = "";
+      let reasoningSignature: string | null = null;
       let isReasoningComplete = false;
       let buffer = ""; // Buffer for incomplete data
 
@@ -82,6 +158,8 @@ export class ReasoningTransformer implements Transformer {
               encoder: typeof TextEncoder;
               reasoningContent: () => string;
               appendReasoningContent: (content: string) => void;
+              reasoningSignature: () => string | null;
+              setReasoningSignature: (sig: string | null) => void;
               isReasoningComplete: () => boolean;
               setReasoningComplete: (val: boolean) => void;
             }
@@ -93,33 +171,68 @@ export class ReasoningTransformer implements Transformer {
             if (line.startsWith("data: ") && line.trim() !== "data: [DONE]") {
               try {
                 const data = JSON.parse(line.slice(6));
-                console.log(JSON.stringify(data))
+                console.log(JSON.stringify(data));
 
-                // Extract reasoning_content from delta
-                if (data.choices?.[0]?.delta?.reasoning_content) {
-                  context.appendReasoningContent(
-                    data.choices[0].delta.reasoning_content
-                  );
-                  const thinkingChunk = {
-                    ...data,
-                    choices: [
-                      {
-                        ...data.choices[0],
-                        delta: {
-                          ...data.choices[0].delta,
-                          thinking: {
-                            content: data.choices[0].delta.reasoning_content,
+                if (handleDetails) {
+                  // Drain reasoning text from any of the three delta shapes:
+                  //   delta.reasoning_content (string, legacy)
+                  //   delta.reasoning (string, vLLM --reasoning-parser raw)
+                  //   delta.reasoning_details (array, Bifrost-normalized)
+                  // The helper DELETES the consumed fields from delta in-place, so the
+                  // forwarded chunk never carries an object-array a downstream like
+                  // Fastify reply.send() can't serialize.
+                  const { text: chunkReasoning, signature: chunkSignature } =
+                    extractReasoningFromDelta(data.choices?.[0]?.delta);
+                  if (chunkReasoning) {
+                    context.appendReasoningContent(chunkReasoning);
+                    if (chunkSignature) context.setReasoningSignature(chunkSignature);
+                    const thinkingChunk = {
+                      ...data,
+                      choices: [
+                        {
+                          ...data.choices[0],
+                          delta: {
+                            ...data.choices[0].delta,
+                            thinking: {
+                              content: chunkReasoning,
+                            },
                           },
                         },
-                      },
-                    ],
-                  };
-                  delete thinkingChunk.choices[0].delta.reasoning_content;
-                  const thinkingLine = `data: ${JSON.stringify(
-                    thinkingChunk
-                  )}\n\n`;
-                  controller.enqueue(encoder.encode(thinkingLine));
-                  return;
+                      ],
+                    };
+                    const thinkingLine = `data: ${JSON.stringify(
+                      thinkingChunk
+                    )}\n\n`;
+                    controller.enqueue(encoder.encode(thinkingLine));
+                    return;
+                  }
+                } else {
+                  // Original behaviour: only handle reasoning_content (string).
+                  if (data.choices?.[0]?.delta?.reasoning_content) {
+                    context.appendReasoningContent(
+                      data.choices[0].delta.reasoning_content
+                    );
+                    const thinkingChunk = {
+                      ...data,
+                      choices: [
+                        {
+                          ...data.choices[0],
+                          delta: {
+                            ...data.choices[0].delta,
+                            thinking: {
+                              content: data.choices[0].delta.reasoning_content,
+                            },
+                          },
+                        },
+                      ],
+                    };
+                    delete thinkingChunk.choices[0].delta.reasoning_content;
+                    const thinkingLine = `data: ${JSON.stringify(
+                      thinkingChunk
+                    )}\n\n`;
+                    controller.enqueue(encoder.encode(thinkingLine));
+                    return;
+                  }
                 }
 
                 // Check if reasoning is complete (when delta has content but no reasoning_content)
@@ -130,7 +243,10 @@ export class ReasoningTransformer implements Transformer {
                   !context.isReasoningComplete()
                 ) {
                   context.setReasoningComplete(true);
-                  const signature = Date.now().toString();
+                  // Prefer the upstream-supplied signature (from reasoning_details)
+                  // over a fabricated timestamp; fall back to Date.now() if missing.
+                  const signature =
+                    context.reasoningSignature() ?? Date.now().toString();
 
                   // Create a new chunk with thinking block
                   const thinkingChunk = {
@@ -210,6 +326,8 @@ export class ReasoningTransformer implements Transformer {
                     reasoningContent: () => reasoningContent,
                     appendReasoningContent: (content) =>
                       (reasoningContent += content),
+                    reasoningSignature: () => reasoningSignature,
+                    setReasoningSignature: (sig) => (reasoningSignature = sig),
                     isReasoningComplete: () => isReasoningComplete,
                     setReasoningComplete: (val) => (isReasoningComplete = val),
                   });


### PR DESCRIPTION
## Summary
Adds opt-in handling for the `delta.reasoning_details[]` array shape (Bifrost / OpenAI-compat normalized) and the flat `delta.reasoning` string (vLLM `--reasoning-parser`). When the new `handleReasoningDetails` option is set on the reasoning transformer, both new shapes are drained into the existing thinking block alongside the legacy `reasoning_content`, and the consumed fields are deleted from the forwarded delta.

## Why
Today the transformer only inspects `delta.reasoning_content`. When the upstream emits the newer array shape (e.g. Bifrost in front of vLLM with `--reasoning-parser qwen3` + a Qwen3 family model), the un-rendered object-array passes through and downstream consumers crash:

```
FastifyError: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.
    at qU (/app/packages/server/dist/index.js:51:23645)
    at ege (/app/packages/server/dist/index.js:51:22468)
```

This is the same class of issue tracked in #1397.

## Design
- Default off — purely additive, existing configs unchanged.
- Two helpers drain reasoning text from all three known shapes (`reasoning_content`, `reasoning`, `reasoning_details`) and delete the source fields in place.
- When the upstream supplied a `signature` field inside `reasoning_details`, prefer it over a fabricated `Date.now()` for the closing thinking block.
- Streaming path: helper runs once per chunk; the forwarded chunk carries only a thinking block.
- Non-streaming path: same logic at `message` level.

## Configuration
```json
["reasoning", { "enable": true, "handleReasoningDetails": true }]
```

## Test plan
- [x] Repro pre-patch: claude-code-router → Bifrost → vLLM 0.x `--reasoning-parser qwen3` + Qwen3 family. First reasoning chunk → `Attempted to send payload of invalid type 'object'` and the stream dies.
- [x] Post-patch with the opt-in: clean stream, thinking block delivered, tool calls preserved.
- [ ] Regression: existing configs without the opt-in continue to behave identically (default `false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)