### PR TITLE
docs: add Morph Model Router custom router example

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ module.exports = async function router(req, config) {
 };
 ```
 
+For a complete BYO-key custom router that asks Morph Model Router to choose the
+best provider/model for each eligible prompt, see
+[`examples/morph-router.cjs`](examples/morph-router.cjs) and the
+[Morph Model Router docs](docs/docs/server/advanced/morph-model-router.md).
+You can run `node examples/morph-router-smoke-test.cjs` to smoke-test it locally
+with mock Morph and provider services, or run
+`node examples/morph-router-claude-code-smoke-test.cjs` after `pnpm build` to
+verify routing through a real Claude Code request pointed at the branch-built
+CCR server.
+
 ##### Subagent Routing
 
 For routing within subagents, you must specify a particular provider and model by including `<CCR-SUBAGENT-MODEL>provider,model</CCR-SUBAGENT-MODEL>` at the **beginning** of the subagent's prompt. This allows you to direct specific subagent tasks to designated models.

--- a/docs/docs/server/advanced/custom-router.md
+++ b/docs/docs/server/advanced/custom-router.md
@@ -120,7 +120,12 @@ tail -f ~/.claude-code-router/claude-code-router.log
 
 Look for routing decisions to see which model is being selected.
 
+## Morph Model Router Example
+
+For an example that delegates prompt classification to Morph and returns a CCR
+route dynamically, see [Morph Model Router](/docs/server/advanced/morph-model-router).
+
 ## Next Steps
 
-- [Agents](/docs/advanced/agents) - Extend functionality with agents
-- [Presets](/docs/advanced/presets) - Use predefined configurations
+- [Routing](/docs/server/config/routing) - Configure built-in routing rules
+- [Presets](/docs/presets/intro) - Use predefined configurations

--- a/docs/docs/server/advanced/morph-model-router.md
+++ b/docs/docs/server/advanced/morph-model-router.md
@@ -1,0 +1,256 @@
+---
+sidebar_position: 2
+---
+
+# Morph Model Router
+
+Use [Morph Model Router](https://docs.morphllm.com/sdk/components/router#router-multimodel)
+as an optional bring-your-own-key custom router for Claude Code Router.
+
+CCR still sends the final model request to the provider you configure. Morph only
+receives the latest user text prompt and returns the single provider/model that
+should handle it.
+
+## How it works
+
+1. CCR receives a Claude Code request.
+2. CCR calls `CUSTOM_ROUTER_PATH` before its built-in scenario router.
+3. The Morph router script sends the latest user text prompt to Morph's
+   `/v1/router/multimodel` endpoint with your allowed models, allowed
+   providers, and policy.
+4. Morph returns a `{ provider, model }` decision.
+5. The script maps that decision to a CCR route like `openai,gpt-5.5`.
+6. CCR calls the selected provider using the provider keys in your CCR config.
+
+The integration is fail-open. If Morph is disabled, missing a key, times out, or
+returns a model that is not configured in CCR, the script returns a configured
+fallback route or `null` so CCR falls back to its normal `Router` behavior.
+
+## Install
+
+Copy the example custom router from this repository:
+
+```bash
+mkdir -p ~/.claude-code-router
+cp examples/morph-router.cjs ~/.claude-code-router/morph-router.cjs
+```
+
+Then set `CUSTOM_ROUTER_PATH` and `MORPH_ROUTER` in
+`~/.claude-code-router/config.json`:
+
+```json
+{
+  "CUSTOM_ROUTER_PATH": "/Users/you/.claude-code-router/morph-router.cjs",
+  "MORPH_ROUTER": {
+    "enabled": true,
+    "api_key": "$MORPH_API_KEY",
+    "policy": "balanced",
+    "allowed_models": [
+      "gpt-5.5",
+      "claude-haiku-4-5-20251001",
+      "claude-sonnet-4-6",
+      "claude-opus-4-8"
+    ],
+    "allowed_providers": [],
+    "default_model": "claude-sonnet-4-6",
+    "fallback": "openai,gpt-4.1",
+    "timeout_ms": 750,
+    "provider_map": {
+      "openai": "openai",
+      "anthropic": "anthropic",
+      "gemini": "gemini",
+      "deepseek": "deepseek"
+    },
+    "model_map": {}
+  },
+  "Providers": [
+    {
+      "name": "openai",
+      "api_base_url": "https://api.openai.com/v1/chat/completions",
+      "api_key": "$OPENAI_API_KEY",
+      "models": ["gpt-5.5", "gpt-4.1"]
+    },
+    {
+      "name": "anthropic",
+      "api_base_url": "https://api.anthropic.com/v1/messages",
+      "api_key": "$ANTHROPIC_API_KEY",
+      "models": [
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-6",
+        "claude-opus-4-8"
+      ],
+      "transformer": {
+        "use": ["Anthropic"]
+      }
+    }
+  ],
+  "Router": {
+    "default": "openai,gpt-4.1",
+    "background": "openai,gpt-4.1",
+    "think": "openai,gpt-4.1",
+    "longContext": "openai,gpt-4.1",
+    "webSearch": "openai,gpt-4.1",
+    "longContextThreshold": 60000
+  }
+}
+```
+
+You can also start from the copyable example:
+
+```bash
+cp examples/morph-router.config.example.json ~/.claude-code-router/config.json
+```
+
+Edit provider names, model names, and transformers to match the models your
+accounts can call.
+
+## Set keys
+
+```bash
+export MORPH_API_KEY="..."
+export OPENAI_API_KEY="..."
+export ANTHROPIC_API_KEY="..."
+```
+
+`MORPH_API_KEY` is only used to choose the route. CCR uses the provider keys
+when it calls the selected model.
+
+Keep keys in environment variables or your shell secret manager. The examples
+use `$MORPH_API_KEY`, `$OPENAI_API_KEY`, and `$ANTHROPIC_API_KEY` instead of
+hardcoding secrets.
+
+## Start CCR
+
+```bash
+ccr restart
+ccr status
+ccr code
+```
+
+## Local smoke test
+
+To verify the example without using real Morph or provider keys, run the
+included smoke test from the repository root:
+
+```bash
+node examples/morph-router-smoke-test.cjs
+```
+
+The smoke test starts a mock Morph router, a mock OpenAI-compatible provider,
+and a real CCR process with a temporary `HOME`. It sends requests through CCR's
+`/v1/messages` endpoint and checks that:
+
+- an eligible prompt routes through Morph to the selected provider model
+- an unconfigured Morph model falls back to the configured CCR fallback route
+- thinking requests keep CCR's built-in thinking route by default
+- `tool_result` content is not sent to Morph
+
+If you want to test a locally built CCR binary instead of the `ccr` command on
+your `PATH`, run:
+
+```bash
+pnpm build
+CCR_COMMAND=node CCR_COMMAND_ARGS=dist/cli.js node examples/morph-router-smoke-test.cjs
+```
+
+If you also have Claude Code installed, you can run an end-to-end acceptance
+test that starts the branch-built CCR CLI and points Claude Code at it:
+
+```bash
+pnpm build
+node examples/morph-router-claude-code-smoke-test.cjs
+```
+
+That test runs `node dist/cli.js start`, invokes `claude --print` with
+`ANTHROPIC_BASE_URL` set to the local CCR server, and verifies that Claude Code's
+request reaches the provider model selected by the Morph custom router.
+
+## Configuration reference
+
+| Field | Default | Description |
+|---|---:|---|
+| `enabled` | `false` | Enables Morph routing when true. |
+| `api_key` | `$MORPH_API_KEY` | Morph API key or environment variable reference. |
+| `endpoint` | `https://api.morphllm.com/v1/router/multimodel` | Morph router endpoint. |
+| `policy` | `balanced` | One of `balanced`, `cost_efficient`, `capability_heavy`, or `domain_skills`. |
+| `allowed_models` | unset | Exact Morph model candidates. |
+| `allowed_providers` | unset | Provider candidates, such as `openai`, `anthropic`, `gemini`, or `deepseek`. |
+| `default_model` | unset | Model Morph returns for ambiguous prompts. |
+| `fallback` | `null` | CCR route to use if Morph fails, such as `openai,gpt-4.1`. If unset, CCR's normal router handles fallback. |
+| `timeout_ms` | `750` | Morph router timeout. |
+| `max_input_chars` | `24000` | Character cap for the prompt sent to Morph. |
+| `provider_map` | identity | Maps Morph providers to CCR provider names. |
+| `model_map` | identity | Maps Morph model names to CCR model names. |
+| `allow_unconfigured_routes` | `false` | Return Morph routes even when not present in CCR `Providers`. |
+
+## Preserving CCR routes
+
+The example preserves CCR's built-in routing by default for:
+
+- explicit `/model provider,model` selections
+- subagent `<CCR-SUBAGENT-MODEL>` directives
+- thinking requests
+- web-search requests
+- long-context requests
+- background Haiku requests
+
+Set `route_thinking`, `route_web_search`, `route_long_context`, or
+`route_background` to `true` in `MORPH_ROUTER` if you want Morph to override one
+of those scenarios.
+
+## Mapping model names
+
+If Morph returns a model name that differs from your CCR provider config, map it:
+
+```json
+{
+  "MORPH_ROUTER": {
+    "model_map": {
+      "gpt-5.5": "gpt-5.5-chat-latest",
+      "anthropic:claude-sonnet-4-6": "claude-sonnet-4-20250514"
+    }
+  }
+}
+```
+
+`provider:model` mappings take precedence over generic model mappings.
+
+## Privacy and logs
+
+The example sends only text prompt parts to Morph. It skips tool results,
+images, and other non-text blocks, and removes Claude Code system reminders and
+CCR subagent route directives before calling Morph.
+
+If Morph returns an error, the script logs only the HTTP status, not the response
+body, so an upstream error that echoes prompt text does not write that prompt to
+CCR logs.
+
+## Turn it off
+
+Use either option:
+
+```json
+{
+  "MORPH_ROUTER": {
+    "enabled": false
+  }
+}
+```
+
+or remove `CUSTOM_ROUTER_PATH` from `config.json`.
+
+Restart after changing config:
+
+```bash
+ccr restart
+```
+
+## Troubleshooting
+
+- If Morph is not called, check `MORPH_ROUTER.enabled`,
+  `MORPH_API_KEY`, `CUSTOM_ROUTER_PATH`, and that `ccr restart` was run.
+- If Morph returns a model CCR cannot call, add it to the matching provider,
+  add a `model_map`, or set a configured `fallback`.
+- If CCR still uses its normal route, check whether the request is a preserved
+  scenario such as thinking, web search, long context, background, explicit
+  `/model`, or subagent routing.

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/advanced/custom-router.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/server/advanced/custom-router.md
@@ -144,5 +144,5 @@ tail -f ~/.claude-code-router/claude-code-router.log
 
 ## 下一步
 
-- [Agent](/zh/docs/advanced/agents) - 使用 Agent 扩展功能
-- [预设](/zh/docs/advanced/presets) - 使用预定义配置
+- [路由](/docs/server/config/routing) - 配置内置路由规则
+- [预设](/docs/presets/intro) - 使用预定义配置

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -106,6 +106,7 @@ const sidebars: SidebarsConfig = {
           },
           items: [
             'server/advanced/custom-router',
+            'server/advanced/morph-model-router',
           ],
         },
       ],

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,20 @@
 
 ## 示例文件
 
+### 0. `morph-router.cjs` - Morph Model Router custom router
+
+Optional BYO-key custom router that calls Morph's `/v1/router/multimodel`
+endpoint, maps the returned `{ provider, model }` decision to a CCR route, and
+falls back to CCR's normal router when disabled or unavailable.
+
+Pair it with `morph-router.config.example.json` and set `MORPH_API_KEY` in the
+shell that starts CCR. Run `node examples/morph-router-smoke-test.cjs` from the
+repository root for a local end-to-end smoke test that uses mock Morph and
+provider services. After `pnpm build`, run
+`node examples/morph-router-claude-code-smoke-test.cjs` to verify the same
+router through a real Claude Code `--print` request pointed at the branch-built
+CCR server.
+
 ### 1. `simple-preset-example.json` - 简单示例
 适合初学者，展示了基本的动态配置功能：
 - 密码输入（API Key）

--- a/examples/morph-router-claude-code-smoke-test.cjs
+++ b/examples/morph-router-claude-code-smoke-test.cjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+/**
+ * Claude Code acceptance smoke test for examples/morph-router.cjs.
+ *
+ * This is stricter than morph-router-smoke-test.cjs:
+ * - it uses the branch-built CCR CLI at ./dist/cli.js
+ * - it runs the real `claude` CLI with ANTHROPIC_BASE_URL pointed at CCR
+ * - it proves Claude Code's request was routed to the provider model selected
+ *   by the Morph custom router
+ *
+ * Run `pnpm build` first so ./dist/cli.js exists.
+ */
+
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+const routerSource = path.join(__dirname, "morph-router.cjs");
+const localCcrCli = path.join(repoRoot, "dist", "cli.js");
+
+main().catch((error) => {
+  console.error(`\nFAIL ${error.message}`);
+  process.exitCode = 1;
+});
+
+async function main() {
+  if (!fs.existsSync(localCcrCli)) {
+    throw new Error("dist/cli.js is missing. Run `pnpm build` before this smoke test.");
+  }
+
+  await assertCommandExists("claude", ["--version"]);
+
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ccr-claude-code-morph-"));
+  const ccrHome = path.join(tempHome, ".claude-code-router");
+  fs.mkdirSync(ccrHome, { recursive: true });
+  fs.mkdirSync(path.join(tempHome, ".claude"), { recursive: true });
+
+  const routerTarget = path.join(ccrHome, "morph-router.cjs");
+  fs.copyFileSync(routerSource, routerTarget);
+
+  const morphCalls = [];
+  const providerCalls = [];
+  const cleanup = [];
+
+  try {
+    const morphServer = await startJsonServer(async ({ req, body }) => {
+      if (req.method !== "POST" || req.url !== "/v1/router/multimodel") {
+        return { status: 404, body: { error: "not found" } };
+      }
+
+      morphCalls.push({
+        input: body.input,
+        authorization: req.headers.authorization,
+      });
+
+      return {
+        body: {
+          model: "chosen-model",
+          provider: "openai",
+          difficulty: "medium",
+          confidence: 0.97,
+          ambiguity: "low",
+          ambiguity_confidence: 0.88,
+          domain: "coding",
+          domain_confidence: 0.92,
+        },
+      };
+    });
+    cleanup.push(() => morphServer.close());
+
+    const providerServer = await startJsonServer(async ({ req, body }) => {
+      providerCalls.push({
+        path: req.url,
+        model: body.model,
+        messages: body.messages,
+        authorization: req.headers.authorization,
+      });
+
+      return {
+        body: {
+          id: "chatcmpl-claude-code-morph-router-proof",
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1000),
+          model: body.model,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: `ROUTE_PROOF_OK provider_model=${body.model}`,
+              },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 8,
+            completion_tokens: 5,
+            total_tokens: 13,
+          },
+        },
+      };
+    });
+    cleanup.push(() => providerServer.close());
+
+    const ccrPort = await getFreePort();
+    writeConfig({
+      path: path.join(ccrHome, "config.json"),
+      port: ccrPort,
+      routerPath: routerTarget,
+      morphEndpoint: `${morphServer.url}/v1/router/multimodel`,
+      providerEndpoint: `${providerServer.url}/v1/chat/completions`,
+    });
+
+    console.log("CCR Morph Model Router Claude Code acceptance test");
+    console.log(`repo: ${repoRoot}`);
+    console.log(`temp HOME: ${tempHome}`);
+    console.log("");
+
+    console.log("$ HOME=<temp> node dist/cli.js start");
+    const ccrProcess = spawn(process.execPath, [localCcrCli, "start"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HOME: tempHome,
+        MORPH_API_KEY: "test-morph-key",
+        OPENAI_API_KEY: "test-openai-key",
+        NO_COLOR: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    cleanup.push(() => stopProcess(ccrProcess));
+
+    const ccrOutput = collectOutput(ccrProcess);
+    await waitForHttp(`http://127.0.0.1:${ccrPort}/health`, 15000);
+    console.log(`CCR dev endpoint: http://127.0.0.1:${ccrPort}/v1/messages`);
+    console.log(`mock Morph endpoint: ${morphServer.url}/v1/router/multimodel`);
+    console.log("");
+
+    const claudeArgs = [
+      "--bare",
+      "--print",
+      "--output-format",
+      "json",
+      "--model",
+      "claude-3-5-sonnet-20241022",
+      "--no-session-persistence",
+      "--prompt-suggestions",
+      "false",
+      "ROUTE_ME call CCR through Claude Code and return the provider proof.",
+    ];
+
+    console.log(
+      `$ ANTHROPIC_BASE_URL=http://127.0.0.1:${ccrPort} ANTHROPIC_API_KEY=<test> claude ${claudeArgs.join(" ")}`
+    );
+
+    const claude = await runCommand("claude", claudeArgs, {
+      cwd: repoRoot,
+      timeoutMs: 45000,
+      env: {
+        ...process.env,
+        HOME: tempHome,
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${ccrPort}`,
+        ANTHROPIC_AUTH_TOKEN: "test-client-key",
+        ANTHROPIC_API_KEY: "test-client-key",
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+        NO_COLOR: "1",
+      },
+    });
+
+    const claudeText = extractClaudeText(claude.stdout);
+    console.log("");
+    console.log("Claude Code output:");
+    console.log(claudeText || claude.stdout.trim());
+    if (claude.stderr.trim()) {
+      console.log("");
+      console.log("Claude Code stderr:");
+      console.log(claude.stderr.trim());
+    }
+
+    const providerCall = last(providerCalls);
+    const morphCall = last(morphCalls);
+
+    console.log("");
+    console.log("Route proof:");
+    console.log(`Morph calls: ${morphCalls.length}`);
+    console.log(`Morph input: ${morphCall?.input || "(none)"}`);
+    console.log(`Provider calls: ${providerCalls.length}`);
+    console.log(`Provider endpoint path: ${providerCall?.path || "(none)"}`);
+    console.log(`Provider received model: ${providerCall?.model || "(none)"}`);
+
+    if (ccrOutput.stderr.trim()) {
+      console.log("");
+      console.log("CCR stderr:");
+      console.log(ccrOutput.stderr.trim().split("\n").slice(-8).join("\n"));
+    }
+
+    if (morphCalls.length < 1) {
+      throw new Error(`expected at least one Morph call, got ${morphCalls.length}`);
+    }
+    if (!morphCalls.every((call) => call.input.includes("ROUTE_ME"))) {
+      throw new Error("Claude Code prompt did not reach Morph router");
+    }
+    if (providerCalls.length < 1) {
+      throw new Error(`expected at least one provider call, got ${providerCalls.length}`);
+    }
+    if (!providerCalls.every((call) => call.model === "chosen-model")) {
+      throw new Error(`expected every provider call to use chosen-model, got ${providerCalls.map((call) => call.model).join(", ")}`);
+    }
+    if (!claudeText.includes("ROUTE_PROOF_OK provider_model=chosen-model")) {
+      throw new Error("Claude Code did not print the mock provider proof response");
+    }
+
+    console.log("");
+    console.log("PASS Claude Code used branch-built CCR and routed to chosen-model");
+  } finally {
+    for (const item of cleanup.reverse()) {
+      await item().catch?.(() => {});
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+}
+
+function writeConfig({ path: configPath, port, routerPath, morphEndpoint, providerEndpoint }) {
+  const config = {
+    PORT: port,
+    HOST: "127.0.0.1",
+    LOG: false,
+    API_TIMEOUT_MS: 10000,
+    CUSTOM_ROUTER_PATH: routerPath,
+    MORPH_ROUTER: {
+      enabled: true,
+      api_key: "$MORPH_API_KEY",
+      endpoint: morphEndpoint,
+      policy: "balanced",
+      allowed_providers: ["openai"],
+      default_model: "fallback-model",
+      fallback: "openai,fallback-model",
+      timeout_ms: 2000,
+    },
+    Providers: [
+      {
+        name: "openai",
+        api_base_url: providerEndpoint,
+        api_key: "$OPENAI_API_KEY",
+        models: ["chosen-model", "fallback-model"],
+        transformer: {
+          use: ["OpenAI"],
+        },
+      },
+    ],
+    Router: {
+      default: "openai,fallback-model",
+      background: "openai,fallback-model",
+      think: "openai,fallback-model",
+      longContext: "openai,fallback-model",
+      webSearch: "openai,fallback-model",
+      longContextThreshold: 60000,
+    },
+  };
+
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+async function assertCommandExists(command, args) {
+  const result = await runCommand(command, args, { timeoutMs: 10000 });
+  if (!result.stdout && !result.stderr) {
+    throw new Error(`Unable to run ${command}`);
+  }
+}
+
+async function runCommand(command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: options.cwd || repoRoot,
+    env: options.env || process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const output = collectOutput(child);
+  const timeoutMs = options.timeoutMs || 30000;
+  let timeout;
+
+  const exit = await Promise.race([
+    new Promise((resolve) => child.once("exit", (code, signal) => resolve({ code, signal }))),
+    new Promise((resolve) => {
+      timeout = setTimeout(() => {
+        child.kill("SIGTERM");
+        resolve({ code: null, signal: "TIMEOUT" });
+      }, timeoutMs);
+    }),
+  ]);
+
+  clearTimeout(timeout);
+
+  if (exit.signal === "TIMEOUT") {
+    throw new Error(`${command} timed out after ${timeoutMs}ms`);
+  }
+  if (exit.code !== 0) {
+    throw new Error(`${command} exited with ${exit.code}\n${output.stderr || output.stdout}`);
+  }
+
+  return output;
+}
+
+function collectOutput(child) {
+  const output = { stdout: "", stderr: "" };
+  child.stdout.on("data", (chunk) => {
+    output.stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    output.stderr += chunk.toString();
+  });
+  return output;
+}
+
+function extractClaudeText(stdout) {
+  const trimmed = stdout.trim();
+  if (!trimmed) return "";
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed.result || parsed.message || parsed.content || trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+function last(items) {
+  return items[items.length - 1];
+}
+
+async function startJsonServer(handler) {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const body = await readJson(req);
+      const result = await handler({ req, body });
+      const status = result.status || 200;
+      res.writeHead(status, {
+        "Content-Type": "application/json",
+      });
+      res.end(JSON.stringify(result.body || {}));
+    } catch (error) {
+      res.writeHead(500, {
+        "Content-Type": "application/json",
+      });
+      res.end(JSON.stringify({ error: error.message }));
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text ? JSON.parse(text) : {};
+}
+
+async function getFreePort() {
+  const server = http.createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitForHttp(url, timeoutMs) {
+  const start = Date.now();
+  let lastError;
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(250);
+  }
+
+  throw new Error(`Timed out waiting for ${url}: ${lastError?.message || "no response"}`);
+}
+
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    sleep(3000).then(() => {
+      if (child.exitCode === null) child.kill("SIGKILL");
+    }),
+  ]);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/examples/morph-router-smoke-test.cjs
+++ b/examples/morph-router-smoke-test.cjs
@@ -1,0 +1,453 @@
+#!/usr/bin/env node
+/**
+ * Local smoke test for examples/morph-router.cjs.
+ *
+ * The test runs entirely against local mock services:
+ * - a mock Morph Router API
+ * - a mock OpenAI-compatible provider
+ * - a real CCR process started with a temporary HOME
+ *
+ * It then sends Anthropic /v1/messages requests through CCR and asserts that
+ * Morph decisions become provider calls with the expected model.
+ */
+
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+const routerSource = path.join(__dirname, "morph-router.cjs");
+
+main().catch((error) => {
+  console.error(`\nFAIL ${error.message}`);
+  if (error.stack) console.error(error.stack.split("\n").slice(1).join("\n"));
+  process.exitCode = 1;
+});
+
+async function main() {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ccr-morph-router-smoke-"));
+  const ccrHome = path.join(tempHome, ".claude-code-router");
+  fs.mkdirSync(ccrHome, { recursive: true });
+
+  const routerTarget = path.join(ccrHome, "morph-router.cjs");
+  fs.copyFileSync(routerSource, routerTarget);
+
+  const morphCalls = [];
+  const providerCalls = [];
+  const cleanup = [];
+
+  try {
+    const morphServer = await startJsonServer(async ({ req, body }) => {
+      if (req.method !== "POST" || req.url !== "/v1/router/multimodel") {
+        return { status: 404, body: { error: "not found" } };
+      }
+
+      morphCalls.push({
+        input: body.input,
+        authorization: req.headers.authorization,
+        policy: body.policy,
+      });
+
+      if (body.input.includes("UNKNOWN_MODEL")) {
+        return {
+          body: decision("missing-model", "easy", 0.91),
+        };
+      }
+
+      return {
+        body: decision("chosen-model", "medium", 0.97),
+      };
+    });
+    cleanup.push(() => morphServer.close());
+
+    const providerServer = await startJsonServer(async ({ req, body }) => {
+      providerCalls.push({
+        path: req.url,
+        model: body.model,
+        messages: body.messages,
+        authorization: req.headers.authorization,
+      });
+
+      return {
+        body: {
+          id: "chatcmpl-morph-router-smoke",
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1000),
+          model: body.model,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: `mock provider handled ${body.model}`,
+              },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 8,
+            completion_tokens: 5,
+            total_tokens: 13,
+          },
+        },
+      };
+    });
+    cleanup.push(() => providerServer.close());
+
+    const ccrPort = await getFreePort();
+    writeConfig({
+      path: path.join(ccrHome, "config.json"),
+      port: ccrPort,
+      routerPath: routerTarget,
+      morphEndpoint: `${morphServer.url}/v1/router/multimodel`,
+      providerEndpoint: `${providerServer.url}/v1/chat/completions`,
+    });
+
+    const ccrProcess = startCcr({ tempHome });
+    cleanup.push(() => stopProcess(ccrProcess));
+    await waitForHttp(`http://127.0.0.1:${ccrPort}/health`, 15000);
+
+    console.log("CCR Morph Model Router smoke test");
+    console.log(`repo: ${repoRoot}`);
+    console.log(`temp HOME: ${tempHome}`);
+    console.log(`CCR endpoint: http://127.0.0.1:${ccrPort}/v1/messages`);
+    console.log(`mock Morph endpoint: ${morphServer.url}/v1/router/multimodel`);
+    console.log("");
+
+    const results = [];
+
+    const eligibleStart = morphCalls.length;
+    await sendCcrMessage(ccrPort, "ROUTE_ME choose the best coding model");
+    results.push(assertCase({
+      name: "eligible prompt routes through Morph",
+      morphDelta: morphCalls.length - eligibleStart,
+      morphInput: last(morphCalls).input,
+      providerModel: last(providerCalls).model,
+      expectedMorphDelta: 1,
+      expectedProviderModel: "chosen-model",
+    }));
+
+    const fallbackStart = morphCalls.length;
+    await sendCcrMessage(ccrPort, "UNKNOWN_MODEL demonstrate fallback");
+    results.push(assertCase({
+      name: "unconfigured Morph model falls back",
+      morphDelta: morphCalls.length - fallbackStart,
+      morphInput: last(morphCalls).input,
+      providerModel: last(providerCalls).model,
+      expectedMorphDelta: 1,
+      expectedProviderModel: "fallback-model",
+    }));
+
+    const thinkingStart = morphCalls.length;
+    await sendCcrMessage(ccrPort, "ROUTE_ME but preserve CCR thinking route", {
+      thinking: { type: "enabled", budget_tokens: 1024 },
+    });
+    results.push(assertCase({
+      name: "thinking request keeps CCR route",
+      morphDelta: morphCalls.length - thinkingStart,
+      morphInput: "(not called)",
+      providerModel: last(providerCalls).model,
+      expectedMorphDelta: 0,
+      expectedProviderModel: "fallback-model",
+    }));
+
+    const privacyStart = morphCalls.length;
+    await sendCcrMessage(ccrPort, [
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_secret",
+        content: "SECRET_TOOL_OUTPUT_SHOULD_NOT_REACH_MORPH",
+      },
+      {
+        type: "text",
+        text: "TOOL_PRIVACY_TEXT route this prompt only",
+      },
+    ]);
+    const privacyInput = last(morphCalls).input;
+    results.push(assertCase({
+      name: "tool_result content is not sent to Morph",
+      morphDelta: morphCalls.length - privacyStart,
+      morphInput: privacyInput,
+      providerModel: last(providerCalls).model,
+      expectedMorphDelta: 1,
+      expectedProviderModel: "chosen-model",
+      extraCheck: !privacyInput.includes("SECRET_TOOL_OUTPUT_SHOULD_NOT_REACH_MORPH"),
+      extraFailure: "secret tool output reached Morph input",
+    }));
+
+    printResults(results);
+
+    const failed = results.filter((result) => result.status !== "PASS");
+    if (failed.length) {
+      throw new Error(`${failed.length} smoke-test case(s) failed`);
+    }
+
+    if (last(morphCalls).authorization !== "Bearer test-morph-key") {
+      throw new Error("Morph API key was not resolved from MORPH_API_KEY");
+    }
+
+    console.log("");
+    console.log("PASS all smoke-test cases passed");
+  } finally {
+    for (const item of cleanup.reverse()) {
+      await item().catch?.(() => {});
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+}
+
+function decision(model, difficulty, confidence) {
+  return {
+    model,
+    provider: "openai",
+    difficulty,
+    confidence,
+    ambiguity: "low",
+    ambiguity_confidence: 0.88,
+    domain: "coding",
+    domain_confidence: 0.92,
+  };
+}
+
+function writeConfig({ path: configPath, port, routerPath, morphEndpoint, providerEndpoint }) {
+  const config = {
+    PORT: port,
+    HOST: "127.0.0.1",
+    LOG: false,
+    API_TIMEOUT_MS: 10000,
+    CUSTOM_ROUTER_PATH: routerPath,
+    MORPH_ROUTER: {
+      enabled: true,
+      api_key: "$MORPH_API_KEY",
+      endpoint: morphEndpoint,
+      policy: "balanced",
+      allowed_providers: ["openai"],
+      default_model: "fallback-model",
+      fallback: "openai,fallback-model",
+      timeout_ms: 2000,
+    },
+    Providers: [
+      {
+        name: "openai",
+        api_base_url: providerEndpoint,
+        api_key: "$OPENAI_API_KEY",
+        models: ["chosen-model", "fallback-model"],
+        transformer: {
+          use: ["OpenAI"],
+        },
+      },
+    ],
+    Router: {
+      default: "openai,fallback-model",
+      background: "openai,fallback-model",
+      think: "openai,fallback-model",
+      longContext: "openai,fallback-model",
+      webSearch: "openai,fallback-model",
+      longContextThreshold: 60000,
+    },
+  };
+
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+function startCcr({ tempHome }) {
+  const { command, args } = resolveCcrCommand();
+  const child = spawn(command, [...args, "start"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tempHome,
+      MORPH_API_KEY: "test-morph-key",
+      OPENAI_API_KEY: "test-openai-key",
+      NO_COLOR: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout.on("data", (chunk) => {
+    if (process.env.CCR_SMOKE_VERBOSE) process.stdout.write(chunk);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    if (process.env.CCR_SMOKE_VERBOSE) process.stderr.write(chunk);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (code && process.env.CCR_SMOKE_VERBOSE) {
+      console.error(`ccr exited with code ${code} signal ${signal}`);
+    }
+  });
+
+  return child;
+}
+
+function resolveCcrCommand() {
+  if (process.env.CCR_COMMAND) {
+    return {
+      command: process.env.CCR_COMMAND,
+      args: splitArgs(process.env.CCR_COMMAND_ARGS || ""),
+    };
+  }
+
+  const localCli = path.join(repoRoot, "dist", "cli.js");
+  if (fs.existsSync(localCli)) {
+    return { command: process.execPath, args: [localCli] };
+  }
+
+  return { command: "ccr", args: [] };
+}
+
+function splitArgs(value) {
+  if (!value.trim()) return [];
+  return value.match(/(?:[^\s"]+|"[^"]*")+/g).map((part) => part.replace(/^"|"$/g, ""));
+}
+
+async function sendCcrMessage(port, content, extra = {}) {
+  const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      max_tokens: 64,
+      messages: [{ role: "user", content }],
+      ...extra,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`CCR request failed with HTTP ${response.status}: ${await response.text()}`);
+  }
+
+  return response.json();
+}
+
+function assertCase({
+  name,
+  morphDelta,
+  morphInput,
+  providerModel,
+  expectedMorphDelta,
+  expectedProviderModel,
+  extraCheck = true,
+  extraFailure = "extra check failed",
+}) {
+  const failures = [];
+  if (morphDelta !== expectedMorphDelta) {
+    failures.push(`expected Morph calls +${expectedMorphDelta}, got +${morphDelta}`);
+  }
+  if (providerModel !== expectedProviderModel) {
+    failures.push(`expected provider model ${expectedProviderModel}, got ${providerModel}`);
+  }
+  if (!extraCheck) failures.push(extraFailure);
+
+  return {
+    status: failures.length ? "FAIL" : "PASS",
+    name,
+    morphCalls: `+${morphDelta}`,
+    morphInput,
+    providerModel,
+    failures,
+  };
+}
+
+function printResults(results) {
+  const rows = results.map((result) => ({
+    status: result.status,
+    case: result.name,
+    morph: result.morphCalls,
+    provider_model: result.providerModel,
+    morph_input: result.morphInput,
+  }));
+
+  console.table(rows);
+
+  for (const result of results) {
+    if (result.failures.length) {
+      console.error(`${result.name}: ${result.failures.join("; ")}`);
+    }
+  }
+}
+
+function last(items) {
+  return items[items.length - 1];
+}
+
+async function startJsonServer(handler) {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const body = await readJson(req);
+      const result = await handler({ req, body });
+      const status = result.status || 200;
+      res.writeHead(status, {
+        "Content-Type": "application/json",
+      });
+      res.end(JSON.stringify(result.body || {}));
+    } catch (error) {
+      res.writeHead(500, {
+        "Content-Type": "application/json",
+      });
+      res.end(JSON.stringify({ error: error.message }));
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text ? JSON.parse(text) : {};
+}
+
+async function getFreePort() {
+  const server = http.createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitForHttp(url, timeoutMs) {
+  const start = Date.now();
+  let lastError;
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(250);
+  }
+
+  throw new Error(`Timed out waiting for ${url}: ${lastError?.message || "no response"}`);
+}
+
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    sleep(3000).then(() => {
+      if (child.exitCode === null) child.kill("SIGKILL");
+    }),
+  ]);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/examples/morph-router.cjs
+++ b/examples/morph-router.cjs
@@ -1,0 +1,245 @@
+/**
+ * Optional Morph Model Router integration for Claude Code Router (CCR).
+ *
+ * Install by copying this file into ~/.claude-code-router/morph-router.cjs and
+ * setting CUSTOM_ROUTER_PATH in ~/.claude-code-router/config.json.
+ *
+ * This router is BYO-key and fail-open: if MORPH_ROUTER is disabled, the
+ * Morph API key is missing, Morph times out, or Morph returns a route that is
+ * not configured in CCR, it returns a configured fallback route or null so CCR
+ * falls back to its normal Router.
+ */
+
+const DEFAULT_ENDPOINT = "https://api.morphllm.com/v1/router/multimodel";
+const DEFAULT_TIMEOUT_MS = 750;
+const DEFAULT_MAX_INPUT_CHARS = 24000;
+
+module.exports = async function morphRouter(req, config) {
+  const options = config.MORPH_ROUTER || {};
+  if (!options.enabled) return null;
+
+  const apiKey = resolveSecret(options.api_key) || process.env.MORPH_API_KEY;
+  if (!apiKey) {
+    req.log?.debug?.("MORPH_ROUTER enabled but MORPH_API_KEY is not set");
+    return null;
+  }
+
+  if (shouldPreserveCcrRoute(req, config, options)) return null;
+
+  const input = extractLatestUserText(req.body?.messages || []);
+  if (!input) return null;
+
+  const payload = {
+    input: truncateForRouter(input, options.max_input_chars || DEFAULT_MAX_INPUT_CHARS),
+    policy: options.policy || "balanced",
+    default_model: options.default_model,
+    allowed_models: options.allowed_models,
+    allowed_providers: options.allowed_providers,
+  };
+
+  for (const key of Object.keys(payload)) {
+    if (payload[key] == null) delete payload[key];
+  }
+
+  try {
+    const decision = await callMorphRouter({
+      endpoint: options.endpoint || DEFAULT_ENDPOINT,
+      apiKey,
+      payload,
+      timeoutMs: options.timeout_ms || DEFAULT_TIMEOUT_MS,
+    });
+
+    const route = mapMorphDecisionToCcrRoute(decision, config, options);
+    if (!route) {
+      req.log?.warn?.({ decision }, "Morph router returned an unconfigured route");
+      return resolveFallbackRoute(config, options);
+    }
+
+    req.log?.info?.({ route, decision }, "Morph router selected CCR route");
+    return route;
+  } catch (error) {
+    req.log?.warn?.({ error: error.message }, "Morph router failed; falling back to CCR");
+    return resolveFallbackRoute(config, options);
+  }
+};
+
+function resolveSecret(value) {
+  if (!value || typeof value !== "string") return value;
+  const braced = value.match(/^\$\{([A-Z0-9_]+)\}$/i);
+  if (braced) return process.env[braced[1]];
+  const bare = value.match(/^\$([A-Z0-9_]+)$/i);
+  if (bare) return process.env[bare[1]];
+  return value;
+}
+
+function shouldPreserveCcrRoute(req, config, options) {
+  const body = req.body || {};
+  const router = config.Router || {};
+
+  if (typeof body.model === "string" && body.model.includes(",")) return true;
+
+  if (hasSubagentModelDirective(body)) return true;
+
+  if (!options.route_thinking && body.thinking) return true;
+
+  if (!options.route_web_search && hasWebSearchTool(body.tools)) return true;
+
+  const threshold = router.longContextThreshold || 60000;
+  if (!options.route_long_context && req.tokenCount && req.tokenCount > threshold) {
+    return true;
+  }
+
+  if (
+    !options.route_background &&
+    typeof body.model === "string" &&
+    body.model.includes("claude") &&
+    body.model.includes("haiku") &&
+    router.background
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function hasSubagentModelDirective(body) {
+  const system = body.system;
+  if (!system) return false;
+
+  const entries = Array.isArray(system) ? system : [system];
+  return entries.some((entry) => {
+    const text = typeof entry === "string" ? entry : entry?.text;
+    return typeof text === "string" && text.includes("<CCR-SUBAGENT-MODEL>");
+  });
+}
+
+function hasWebSearchTool(tools) {
+  if (!Array.isArray(tools)) return false;
+  return tools.some((tool) => {
+    const name = tool?.name || tool?.function?.name || "";
+    return tool?.type?.startsWith?.("web_search") || /web[_-]?search/.test(name.toLowerCase());
+  });
+}
+
+function extractLatestUserText(messages) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user") continue;
+
+    const text = contentToText(message.content)
+      .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+      .replace(/<CCR-SUBAGENT-MODEL>[\s\S]*?<\/CCR-SUBAGENT-MODEL>/g, "")
+      .trim();
+
+    if (text) return text;
+  }
+
+  return "";
+}
+
+function contentToText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part?.type === "text" && typeof part.text === "string") return part.text;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function truncateForRouter(input, maxChars) {
+  const configuredLimit = Number(maxChars);
+  const limit =
+    Number.isFinite(configuredLimit) && configuredLimit > 0
+      ? configuredLimit
+      : DEFAULT_MAX_INPUT_CHARS;
+
+  if (input.length <= limit) return input;
+
+  const marker = "\n\n[...truncated for Morph router...]\n\n";
+  if (limit <= marker.length) return input.slice(0, limit);
+
+  const keep = limit - marker.length;
+  const head = Math.ceil(keep / 2);
+  const tail = Math.floor(keep / 2);
+  return `${input.slice(0, head)}${marker}${input.slice(-tail)}`;
+}
+
+async function callMorphRouter({ endpoint, apiKey, payload, timeoutMs }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Morph router request failed with HTTP ${response.status}`);
+    }
+
+    const body = await response.json().catch(() => ({}));
+    return body;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function mapMorphDecisionToCcrRoute(decision, config, options) {
+  const provider = decision?.provider;
+  const model = decision?.model;
+  if (!provider || !model) return null;
+
+  const providerMap = options.provider_map || {};
+  const modelMap = options.model_map || {};
+
+  const ccrProvider = providerMap[provider] || provider;
+  const ccrModel =
+    modelMap[`${provider}:${model}`] ||
+    modelMap[`${provider}/${model}`] ||
+    modelMap[model] ||
+    model;
+
+  if (options.allow_unconfigured_routes || hasConfiguredModel(config, ccrProvider, ccrModel)) {
+    return `${ccrProvider},${ccrModel}`;
+  }
+
+  return null;
+}
+
+function hasConfiguredModel(config, providerName, modelName) {
+  const providers = config.Providers || config.providers || [];
+  const provider = providers.find((entry) => entry.name === providerName);
+  return Boolean(provider && Array.isArray(provider.models) && provider.models.includes(modelName));
+}
+
+function resolveFallbackRoute(config, options) {
+  if (!options.fallback) return null;
+  if (options.allow_unconfigured_routes) return options.fallback;
+
+  const [provider, ...modelParts] = options.fallback.split(",");
+  const model = modelParts.join(",");
+  if (!provider || !model) return null;
+
+  return hasConfiguredModel(config, provider, model) ? options.fallback : null;
+}
+
+module.exports._test = {
+  contentToText,
+  extractLatestUserText,
+  hasConfiguredModel,
+  mapMorphDecisionToCcrRoute,
+  resolveFallbackRoute,
+  shouldPreserveCcrRoute,
+  truncateForRouter,
+};

--- a/examples/morph-router.config.example.json
+++ b/examples/morph-router.config.example.json
@@ -1,0 +1,64 @@
+{
+  "CUSTOM_ROUTER_PATH": "/Users/you/.claude-code-router/morph-router.cjs",
+  "MORPH_ROUTER": {
+    "enabled": true,
+    "api_key": "$MORPH_API_KEY",
+    "policy": "balanced",
+    "allowed_models": [
+      "gpt-5.5",
+      "claude-haiku-4-5-20251001",
+      "claude-sonnet-4-6",
+      "claude-opus-4-8"
+    ],
+    "allowed_providers": [],
+    "default_model": "claude-sonnet-4-6",
+    "fallback": "openai,gpt-4.1",
+    "timeout_ms": 750,
+    "provider_map": {
+      "openai": "openai",
+      "anthropic": "anthropic",
+      "gemini": "gemini",
+      "deepseek": "deepseek"
+    },
+    "model_map": {
+      "gpt-5.5": "gpt-5.5",
+      "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
+      "claude-sonnet-4-6": "claude-sonnet-4-6",
+      "claude-opus-4-8": "claude-opus-4-8"
+    }
+  },
+  "Providers": [
+    {
+      "name": "openai",
+      "api_base_url": "https://api.openai.com/v1/chat/completions",
+      "api_key": "$OPENAI_API_KEY",
+      "models": [
+        "gpt-5.5",
+        "gpt-4.1"
+      ]
+    },
+    {
+      "name": "anthropic",
+      "api_base_url": "https://api.anthropic.com/v1/messages",
+      "api_key": "$ANTHROPIC_API_KEY",
+      "models": [
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-6",
+        "claude-opus-4-8"
+      ],
+      "transformer": {
+        "use": [
+          "Anthropic"
+        ]
+      }
+    }
+  ],
+  "Router": {
+    "default": "openai,gpt-4.1",
+    "background": "openai,gpt-4.1",
+    "think": "openai,gpt-4.1",
+    "longContext": "openai,gpt-4.1",
+    "webSearch": "openai,gpt-4.1",
+    "longContextThreshold": 60000
+  }
+}


### PR DESCRIPTION
## Summary

Adds a bring-your-own-key Morph Model Router example for CCR custom routing.

- adds `examples/morph-router.cjs`, a fail-open custom router that calls Morph's multimodel router and maps the returned `{ provider, model }` decision to a configured CCR route
- preserves CCR's explicit model, subagent, thinking, web-search, long-context, and background routes by default
- adds `examples/morph-router.config.example.json` plus docs/sidebar/README links
- adds two reproducible local validation scripts:
  - `node examples/morph-router-smoke-test.cjs` for local CCR + mock Morph/provider regression coverage
  - `node examples/morph-router-claude-code-smoke-test.cjs` after `pnpm build` for a real Claude Code request pointed at branch-built CCR via `ANTHROPIC_BASE_URL`

## Proof: real Morph + production CCR

This demo does **not** use the smoke-test scripts and does **not** mock Morph. It runs branch-built production CCR with `node dist/cli.js start`, installs `examples/morph-router.cjs` via `CUSTOM_ROUTER_PATH`, calls the real Morph endpoint at `https://api.morphllm.com/v1/router/multimodel`, and sends real `claude --bare --print` chats through CCR via `ANTHROPIC_BASE_URL`.

Only an OpenAI downstream key was available for provider calls, so the demo uses `provider_map` / `model_map` to map real Morph decisions onto real OpenAI models that CCR can call:

- `deepseek/deepseek-v4-flash` -> `openai,gpt-4.1-mini`
- `anthropic/claude-opus-4-8` -> `openai,gpt-4o`

The recording shows two chats in one production CCR session:

1. Easy prompt: Morph chose `deepseek/deepseek-v4-flash`, CCR routed to `openai,gpt-4.1-mini`
2. Hard architecture prompt: Morph chose `anthropic/claude-opus-4-8`, CCR routed to `openai,gpt-4o`

### Screen Recording

![Real Morph production CCR routing demo](https://raw.githubusercontent.com/shreybirmiwalmorph/claude-code-router/3e858bda1959d39bd5fabba1b3e68517de93a3ad/proof/morph-router/real-morph-production-demo.gif)

### Final Frame

![Real Morph production CCR routing final frame](https://raw.githubusercontent.com/shreybirmiwalmorph/claude-code-router/3e858bda1959d39bd5fabba1b3e68517de93a3ad/proof/morph-router/real-morph-production-demo-final.png)

### Repro Artifacts

- Real-Morph demo transcript: https://raw.githubusercontent.com/shreybirmiwalmorph/claude-code-router/3e858bda1959d39bd5fabba1b3e68517de93a3ad/proof/morph-router/real-morph-production-demo.txt
- Real-Morph asciinema cast: https://raw.githubusercontent.com/shreybirmiwalmorph/claude-code-router/3e858bda1959d39bd5fabba1b3e68517de93a3ad/proof/morph-router/real-morph-production-demo.cast

## Validation

- `npx -y pnpm@10.24.0 build`
- `git diff --check`
- `node --check examples/morph-router.cjs`
- `node --check examples/morph-router-smoke-test.cjs`
- `node --check examples/morph-router-claude-code-smoke-test.cjs`
- Parsed `examples/morph-router.config.example.json` with Node JSON parsing
- Strict secret-pattern scan across the new Morph router/example/docs files
- `node examples/morph-router-smoke-test.cjs`
- `node examples/morph-router-claude-code-smoke-test.cjs`
- Real Morph production CCR demo recorded above
- `npx -y pnpm@10.24.0 build:docs`

`build:docs` succeeds. It still prints pre-existing Docusaurus deprecation/blog/Browserslist warnings and unrelated broken-link warnings elsewhere in the docs tree.
