### PR TITLE
fix(anthropic): re-merge inline role:system messages into last user message

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -175,12 +175,13 @@ export class AnthropicTransformer implements Transformer {
           return;
         }
       } else if (msg.role === "system") {
-        // PATCH Trinity: rifondi i role:system INLINE nell'ultimo messaggio user
-        // invece di scartarli. Il forEach originale gestiva solo user/assistant, quindi
-        // i system inline (additionalContext degli hook UserPromptSubmit: skill, Hindsight)
-        // venivano persi nella conversione. I modelli non-Anthropic non vedono i system
-        // inline; spostarli nel canale user li rende efficaci. Il system prompt top-level
-        // (request.system) e' gestito sopra e non passa di qui.
+        // Inline role:system messages are silently dropped by this forEach because only
+        // "user" and "assistant" roles are handled. These inline system messages carry
+        // additional context injected by UserPromptSubmit hooks in Claude Code (e.g. tool
+        // hints, session context) and are distinct from the top-level request.system field
+        // (already handled above). Non-Anthropic providers do not recognize inline system
+        // messages, so we re-merge their text into the last user message to ensure the
+        // context reaches the model. If no user message exists yet, we create a synthetic one.
         const sysText =
           typeof msg.content === "string"
             ? msg.content

--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -174,6 +174,43 @@ export class AnthropicTransformer implements Transformer {
           }
           return;
         }
+      } else if (msg.role === "system") {
+        // PATCH Trinity: rifondi i role:system INLINE nell'ultimo messaggio user
+        // invece di scartarli. Il forEach originale gestiva solo user/assistant, quindi
+        // i system inline (additionalContext degli hook UserPromptSubmit: skill, Hindsight)
+        // venivano persi nella conversione. I modelli non-Anthropic non vedono i system
+        // inline; spostarli nel canale user li rende efficaci. Il system prompt top-level
+        // (request.system) e' gestito sopra e non passa di qui.
+        const sysText =
+          typeof msg.content === "string"
+            ? msg.content
+            : Array.isArray(msg.content)
+            ? msg.content
+                .filter((c: any) => c.type === "text" && c.text)
+                .map((c: any) => c.text)
+                .join("\n")
+            : "";
+        if (sysText && sysText.trim()) {
+          let lastUser: any = null;
+          for (let i = messages.length - 1; i >= 0; i--) {
+            if (messages[i].role === "user") {
+              lastUser = messages[i];
+              break;
+            }
+          }
+          const wrapped = `\n\n<injected-system-context>\n${sysText}\n</injected-system-context>`;
+          if (lastUser) {
+            if (typeof lastUser.content === "string") {
+              lastUser.content += wrapped;
+            } else if (Array.isArray(lastUser.content)) {
+              lastUser.content.push({ type: "text", text: wrapped });
+            } else {
+              lastUser.content = wrapped;
+            }
+          } else {
+            messages.push({ role: "user", content: wrapped });
+          }
+        }
       }
     });
 
@@ -570,6 +607,11 @@ export class AnthropicTransformer implements Transformer {
                       )
                     );
                     currentContentBlockIndex = -1;
+                    // I summary di reasoning di gpt-5.5 arrivano in piu' part: dopo la
+                    // signature il blocco e' chiuso, quindi va riaperto un nuovo
+                    // content_block_start per i thinking_delta del part successivo
+                    // (altrimenti puntano a index -1 -> "Content block not found").
+                    isThinkingStarted = false;
                   } else if (choice.delta.thinking.content) {
                     const thinkingChunk = {
                       type: "content_block_delta",


### PR DESCRIPTION
  Descrizione:

  ## Problem

  The `forEach` in `transformRequestOut` only handles `role: "user"` and
  `role: "assistant"` messages. Inline `role: "system"` messages are silently
  dropped during the Anthropic → unified conversion.

  These inline system messages are generated by Claude Code's `UserPromptSubmit`
  hooks via `additionalContext` — they carry per-prompt context such as tool
  hints and session state. They are distinct from the top-level `request.system`
  field (already handled correctly above the loop).

  Since non-Anthropic providers do not recognize inline system messages, this
  context never reaches the model when routing through any non-Anthropic provider
  (DeepSeek, OpenAI, Gemini, etc.).

  ## Fix

  Add an `else if (msg.role === "system")` branch in the `forEach` that extracts
  the text from inline system messages and appends it to the last user message,
  wrapped in an `<injected-system-context>` tag to keep it semantically distinct
  from the user's own text.

  Handles all three content formats:
  - `string` → append directly
  - `Array` of content blocks → push a new `{ type: "text" }` block
  - fallback → assign directly

  If no user message exists yet in the accumulated `messages` array, a synthetic
  user message is created so the context is never lost.

  ## Files changed

  - `packages/core/src/transformer/anthropic.transformer.ts`