### PR TITLE
feat(cli): add support for claude agents view mode

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,6 +30,7 @@ const KNOWN_COMMANDS = [
   "status",
   "statusline",
   "code",
+  "agents",
   "model",
   "preset",
   "install",
@@ -277,6 +278,7 @@ async function main() {
       await activateCommand();
       break;
     case "code":
+    case "agents":
       if (!isRunning) {
         console.log("Service not running, starting service...");
         const cliPath = join(__dirname, "cli.js");
@@ -293,7 +295,7 @@ async function main() {
         startProcess.unref();
 
         if (await waitForService()) {
-          const codeArgs = process.argv.slice(3);
+          const codeArgs = command === "agents" ? [command, ...process.argv.slice(3)] : process.argv.slice(3);
           executeCodeCommand(codeArgs);
         } else {
           console.error(
@@ -302,7 +304,7 @@ async function main() {
           process.exit(1);
         }
       } else {
-        const codeArgs = process.argv.slice(3);
+        const codeArgs = command === "agents" ? [command, ...process.argv.slice(3)] : process.argv.slice(3);
         executeCodeCommand(codeArgs);
       }
       break;

--- a/packages/cli/src/utils/codeCommand.ts
+++ b/packages/cli/src/utils/codeCommand.ts
@@ -100,7 +100,7 @@ export async function executeCodeCommand(
     : "inherit"; // Default inherited behavior
 
   const argsObj = minimist(args)
-  const argsArr = []
+  const argsArr = [...argsObj['_']]
   for (const [argsObjKey, argsObjValue] of Object.entries(argsObj)) {
     if (argsObjKey !== '_' && argsObj[argsObjKey]) {
       const prefix = argsObjKey.length === 1 ? '-' : '--';

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -43,8 +43,8 @@ function CommandDialog({
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
+        <DialogTitle>{title as React.ReactNode}</DialogTitle>
+        <DialogDescription>{description as React.ReactNode}</DialogDescription>
       </DialogHeader>
       <DialogContent
         className={cn("overflow-hidden p-0", className)}


### PR DESCRIPTION
This PR adds official support for running `ccr agents` to open Claude Code's Agents View Mode.\n\n### What this does:\n- Registers the `agents` sub-command inside `cli.ts` so it doesn't get flagged as an unknown command.\n- Modifies `codeCommand.ts` to preserve the raw positional arguments (extracted from minimist's `_` array) when spawning the downstream `claude` process. Previously, keyword commands like `agents` were stripped from the arguments list.\n- Fixes a TypeScript type mismatch in the UI package (`command.tsx`) where `title` and `description` props of type `ReactNode` were being assigned to component slots demanding narrower types, causing compilation errors during `pnpm run build`.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)