### PR TITLE
fix: increase Fastify keepAliveTimeout to prevent socket drops during long agentic sessions

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -54,6 +54,9 @@ interface ServerOptions extends FastifyServerOptions {
 function createApp(options: FastifyServerOptions = {}): FastifyInstance {
   const fastify = Fastify({
     bodyLimit: 50 * 1024 * 1024,
+    keepAliveTimeout: 650000,
+    connectionTimeout: 0,
+    requestTimeout: 0,
     ...options,
   });
 


### PR DESCRIPTION
## Problem

Claude Code agentic sessions that involve extended think-then-write cycles (e.g. 13–15 minutes of tool execution + reasoning) intermittently fail with:

> API Error: The socket connection was closed unexpectedly.

This is caused by Fastify's default `keepAliveTimeout` of 5000ms (5 seconds). When Claude Code's connection goes idle during a long local tool execution, Fastify closes the keep-alive connection. The next request from Claude Code arrives on a dead socket and throws.

This is a known issue in the Claude Code ecosystem for self-hosted router deployments, particularly when using local providers where long reasoning/tool chains are common.

## Fix

Set `keepAliveTimeout: 650000` (650 seconds) in `createApp()` so the connection outlives any reasonable agentic session. Also sets `connectionTimeout: 0` and `requestTimeout: 0` to remove other artificial timeout limits for long-running streaming requests.

These values are intentionally generous — the server is designed to be run locally or on a trusted LAN, not as a public-facing service.

## Impact

- No breaking changes
- `...options` spread means consumers can still override all three values if needed
- Fixes silent socket drop errors in long Claude Code sessions

## Tests

Not included: this repository currently has no test harness in `packages/core` (no vitest/jest/test script), so a unit test could not be added without first introducing a test framework. Happy to follow up with a `vitest` setup + a `createApp` keep-alive config test if the maintainers would like that as a separate PR.
