### PR TITLE
bugfix: Handle spaces in Windows paths for cmd.exe spawn and apiKeyHelper

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -58,7 +58,8 @@ async function main(): Promise<void> {
   const launch = profileLaunchSpawnCommand(plan);
   const child = spawn(launch.command, launch.args, {
     env: childEnv,
-    stdio: "inherit"
+    stdio: "inherit",
+    windowsVerbatimArguments: !!launch.windowsVerbatimArguments
   });
   const code = await waitForChild(child);
   process.exitCode = code;

--- a/src/main/profile-launch-core.ts
+++ b/src/main/profile-launch-core.ts
@@ -13,6 +13,7 @@ export type ProfileLaunchPlan = {
 export type ProfileLaunchSpawnCommand = {
   args: string[];
   command: string;
+  windowsVerbatimArguments?: boolean;
 };
 
 export function findProfileForOpen(config: Pick<AppConfig, "profile">, profileRef: string): ProfileConfig {
@@ -98,15 +99,14 @@ export function profileLaunchSpawnCommand(plan: Pick<ProfileLaunchPlan, "args" |
       command: plan.command
     };
   }
+  let cmdLine = `"${plan.command}"`;
+  if (plan.args && plan.args.length > 0) {
+    cmdLine += " " + plan.args.join(" ");
+  }
   return {
-    args: [
-      "/d",
-      "/s",
-      "/v:off",
-      "/c",
-      windowsCommandScriptInvocation(plan.command, plan.args)
-    ],
-    command: process.env.ComSpec || process.env.COMSPEC || "cmd.exe"
+    args: ["/d", "/v:off", "/c", cmdLine],
+    command: process.env.ComSpec || process.env.COMSPEC || "cmd.exe",
+    windowsVerbatimArguments: true
   };
 }
 

--- a/src/main/profile-service.ts
+++ b/src/main/profile-service.ts
@@ -77,7 +77,7 @@ function applyClaudeCodeProfile(config: AppConfig, profile: ProfileConfig, token
     const wrapperResult = writeClaudeCodeWrapper(config, profile);
     const nextSettings = {
       ...settings,
-      apiKeyHelper: helperResult.file,
+      apiKeyHelper: process.platform === "win32" ? `"${helperResult.file}"` : helperResult.file,
       env
     };
     const writeResult = writeFileWithBackup(settingsFile, `${JSON.stringify(nextSettings, null, 2)}\n`, { mode: privateFileMode });


### PR DESCRIPTION
Fix for https://github.com/musistudio/claude-code-router/issues/1459 and other issue with paths

Please check if this is correct. I'm not very strong in JavaScript.

I built and tested the project locally. Everything worked correctly.
