### PR TITLE
fix(groq): strip unsupported reasoning field from requests

### DIFF
--- a/packages/core/src/transformer/groq.transformer.ts
+++ b/packages/core/src/transformer/groq.transformer.ts
@@ -22,6 +22,10 @@ export class GroqTransformer implements Transformer {
         delete tool.function.parameters.$schema;
       })
     }
+    // Groq's OpenAI-compatible API rejects the reasoning field.
+    if (request.reasoning) {
+      delete request.reasoning;
+    }
     return request
   }
 


### PR DESCRIPTION
## Summary

Strip the top-level `reasoning` field in `GroqTransformer.transformRequestIn()` before forwarding requests to Groq.

Fixes #1458

## Motivation

Groq's OpenAI-compatible API rejects requests containing a `reasoning` field with:

```json
{ "error": { "message": "property 'reasoning' is unsupported", "type": "invalid_request_error" } }
```

When routing Claude Code through CCR to Groq, the anthropic transformer adds `reasoning` (effort/enabled) to the request body. `GroqTransformer` already strips `cache_control` and `$schema`, but not `reasoning`.

## Changes

- Delete `request.reasoning` in `packages/core/src/transformer/groq.transformer.ts`
- Mirrors the existing `CerebrasTransformer` pattern

## Tests

- Manual verification: `GroqTransformer.transformRequestIn()` removes `reasoning` from a sample request
- `npx tsx scripts/build.ts` in `packages/core` — build succeeded

## Notes

- Targets `feature/2.0` (npm `@musistudio/claude-code-router@2.0.0`) where the Groq transformer lives
- Composer-2.5 review: **APPROVE**
- If Groq later supports reasoning parameters, this strip may need to become model-conditional