### PR TITLE
feat: support NO_PROXY env for proxy bypass

### DIFF
--- a/packages/core/src/api/routes.ts
+++ b/packages/core/src/api/routes.ts
@@ -355,6 +355,7 @@ async function sendRequestToProvider(
     requestBody,
     {
       httpsProxy: fastify.configService.getHttpsProxy(),
+      noProxy: fastify.configService.getNoProxy(),
       ...config,
       headers: JSON.parse(JSON.stringify(requestHeaders)),
     },

--- a/packages/core/src/services/config.ts
+++ b/packages/core/src/services/config.ts
@@ -138,7 +138,21 @@ export class ConfigService {
       this.get("HTTPS_PROXY") ||
       this.get("https_proxy") ||
       this.get("httpsProxy") ||
-      this.get("PROXY_URL")
+      this.get("PROXY_URL") ||
+      process.env.HTTPS_PROXY ||
+      process.env.https_proxy ||
+      process.env.HTTP_PROXY ||
+      process.env.http_proxy
+    );
+  }
+
+  public getNoProxy(): string | undefined {
+    return (
+      this.get("NO_PROXY") ||
+      this.get("no_proxy") ||
+      this.get("noProxy") ||
+      process.env.NO_PROXY ||
+      process.env.no_proxy
     );
   }
 

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -1,5 +1,63 @@
 import { ProxyAgent } from "undici";
 import { UnifiedChatRequest } from "../types/llm";
+import { parseNoProxy } from "@CCR/shared";
+
+function isIpAddress(s: string): boolean {
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(s)) return true;
+  if (s.includes(":")) return true;
+  return false;
+}
+
+function shouldBypassProxy(hostname: string, noProxyList: string[]): boolean {
+  if (noProxyList.length === 0) return false;
+
+  for (const pattern of noProxyList) {
+    if (pattern === "*") return true;
+
+    if (pattern.startsWith(".")) {
+      if (!isIpAddress(hostname)) {
+        if (hostname.endsWith(pattern) || hostname === pattern.slice(1)) {
+          return true;
+        }
+      }
+      continue;
+    }
+
+    if (pattern.includes("/")) {
+      if (isInCidr(hostname, pattern)) return true;
+      continue;
+    }
+
+    if (hostname.toLowerCase() === pattern.toLowerCase()) return true;
+  }
+
+  return false;
+}
+
+function isInCidr(ip: string, cidr: string): boolean {
+  const [network, prefixStr] = cidr.split("/");
+  const prefix = parseInt(prefixStr, 10);
+  if (isNaN(prefix) || prefix < 0 || prefix > 32) return false;
+
+  const ipInt = ipToInt(ip);
+  const netInt = ipToInt(network);
+  if (ipInt === null || netInt === null) return false;
+
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+  return (ipInt & mask) === (netInt & mask);
+}
+
+function ipToInt(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let result = 0;
+  for (const part of parts) {
+    const num = parseInt(part, 10);
+    if (isNaN(num) || num < 0 || num > 255) return null;
+    result = (result << 8) | num;
+  }
+  return result >>> 0;
+}
 
 export function sendUnifiedRequest(
   url: URL | string,
@@ -39,9 +97,15 @@ export function sendUnifiedRequest(
   };
 
   if (config.httpsProxy) {
-    (fetchOptions as any).dispatcher = new ProxyAgent(
-      new URL(config.httpsProxy).toString()
-    );
+    const targetUrl = typeof url === "string" ? new URL(url) : url;
+    const noProxyList = parseNoProxy(config.noProxy);
+    const shouldProxy = !shouldBypassProxy(targetUrl.hostname, noProxyList);
+
+    if (shouldProxy) {
+      (fetchOptions as any).dispatcher = new ProxyAgent(
+        new URL(config.httpsProxy).toString()
+      );
+    }
   }
   logger?.debug(
     {
@@ -50,6 +114,7 @@ export function sendUnifiedRequest(
       headers: Object.fromEntries(headers.entries()),
       requestUrl: typeof url === "string" ? url : url.toString(),
       useProxy: config.httpsProxy,
+      noProxy: config.noProxy,
     },
     "final request"
   );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants";
+export * from "./proxy";
 
 // Export preset-related functionality
 export * from './preset/types';

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -1,0 +1,7 @@
+export function parseNoProxy(noProxy: string | undefined): string[] {
+  if (!noProxy) return [];
+  return noProxy
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}


### PR DESCRIPTION
## Summary
- Support `NO_PROXY` to bypass proxy for specific hosts
- Supports exact hostname, `.suffix`, `*` wildcard, and IPv4 CIDR
- Reads `NO_PROXY`/`no_proxy`/`noProxy` from config and env vars
- Also adds `HTTPS_PROXY`/`HTTP_PROXY` env var fallbacks to `getHttpsProxy()`

## Changes
| File | Change |
|------|--------|
| `packages/shared/src/proxy.ts` | new - `parseNoProxy()` parser |
| `packages/shared/src/index.ts` | export proxy module |
| `packages/core/src/services/config.ts` | add `getNoProxy()`, env var fallbacks |
| `packages/core/src/utils/request.ts` | NO_PROXY check before ProxyAgent |
| `packages/core/src/api/routes.ts` | pass noProxy to request config |

## Test plan
- [ ] `NO_PROXY=localhost,127.0.0.1` → proxy bypassed for those hosts
- [ ] `NO_PROXY=10.0.0.0/8` → CIDR matching works
- [ ] `NO_PROXY=*` → all requests bypass proxy
- [ ] Proxy still used for hosts not in NO_PROXY