### PR TITLE
feat: 支持 NO_PROXY 环境变量与 Linux 环境变量代理回退

### DIFF
--- a/src/main/system-proxy-fetch.ts
+++ b/src/main/system-proxy-fetch.ts
@@ -47,7 +47,11 @@ export async function getSystemProxyUrlForProtocol(protocol: "http" | "https" = 
 async function systemProxyUrlForRequest(url: URL): Promise<string | undefined> {
   const cache = await readSystemProxy();
   const server = proxyServerForRequest(cache.upstreamProxy, url.protocol === "https:" ? "https" : "http");
-  return server ? formatProxyUrl(server) : undefined;
+  if (server) return formatProxyUrl(server);
+
+  const envProxy = process.env.HTTPS_PROXY || process.env.https_proxy ||
+    process.env.HTTP_PROXY || process.env.http_proxy;
+  return envProxy ? envProxy.trim() : undefined;
 }
 
 async function readSystemProxy(): Promise<SystemProxyCache> {
@@ -187,12 +191,65 @@ function isHttpUrl(url: URL): boolean {
 
 function shouldBypassProxy(url: URL): boolean {
   const hostname = normalizeHostname(url.hostname);
-  return hostname === "localhost" ||
+  if (hostname === "localhost" ||
     hostname === "127.0.0.1" ||
     hostname.startsWith("127.") ||
     hostname === "0.0.0.0" ||
     hostname === "::1" ||
-    hostname === "0:0:0:0:0:0:0:1";
+    hostname === "0:0:0:0:0:0:0:1") {
+    return true;
+  }
+
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  if (!noProxy) return false;
+
+  const patterns = noProxy.split(",").map((s) => s.trim()).filter(Boolean);
+  for (const pattern of patterns) {
+    if (pattern === "*") return true;
+
+    if (pattern.startsWith(".")) {
+      if (hostname.endsWith(pattern.toLowerCase()) || hostname === pattern.slice(1).toLowerCase()) return true;
+      continue;
+    }
+
+    if (pattern.includes("/") && isPlainIp(hostname)) {
+      if (isInCidr(hostname, pattern)) return true;
+      continue;
+    }
+
+    if (hostname === pattern.toLowerCase()) return true;
+  }
+
+  return false;
+}
+
+function isPlainIp(s: string): boolean {
+  return /^\d+\.\d+\.\d+\.\d+$/.test(s);
+}
+
+function isInCidr(ip: string, cidr: string): boolean {
+  const [network, prefixStr] = cidr.split("/");
+  const prefix = parseInt(prefixStr, 10);
+  if (isNaN(prefix) || prefix < 0 || prefix > 32) return false;
+
+  const ipInt = ipToInt(ip);
+  const netInt = ipToInt(network);
+  if (ipInt === null || netInt === null) return false;
+
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+  return (ipInt & mask) === (netInt & mask);
+}
+
+function ipToInt(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let result = 0;
+  for (const part of parts) {
+    const num = parseInt(part, 10);
+    if (isNaN(num) || num < 0 || num > 255) return null;
+    result = (result << 8) | num;
+  }
+  return result >>> 0;
 }
 
 function normalizeHostname(hostname: string): string {


### PR DESCRIPTION
## 概述

本 PR 解决了两个在 Linux 上使用 CCR 时遇到的网络问题：

1. **NO_PROXY 环境变量不被识别** — `shouldBypassProxy` 只硬编码了 localhost/127.0.0.1，用户通过 `NO_PROXY` 配置的排除规则不生效
2. **Linux 上 HTTPS_PROXY 环境变量被忽略** — `fetchWithSystemProxy` 只读取系统代理配置（macOS/Win），Linux 上无法使用环境变量配置的代理

## 改动

**`src/main/system-proxy-fetch.ts`** — +60 / -3

### 1. NO_PROXY 支持
- `shouldBypassProxy()` 现在会读取 `NO_PROXY` / `no_proxy` 环境变量
- 支持标准 NO_PROXY 语法：
  - 精确主机名匹配
  - `.后缀` 域名匹配（如 `.example.com`）
  - `*` 通配符（绕过所有代理）
  - IPv4 CIDR 网段（如 `10.0.0.0/8`、`172.16.0.0/12`）
- 原有的 localhost/127.0.0.1 硬编码规则保持不变

### 2. Linux 环境变量代理回退
- `systemProxyUrlForRequest()` 在系统代理不可用时，回退到 `HTTPS_PROXY` / `HTTP_PROXY` / `https_proxy` / `http_proxy` 环境变量
- 因为 `SystemProxyManager` 只支持 macOS（scutil）和 Windows（WinHTTP），Linux 上始终为空

## 测试计划
- [ ] Linux 上设 `HTTPS_PROXY=http://proxy:8080` → 请求走代理
- [ ] macOS 上系统代理优先级仍高于环境变量
- [ ] `NO_PROXY=localhost,127.0.0.1` → 绕过代理
- [ ] `NO_PROXY=10.0.0.0/8` → CIDR 网段匹配生效
- [ ] `NO_PROXY=.zte.com.cn` → 后缀匹配生效
- [ ] `NO_PROXY=*` → 所有请求绕过代理