### PR TITLE
fix: remember main window bounds instead of forcing full-workarea size

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -1,7 +1,8 @@
-import { app, BrowserWindow, screen } from "electron";
+import { app, BrowserWindow, screen, type Rectangle } from "electron";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { loadPersistedAppSetting, replacePersistedAppSetting } from "./app-config-store";
 import { APP_NAME, IPC_CHANNELS, ONBOARDING_FINISHED_FILE } from "./constants";
 
 type WindowName = "main" | string;
@@ -13,6 +14,8 @@ const mainWindowDefaultWidth = 1180;
 const mainWindowMargin = 48;
 const mainWindowMinHeight = 420;
 const mainWindowMinWidth = 360;
+const mainWindowBoundsSettingKey = "mainWindowBounds";
+const mainWindowBoundsSaveDelayMs = 500;
 
 class WindowsManager {
   private windows = new Map<WindowName, BrowserWindow>();
@@ -24,10 +27,8 @@ class WindowsManager {
       return existing;
     }
 
-    const bounds = getMainWindowInitialBounds();
-
     const window = new BrowserWindow({
-      ...bounds,
+      ...getMainWindowDefaultBounds(),
       minHeight: mainWindowMinHeight,
       minWidth: mainWindowMinWidth,
       show: false,
@@ -52,11 +53,15 @@ class WindowsManager {
 
     this.windows.set("main", window);
 
-    window.once("ready-to-show", () => {
+    const contentReady = new Promise<void>((resolve) => {
+      window.once("ready-to-show", () => resolve());
+    });
+    void Promise.all([contentReady, restoreMainWindowBounds(window)]).then(() => {
       if (!window.isDestroyed()) {
         window.show();
       }
     });
+
     window.on("closed", () => this.windows.delete("main"));
     window.webContents.on("page-title-updated", (_event, title) => {
       window.setTitle(title || APP_NAME);
@@ -123,12 +128,8 @@ function fitWindowSize(preferred: number, minimum: number, available: number): n
   return Math.max(minimum, Math.min(preferred, available > 0 ? available : preferred));
 }
 
-function getMainWindowInitialBounds(): WindowBounds {
+function getMainWindowDefaultBounds(): WindowBounds {
   const { height: availableHeight, width: availableWidth } = screen.getPrimaryDisplay().workAreaSize;
-
-  if (existsSync(ONBOARDING_FINISHED_FILE)) {
-    return getMainWindowScreenBounds();
-  }
 
   return {
     height: fitWindowSize(mainWindowDefaultHeight, mainWindowMinHeight, availableHeight - mainWindowMargin),
@@ -145,4 +146,75 @@ function getMainWindowScreenBounds(): Required<WindowBounds> {
     x: workArea.x,
     y: workArea.y
   };
+}
+
+// Restores the user's last window position/size instead of forcing a
+// full-workarea size on every launch. A full-workarea size is only applied
+// once, the very first time a window is created after onboarding finishes
+// (before any bounds have been saved) -- from then on, whatever the user
+// resizes/moves the window to is remembered on subsequent launches.
+async function restoreMainWindowBounds(window: BrowserWindow): Promise<void> {
+  const stored = await loadStoredMainWindowBounds();
+  if (window.isDestroyed()) {
+    return;
+  }
+
+  if (stored) {
+    window.setBounds(stored);
+  } else if (existsSync(ONBOARDING_FINISHED_FILE)) {
+    window.setBounds(getMainWindowScreenBounds());
+  }
+
+  registerMainWindowBoundsPersistence(window);
+}
+
+function registerMainWindowBoundsPersistence(window: BrowserWindow): void {
+  let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const scheduleSave = () => {
+    if (window.isDestroyed() || window.isMinimized() || window.isMaximized() || window.isFullScreen()) {
+      return;
+    }
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      void replacePersistedAppSetting(mainWindowBoundsSettingKey, window.getBounds());
+    }, mainWindowBoundsSaveDelayMs);
+  };
+
+  window.on("resize", scheduleSave);
+  window.on("move", scheduleSave);
+  window.on("close", () => {
+    clearTimeout(saveTimer);
+    if (!window.isMinimized() && !window.isMaximized() && !window.isFullScreen()) {
+      void replacePersistedAppSetting(mainWindowBoundsSettingKey, window.getBounds());
+    }
+  });
+}
+
+async function loadStoredMainWindowBounds(): Promise<Rectangle | undefined> {
+  const raw = await loadPersistedAppSetting(mainWindowBoundsSettingKey);
+  const bounds = parseMainWindowBounds(raw);
+  if (!bounds) {
+    return undefined;
+  }
+  return isBoundsOnAnyDisplay(bounds) ? bounds : undefined;
+}
+
+function parseMainWindowBounds(value: unknown): Rectangle | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const { height, width, x, y } = value as Record<string, unknown>;
+  if (typeof height !== "number" || typeof width !== "number" || typeof x !== "number" || typeof y !== "number") {
+    return undefined;
+  }
+  return { height, width, x, y };
+}
+
+function isBoundsOnAnyDisplay(bounds: Rectangle): boolean {
+  return screen.getAllDisplays().some((display) => rectanglesIntersect(bounds, display.workArea));
+}
+
+function rectanglesIntersect(a: Rectangle, b: Rectangle): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
 }

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -172,7 +172,7 @@ function registerMainWindowBoundsPersistence(window: BrowserWindow): void {
   let saveTimer: ReturnType<typeof setTimeout> | undefined;
 
   const scheduleSave = () => {
-    if (window.isDestroyed() || window.isMinimized() || window.isMaximized() || window.isFullScreen()) {
+    if (window.isDestroyed() || window.isMinimized()) {
       return;
     }
     clearTimeout(saveTimer);
@@ -185,7 +185,7 @@ function registerMainWindowBoundsPersistence(window: BrowserWindow): void {
   window.on("move", scheduleSave);
   window.on("close", () => {
     clearTimeout(saveTimer);
-    if (!window.isMinimized() && !window.isMaximized() && !window.isFullScreen()) {
+    if (!window.isMinimized()) {
       void replacePersistedAppSetting(mainWindowBoundsSettingKey, window.getBounds());
     }
   });


### PR DESCRIPTION
## Summary

- The main window's initial bounds were recomputed to fill the entire display work area on *every* launch once onboarding had finished, not just the first time.
- On desktop environments that don't correctly report reserved panel/sidebar/dock space in the work area, this pins the window at full display size underneath that panel on every single launch, with no way for the user to fix it (any manual resize was discarded on the next launch).
- Now the app persists the actual window bounds (position + size) on resize/move/close and restores them on next launch. The old maximize-to-workarea behavior still runs, but only once — the first time a window is created after onboarding finishes, before any bounds have been saved.
- Stored bounds are validated against the current displays' work areas on load, so a stale position from a since-removed/reconfigured monitor can't strand the window off-screen.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Manual verification on a machine with a desktop panel/sidebar that isn't reported in the Electron work area