### PR TITLE
feat(session): forward x-session-id header from CCRCODE_SESSION_ID env

### DIFF
--- a/src/server/gateway/service.ts
+++ b/src/server/gateway/service.ts
@@ -601,6 +601,10 @@ class GatewayService {
     const startedAtIso = new Date(startedAt).toISOString();
     const requestId = randomUUID();
     headers["x-client-request-id"] = requestId;
+    const ccrSessionId = process.env.CCRCODE_SESSION_ID;
+    if (ccrSessionId) {
+      headers["x-session-id"] = ccrSessionId;
+    }
     const requestUrl = new URL(request.url || path, this.status.endpoint || "http://127.0.0.1").toString();
     const upstreamAbortController = new AbortController();
     let clientDisconnected = false;

--- a/src/server/proxy/service.ts
+++ b/src/server/proxy/service.ts
@@ -1244,6 +1244,10 @@ function createForwardHeaders(
     forwarded.host = upstreamUrl.host;
     forwarded["x-ccr-proxy-mode"] = "transparent";
   }
+  const ccrSessionId = process.env.CCRCODE_SESSION_ID;
+  if (ccrSessionId) {
+    forwarded["x-session-id"] = ccrSessionId;
+  }
   return forwarded;
 }
 


### PR DESCRIPTION
Inject x-session-id on outbound provider requests when CCRCODE_SESSION_ID is set — gateway path (service.ts line ~603, alongside x-client-request-id) and proxy path (createForwardHeaders, covers HTTP+HTTPS). No-op when env var absent so non-ccrcode launches are unaffected.