### PR TITLE
fix(anthropic): forward cache_creation_input_tokens in OpenAI usage mapping

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -15,6 +15,35 @@ import { getThinkLevel } from "@/utils/thinking";
 import { createApiError } from "@/api/middleware";
 import { formatBase64 } from "@/utils/image";
 
+type OpenAIUsageLike = {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  cache_creation_input_tokens?: number;
+  prompt_tokens_details?: {
+    cached_tokens?: number;
+    cache_creation_tokens?: number;
+  };
+};
+
+function buildAnthropicUsageFromOpenAI(usage?: OpenAIUsageLike) {
+  const promptTokens = usage?.prompt_tokens || 0;
+  const cacheReadTokens = usage?.prompt_tokens_details?.cached_tokens || 0;
+  const cacheCreationTokens =
+    usage?.cache_creation_input_tokens ??
+    usage?.prompt_tokens_details?.cache_creation_tokens ??
+    0;
+
+  return {
+    input_tokens: Math.max(
+      0,
+      promptTokens - cacheReadTokens - cacheCreationTokens
+    ),
+    output_tokens: usage?.completion_tokens || 0,
+    cache_read_input_tokens: cacheReadTokens,
+    cache_creation_input_tokens: cacheCreationTokens,
+  };
+}
+
 export class AnthropicTransformer implements Transformer {
   name = "Anthropic";
   endPoint = "/v1/messages";
@@ -481,27 +510,12 @@ export class AnthropicTransformer implements Transformer {
                         stop_reason: "end_turn",
                         stop_sequence: null,
                       },
-                      usage: {
-                        input_tokens:
-                          (chunk.usage?.prompt_tokens || 0) -
-                          (chunk.usage?.prompt_tokens_details?.cached_tokens ||
-                            0),
-                        output_tokens: chunk.usage?.completion_tokens || 0,
-                        cache_read_input_tokens:
-                          chunk.usage?.prompt_tokens_details?.cached_tokens ||
-                          0,
-                      },
+                      usage: buildAnthropicUsageFromOpenAI(chunk.usage),
                     };
                   } else {
-                    stopReasonMessageDelta.usage = {
-                      input_tokens:
-                        (chunk.usage?.prompt_tokens || 0) -
-                        (chunk.usage?.prompt_tokens_details?.cached_tokens ||
-                          0),
-                      output_tokens: chunk.usage?.completion_tokens || 0,
-                      cache_read_input_tokens:
-                        chunk.usage?.prompt_tokens_details?.cached_tokens || 0,
-                    };
+                    stopReasonMessageDelta.usage = buildAnthropicUsageFromOpenAI(
+                      chunk.usage
+                    );
                   }
                 }
                 if (!choice) {
@@ -895,16 +909,7 @@ export class AnthropicTransformer implements Transformer {
                         stop_reason: anthropicStopReason,
                         stop_sequence: null,
                       },
-                      usage: {
-                        input_tokens:
-                          (chunk.usage?.prompt_tokens || 0) -
-                          (chunk.usage?.prompt_tokens_details?.cached_tokens ||
-                            0),
-                        output_tokens: chunk.usage?.completion_tokens || 0,
-                        cache_read_input_tokens:
-                          chunk.usage?.prompt_tokens_details?.cached_tokens ||
-                          0,
-                      },
+                      usage: buildAnthropicUsageFromOpenAI(chunk.usage),
                     };
                   }
 
@@ -1041,14 +1046,7 @@ export class AnthropicTransformer implements Transformer {
             ? "stop_sequence"
             : "end_turn",
         stop_sequence: null,
-        usage: {
-          input_tokens:
-            (openaiResponse.usage?.prompt_tokens || 0) -
-            (openaiResponse.usage?.prompt_tokens_details?.cached_tokens || 0),
-          output_tokens: openaiResponse.usage?.completion_tokens || 0,
-          cache_read_input_tokens:
-            openaiResponse.usage?.prompt_tokens_details?.cached_tokens || 0,
-        },
+        usage: buildAnthropicUsageFromOpenAI(openaiResponse.usage),
       };
       this.logger.debug(
         {


### PR DESCRIPTION
## Summary

Forward `cache_creation_input_tokens` when converting OpenAI-style provider usage to Anthropic format in `AnthropicTransformer`, so Claude Code's footer reports cache write correctly instead of always showing 0.

## Motivation

Fixes #1461.

CCR's OpenAI→Anthropic usage mapping only emitted `input_tokens`, `output_tokens`, and `cache_read_input_tokens`. When providers return `cache_creation_input_tokens` (or `prompt_tokens_details.cache_creation_tokens`), that value was dropped and not subtracted from `input_tokens`.

## Changes

- Add `buildAnthropicUsageFromOpenAI()` helper in `packages/core/src/transformer/anthropic.transformer.ts`
- Use the helper for streaming `message_delta` usage (all paths) and non-streaming response conversion
- Subtract cache read **and** cache creation from `input_tokens`

## Tests

```bash
cd packages/core && npx tsx scripts/build.ts
```

Build succeeded.

## Notes

- Targets the `feature/2.0` branch (npm `@musistudio/claude-code-router@2.0.0`). v3 desktop (`main`) routes through `@the-next-ai/ai-gateway`, which already maps cache creation fields.
- Optional follow-up: add `cache_creation_input_tokens: 0` to the fallback zero-usage `message_delta` block for schema completeness.