### PR TITLE
Fix/gateway crashes

### DIFF
--- a/src/main/codex-cli-middleware-runtime.ts
+++ b/src/main/codex-cli-middleware-runtime.ts
@@ -2355,8 +2355,12 @@ function configRead(params, values) {
       model: agentEnv(runtimeAgent, "MODEL") || DEFAULT_MODEL,
       model_catalog_json: JSON.stringify(modelCatalogConfigValue()),
       model_provider: agentEnv(runtimeAgent, "MODEL_PROVIDER") || "claude-code",
-      approval_policy: "default",
-      sandbox_mode: "workspace-write"
+      approval_policy: "default"
+      // sandbox_mode intentionally omitted: let Codex read it from its own
+      // config.toml (e.g. [windows] sandbox) instead of forcing workspace-write.
+      // Forcing workspace-write triggers codex-windows-sandbox-setup.exe on every
+      // command, which fails on systems where the COM+ catalog is unavailable
+      // (see openai/codex#29332), surfacing as repeated error dialogs.
     }
   };
 }

--- a/src/server/gateway/service.ts
+++ b/src/server/gateway/service.ts
@@ -635,7 +635,7 @@ class GatewayService {
     const client = inferGatewayClient(apiKey, request.headers);
     const cursorCompatPreparation = prepareCursorOpenAICompatChatBody(this.config, client, method, path, requestBody);
     if (cursorCompatPreparation) {
-      headers["x-ccr-cursor-openai-compat"] = cursorCompatPreparation.diagnostic;
+      headers["x-ccr-cursor-openai-compat"] = sanitizeHeaderValue(cursorCompatPreparation.diagnostic);
     }
     let bodyToForward: Buffer | undefined = cursorCompatPreparation?.body ?? requestBody;
     let routeFallback = this.config.Router.fallback;
@@ -643,12 +643,12 @@ class GatewayService {
     let codexApplyPatchBridgeActive = false;
     const claudeModelRewrite = prepareClaudeCodeDiscoveredModelRequest(this.config, request.headers, method, path, bodyToForward);
     if (claudeModelRewrite) {
-      headers["x-ccr-claude-model-discovery"] = claudeModelRewrite.diagnostic;
+      headers["x-ccr-claude-model-discovery"] = sanitizeHeaderValue(claudeModelRewrite.diagnostic);
       bodyToForward = claudeModelRewrite.body;
     }
     const claudeAppModelRewrite = prepareClaudeAppFallbackModelRequest(this.config, method, path, bodyToForward);
     if (claudeAppModelRewrite) {
-      headers["x-ccr-claude-app-model-rewrite"] = claudeAppModelRewrite.diagnostic;
+      headers["x-ccr-claude-app-model-rewrite"] = sanitizeHeaderValue(claudeAppModelRewrite.diagnostic);
       bodyToForward = claudeAppModelRewrite.body;
       routedModel = claudeAppModelRewrite.routedModel;
     }
@@ -677,6 +677,16 @@ class GatewayService {
       clientDisconnected = true;
       upstreamAbortController.abort(new Error(clientDisconnectMessage));
       onClientDisconnect?.();
+    });
+    response.on("error", (error) => {
+      // Client-side write failures (EPIPE / ECONNRESET when the client closes
+      // mid-stream, common during tool execution) must not crash the main
+      // process as an Uncaught Exception. Swallow them here; the close handler
+      // above already records the disconnect via writeStreamLog.
+      if (!clientDisconnected) {
+        clientDisconnected = true;
+        upstreamAbortController.abort(new Error(clientDisconnectMessage));
+      }
     });
 
     const writeRequestLog = (
@@ -743,10 +753,10 @@ class GatewayService {
       });
       const serialized = Buffer.from(`${JSON.stringify(routed.body)}\n`, "utf8");
       headers["content-type"] = "application/json";
-      headers["x-ccr-route-reason"] = routed.decision.reason;
+      headers["x-ccr-route-reason"] = sanitizeHeaderValue(routed.decision.reason);
       routeFallback = routed.decision.fallback ?? routeFallback;
       if (routed.decision.model) {
-        headers["x-ccr-routed-model"] = routed.decision.model;
+        headers["x-ccr-routed-model"] = sanitizeHeaderValue(routed.decision.model);
         routedModel = routed.decision.model;
       }
       bodyToForward = serialized;
@@ -761,10 +771,10 @@ class GatewayService {
       });
       const serialized = Buffer.from(`${JSON.stringify(routed.body)}\n`, "utf8");
       headers["content-type"] = "application/json";
-      headers["x-ccr-route-reason"] = routed.decision.reason;
+      headers["x-ccr-route-reason"] = sanitizeHeaderValue(routed.decision.reason);
       routeFallback = routed.decision.fallback ?? routeFallback;
       if (routed.decision.model) {
-        headers["x-ccr-routed-model"] = routed.decision.model;
+        headers["x-ccr-routed-model"] = sanitizeHeaderValue(routed.decision.model);
         routedModel = routed.decision.model;
       }
       bodyToForward = serialized;
@@ -781,7 +791,7 @@ class GatewayService {
     if (codexApplyPatchBridgeRequest) {
       bodyToForward = codexApplyPatchBridgeRequest.body;
       codexApplyPatchBridgeActive = true;
-      headers["x-ccr-codex-patch-bridge"] = codexApplyPatchBridgeRequest.diagnostic;
+      headers["x-ccr-codex-patch-bridge"] = sanitizeHeaderValue(codexApplyPatchBridgeRequest.diagnostic);
       headers["content-type"] = "application/json";
     }
 
@@ -906,7 +916,13 @@ class GatewayService {
     bodyToForward = upstreamResult.attempt.body ?? bodyToForward;
     routedModel = upstreamResult.attempt.model ?? routedModel;
     const responseHeaders = rewriteCapabilityResponseHeaders(
-      mergeFallbackResponseHeaders(upstreamResponseHeaders(upstreamResult), upstreamResult),
+      // Copy into a mutable Headers instance: upstream fetch Response.headers
+      // can be immutable (TypeError: immutable on .delete/.set), and
+      // mergeFallbackResponseHeaders returns the original object as-is when
+      // no fallback occurred. Codex apply_patch / web-search paths call
+      // .delete("content-length") below, which would otherwise throw and
+      // surface as a 502.
+      new Headers(mergeFallbackResponseHeaders(upstreamResponseHeaders(upstreamResult), upstreamResult)),
       this.config
     );
     const upstreamResponse = upstreamResult.response;
@@ -995,7 +1011,7 @@ class GatewayService {
         writeStreamLog();
       }
     });
-    responseBody.once("error", (error) => {
+    responseBody.on("error", (error) => {
       streamDetectedError ??= sseErrorDetector.finish();
       writeStreamLog(clientDisconnected ? clientDisconnectMessage : formatError(error));
     });
@@ -5592,7 +5608,7 @@ function prepareUpstreamCredentialAttempt(input: {
   const headers: Record<string, string> = {
     ...input.headers,
     "x-target-providers": selection.credentials.map((candidate) => candidate.internalName).join(","),
-    "x-ccr-logical-provider": target.provider.name,
+    "x-ccr-logical-provider": providerRuntimeId(target.provider),
     "x-ccr-provider-credential-chain": selection.credentials.map((candidate) => candidate.credentialId).join(",")
   };
   delete headers["x-target-provider"];
@@ -6002,7 +6018,7 @@ function mergeFallbackResponseHeaders(headers: Headers, result: UpstreamFetchRes
       merged.set("x-ccr-fallback-delays-ms", formatFallbackDelays(result.failedAttempts));
     }
     if (result.attempt.model) {
-      merged.set("x-ccr-fallback-model", result.attempt.model);
+      merged.set("x-ccr-fallback-model", sanitizeHeaderValue(result.attempt.model));
     }
   }
   if (credentialIds.length) {
@@ -6377,6 +6393,20 @@ function sanitizeProviderHeaderId(value: string | undefined): string | undefined
     .replace(/[^a-z0-9_.-]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return normalized || undefined;
+}
+
+function sanitizeHeaderValue(value: unknown): string {
+  // HTTP header values must be ByteString (code point <= 255). Values derived
+  // from user-facing names — model selectors like "小米mimo/...", provider
+  // names, route reasons — can contain non-ASCII characters that crash Node's
+  // fetch/undici with "Cannot convert argument to a ByteString" (surfaced as
+  // 502). Normalize to ASCII while preserving case and printable punctuation.
+  const text = typeof value === "string" && value.trim() ? value : "unknown";
+  const sanitized = text
+    .replace(/[^\x20-\x7E]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "unknown";
 }
 
 function providerCredentialInternalName(


### PR DESCRIPTION
# Fix four ccr crashes: non-ASCII headers, client disconnect, immutable headers, and codex sandbox_mode override

Four independent bugs, split into two commits by subsystem for independent review/revert.

---

## Commit 1 — Three gateway crashes (service.ts)

### 1. Non-ASCII provider/model names → 502 ByteString

When a provider name or model selector contains non-ASCII characters (e.g. `小米mimo/mimo-v2.5-pro-ultraspeed`), every routed request fails:

```
Unexpected status 502 Bad Gateway: Cannot convert argument to a ByteString
because the character at index 0 has a value of 23567 which is greater than 255.
```

Several observability headers derived values from raw, unsanitized user-facing strings. Node/undici enforces the HTTP ByteString contract (code point ≤ 255), so any non-ASCII char throws a `TypeError` that bubbles to the catch-all as 502.

Affected headers and their value sources:

| Header | Value source |
|---|---|
| `x-ccr-logical-provider` | `provider.name` |
| `x-ccr-routed-model` / `x-ccr-route-reason` | `routed.decision.model` / `.reason` |
| `x-ccr-claude-model-discovery` / `app-model-rewrite` / `codex-patch-bridge` / `cursor-openai-compat` | diagnostic templates interpolating the model name |
| `x-ccr-fallback-model` (response) | `result.attempt.model` |

**Fix:** add `sanitizeHeaderValue()` that replaces characters outside the printable ASCII range (`\x20-\x7E`) with `-`, preserving case and punctuation; wrap all ten assignments. The core gateway (`@the-next-ai/ai-gateway`) does not read any `x-ccr-*` header (verified by grep), so values stay observability-only.

### 2. Client disconnect mid-stream → Uncaught Exception

When a client closes the SSE connection mid-stream — normal during local tool execution (file creation) — the gateway emitted an Uncaught Exception that crashed the Electron main process:

```
Uncaught Exception:
Error: Client connection closed before response completed.
```

Two gaps let the error escape:
- `responseBody.once("error", ...)` consumes only the **first** error, but a disconnect triggers several in quick succession (abort, destroy, EPIPE). Remaining errors re-throw as unhandled.
- The destination `ServerResponse` had **no** `"error"` listener, so write failures on a closed socket bubbled up directly.

**Fix:** `once("error")` → `on("error")` on the response body so every error is logged; add `response.on("error")` that marks the disconnect and aborts upstream. Disconnects are still recorded and upstream still aborted — only the spurious crash is removed.

### 3. Codex apply_patch → 502 "immutable"

Creating a file via Codex (apply_patch) fails with:

```
Unexpected status 502 Bad Gateway: immutable
```

Undici's `fetch Response.headers` can be immutable; `mergeFallbackResponseHeaders` returns it as-is when no fallback occurred, and the codex patch bridge then calls `responseHeaders.delete("content-length")`, which throws `TypeError: immutable`.

**Fix:** wrap the merged headers in `new Headers(...)` to guarantee a mutable copy regardless of upstream immutability or merge early-return.

---

## Commit 2 — Codex sandbox_mode override (codex-cli-middleware-runtime.ts)

### 4. Codex COM+ setup dialogs (three repeated)

When Codex runs through the ccr middleware, every command execution fails with three repeated Windows error dialogs from `codex-windows-sandbox-setup.exe` reporting a COM+ registry database error.

**Root cause:** the middleware's `config/read` handler hard-coded `sandbox_mode: "workspace-write"` in the virtual config returned to Codex. Unlike the mode Codex reads from its own `config.toml` when run directly (or via config-only tools like cc-switch), `workspace-write` triggers `codex-windows-sandbox-setup.exe` setup refresh on **every** command. On systems where the COM+ catalog is unavailable (COMSysApp stopped, or the catalog itself misbehaves — see [openai/codex#29332](https://github.com/openai/codex/issues/29332)), that refresh fails and surfaces as the repeated error dialogs.

Empirically verified across the three legal `sandbox_mode` values:

| Value | Triggers setup? | Can write? | Isolated? |
|---|---|---|---|
| `read-only` | No | No | Yes |
| `workspace-write` | **Yes, every command** (fails on affected systems) | — | Yes |
| `danger-full-access` | No | Yes | No |

Forcing `workspace-write` therefore both overrides the user's own `config.toml` preference **and** guarantees the failure on affected systems.

**Fix:** omit `sandbox_mode` from the virtual config entirely, letting Codex read it from its own `config.toml` — matching the behavior of config-only tools like cc-switch. The user keeps full control: those who want isolation set `workspace-write` (and must ensure their COM+ works); those on affected systems set `danger-full-access`. One-line removal plus explanatory comment.

**Refs:** [openai/codex#29332](https://github.com/openai/codex/issues/29332)

---

## Why two commits

The two files belong to different subsystems: commit 1 is the gateway request path, commit 2 is the codex middleware's config injection. They can fail and be reverted independently, and commit 2 references an upstream codex issue. Splitting keeps each commit's responsibility clear.

## Impact

- **Severity:** High. Bugs 1/3/4 make entire workflows unusable (non-ASCII names, apply_patch, codex sandbox); bug 2 fires on every tool call creating a file.
- **Files changed:** `src/server/gateway/service.ts` (commit 1), `src/main/codex-cli-middleware-runtime.ts` (commit 2).
- **No behavioral change** for unaffected configurations — sanitization is a no-op for valid values, error handlers only affect the failure path, and the sandbox_mode removal only adds back user control.