### PR TITLE
Document persistent core gateway config

### DIFF
--- a/docs/src/content/docs/en/configuration/configuration-file.md
+++ b/docs/src/content/docs/en/configuration/configuration-file.md
@@ -15,3 +15,5 @@ lead: Locate the SQLite configuration database maintained by the CCR desktop app
 CCR stores runtime configuration in SQLite. A legacy `config.json` is read only once as a migration source when no SQLite config exists; after migration, editing `config.json` does not affect the current configuration.
 
 Use the desktop UI to change configuration, or export a backup from **Settings**. Do not edit `config.sqlite` directly while CCR is running; SQLite also maintains companion `config.sqlite-wal` and `config.sqlite-shm` files in the same directory.
+
+CCR also writes generated runtime files such as `gateway.config.json` for the embedded core gateway. Treat those files as output: CCR rewrites them when the gateway starts. Persist advanced core gateway settings through the SQLite-backed configuration, for example with `plugins[].coreGateway.config`; see [Extension Mechanism](/en/configuration/extensions/).

--- a/docs/src/content/docs/en/configuration/extensions.md
+++ b/docs/src/content/docs/en/configuration/extensions.md
@@ -194,6 +194,34 @@ CCR stores runtime configuration in SQLite. Add extensions through the UI; the l
 }
 ```
 
+`coreGateway.config` is also the supported place for advanced core gateway options. CCR merges this object into the generated core gateway config when the gateway starts. Do not edit the generated `gateway.config.json` directly; it is rewritten by CCR and manual edits are lost on restart.
+
+For example, an extension or persisted plugin entry can tune upstream retry behavior without changing the generated file:
+
+```json
+{
+  "plugins": [
+    {
+      "id": "advanced-core-gateway",
+      "enabled": true,
+      "coreGateway": {
+        "config": {
+          "upstreamRetry": {
+            "enabled": true,
+            "maxAttempts": 2,
+            "baseDelayMs": 300,
+            "maxDelayMs": 1000,
+            "backoffMultiplier": 2,
+            "jitterMs": 200,
+            "retryStatusCodes": [429, 500, 502, 503, 504]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
 Restart the gateway after saving the extension config. See [Config Database Location](/en/configuration/configuration-file/).
 
 The local directory picker recognizes entry metadata from:

--- a/docs/src/content/docs/zh/configuration/config-file.md
+++ b/docs/src/content/docs/zh/configuration/config-file.md
@@ -15,3 +15,5 @@ lead: 找到 CCR 桌面 App 默认维护的 SQLite 配置数据库。
 CCR 的运行配置存储在 SQLite 中。旧版 `config.json` 只会在没有 SQLite 配置时作为迁移来源读取一次，迁移完成后继续编辑 `config.json` 不会影响当前配置。
 
 建议通过桌面 UI 修改配置，或在 **Settings** 中导出备份。不要在 CCR 运行时直接编辑 `config.sqlite`；SQLite 还会维护同目录的 `config.sqlite-wal` 和 `config.sqlite-shm` 辅助文件。
+
+CCR 还会为内置 core gateway 写入 `gateway.config.json` 等运行时生成文件。请把这些文件视为输出结果：每次启动网关时 CCR 都可能重写它们。需要持久化 core gateway 高级设置时，请写入 SQLite 支持的配置结构，例如 `plugins[].coreGateway.config`；详见 [扩展机制](/configuration/extensions/)。

--- a/docs/src/content/docs/zh/configuration/extensions.md
+++ b/docs/src/content/docs/zh/configuration/extensions.md
@@ -194,6 +194,34 @@ CCR 的运行配置存储在 SQLite 中。请通过 UI 添加扩展；旧版 JSO
 }
 ```
 
+`coreGateway.config` 也是写入 core gateway 高级配置的推荐位置。CCR 启动网关时会把这个对象合并到生成的 core gateway 配置中。不要直接编辑生成出来的 `gateway.config.json`；该文件会被 CCR 重写，手动修改会在重启后丢失。
+
+例如，扩展或持久化插件条目可以这样调整上游重试行为，而不需要修改生成文件：
+
+```json
+{
+  "plugins": [
+    {
+      "id": "advanced-core-gateway",
+      "enabled": true,
+      "coreGateway": {
+        "config": {
+          "upstreamRetry": {
+            "enabled": true,
+            "maxAttempts": 2,
+            "baseDelayMs": 300,
+            "maxDelayMs": 1000,
+            "backoffMultiplier": 2,
+            "jitterMs": 200,
+            "retryStatusCodes": [429, 500, 502, 503, 504]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
 保存扩展配置后需要重启网关。配置数据库位置见 [配置数据库位置](/configuration/config-file/)。
 
 本地目录选择器会按顺序识别这些入口信息：


### PR DESCRIPTION
## Summary
- document that generated core gateway files such as `gateway.config.json` are runtime output and may be overwritten on gateway restart
- explain that advanced embedded core gateway settings should be persisted through `plugins[].coreGateway.config`
- add English and Chinese examples for configuring `upstreamRetry` without editing generated files

## Why
CCR stores its effective runtime configuration in SQLite and rewrites the generated core gateway config when starting the gateway. Without this note, users can edit `gateway.config.json` directly, see the setting work briefly, and then lose the change on restart.

## Test Plan
- [x] `git diff --check`
- [x] `cd docs && npm run build`