### PR TITLE
fix: Claude Code CLI credentials moved to macOS Keychain — local-agent import fails

### DIFF
--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -9,6 +10,7 @@ import type {
 import {
   bearerAuthPlugin,
   findOauthTokenSet,
+  isRecord,
   missingCandidate,
   providerInternalNamePlaceholder,
   providerPayload,
@@ -17,6 +19,8 @@ import {
   uniqueStrings,
   type OAuthTokenSet
 } from "@ccr/core/agents/local-providers/shared";
+
+const claudeCodeKeychainService = "Claude Code-credentials";
 
 const claudeDefaultModels = ["claude-sonnet-4-20250514"];
 
@@ -148,6 +152,19 @@ function readClaudeCodeOauth(): OAuthTokenSet | undefined {
       sourceFile
     };
   }
+
+  const keychainRecord = readClaudeCodeKeychainRecord();
+  if (keychainRecord) {
+    const credential = findOauthTokenSet(keychainRecord);
+    if (credential) {
+      return {
+        accessToken: credential.accessToken,
+        refreshToken: credential.refreshToken,
+        sourceFile: `keychain:${claudeCodeKeychainService}`
+      };
+    }
+  }
+
   return undefined;
 }
 
@@ -157,4 +174,25 @@ function claudeCredentialFiles(): string[] {
     path.join(os.homedir(), ".claude", "credentials.json"),
     path.join(os.homedir(), ".config", "claude", "credentials.json")
   ]);
+}
+
+// Newer macOS builds of the Claude Code CLI store credentials in the
+// Keychain instead of ~/.claude/.credentials.json. Reading it triggers the
+// standard macOS keychain access prompt (Allow / Always Allow); the user
+// declining or the item not existing both surface as a non-zero exit here.
+function readClaudeCodeKeychainRecord(): Record<string, unknown> | undefined {
+  if (process.platform !== "darwin") {
+    return undefined;
+  }
+  try {
+    const output = execFileSync(
+      "security",
+      ["find-generic-password", "-s", claudeCodeKeychainService, "-w"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+    );
+    const parsed = JSON.parse(output.trim()) as unknown;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -22,7 +22,7 @@ import {
 
 const claudeCodeKeychainService = "Claude Code-credentials";
 
-const claudeDefaultModels = ["claude-sonnet-4-5-20250929"];
+const claudeDefaultModels = ["claude-sonnet-4-20250514"];
 
 const percentLimitMapping = (id: string, label: string, path: string, window: string) => ({
   id,

--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -22,7 +22,7 @@ import {
 
 const claudeCodeKeychainService = "Claude Code-credentials";
 
-const claudeDefaultModels = ["claude-sonnet-4-20250514"];
+const claudeDefaultModels = ["claude-sonnet-4-5-20250929"];
 
 const percentLimitMapping = (id: string, label: string, path: string, window: string) => ({
   id,


### PR DESCRIPTION
# Claude Code CLI credentials moved to macOS Keychain — local-agent import fails
ref: https://code.claude.com/docs/en/authentication

<img width="729" height="485" alt="Image" src="https://github.com/user-attachments/assets/7fa98327-3360-413d-86ec-ce826f5cbeaf" />


## Problem

Newer macOS builds of the Claude Code CLI store OAuth credentials in the macOS
Keychain (service name `"Claude Code-credentials"`) instead of
`~/.claude/.credentials.json`. CCR's local-agent provider importer only reads
the file path, so on these installs it finds no credentials and the
"Claude Code API" local login provider cannot be detected/imported.

## Where it's read today

`packages/core/src/agents/local-providers/claude-code.ts` uses
`readJsonRecord()` (from `packages/core/src/agents/local-providers/shared.ts`)
to read `~/.claude/.credentials.json` directly off disk. There is no
Keychain fallback anywhere in `packages/core/src/agents/local-providers/`.

## Fix direction

Add a Keychain fallback when the credentials file is missing/empty:

```bash
security find-generic-password -s "Claude Code-credentials" -w
```

- Triggers a standard macOS permission prompt (Allow / Always Allow) on
  first access — no bypass, same consent flow any app goes through.
- Exits non-zero if the item doesn't exist or the user denies access —
  must be wrapped in try/catch, falling back to "no local credentials
  found" (existing `missingCandidate()` path) rather than throwing.
- Output is JSON on stdout, same shape expected by
  `findOauthTokenSet()` in `shared.ts` — parse and feed through the same
  path used for the file-based case.
- macOS-only path (`process.platform === "darwin"`); other platforms keep
  using the file-based read only.

## Not yet implemented

This is a plan, not a diff — nothing has been changed for this issue yet.