### PR TITLE
fix: Update default sonnet model as old one is no longer existed (404)

### DIFF
--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -18,7 +18,7 @@ import {
   type OAuthTokenSet
 } from "@ccr/core/agents/local-providers/shared";
 
-const claudeDefaultModels = ["claude-sonnet-4-5-20250929"];
+const claudeDefaultModels = ["claude-sonnet-5"];
 
 const percentLimitMapping = (id: string, label: string, path: string, window: string) => ({
   id,

--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -18,7 +18,7 @@ import {
   type OAuthTokenSet
 } from "@ccr/core/agents/local-providers/shared";
 
-const claudeDefaultModels = ["claude-sonnet-4-20250514"];
+const claudeDefaultModels = ["claude-sonnet-4-5-20250929"];
 
 const percentLimitMapping = (id: string, label: string, path: string, window: string) => ({
   id,


### PR DESCRIPTION
Anthroipic server no longer have old claude-sonnet-4-20250514
Refer to [Claude Legacy Model](https://platform.claude.com/docs/en/about-claude/models/overview#:~:text=Claude%20Sonnet%204.6-,Claude%20Sonnet%204.5,-Claude%20Opus%204.5)

<img width="808" height="240" alt="image" src="https://github.com/user-attachments/assets/d1fe3282-8089-47a4-a0ea-d0f1d9684a16" />
