### PR TITLE
fix: pass proxy preload to fusion MCP child processes

### DIFF
--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -1166,7 +1166,14 @@ async function writeCoreGatewayConfig(
     ...pluginService.getVirtualModelProfiles()
   ])), config);
   const coreEndpoint = endpoint(config.gateway.coreHost, config.gateway.corePort);
-  const builtinToolArtifacts = await fusionBuiltinToolArtifacts(virtualModelProfiles, coreEndpoint, coreAuthToken, browserWebSearchMcpIntegration);
+  const proxyUrl = process.env.CCR_UPSTREAM_PROXY_URL || process.env.HTTPS_PROXY || process.env.https_proxy;
+  const proxyPreloadFile = proxyUrl
+    ? pathJoin(dirname(config.gateway.generatedConfigFile), "gateway-proxy-preload.cjs")
+    : undefined;
+  const proxyEnv = proxyUrl ? { CCR_UPSTREAM_PROXY_URL: proxyUrl, CCR_UNDICI_MODULE: resolveUndiciProxyAgentModule() } : undefined;
+  const builtinToolArtifacts = await fusionBuiltinToolArtifacts(
+    virtualModelProfiles, coreEndpoint, coreAuthToken, browserWebSearchMcpIntegration, proxyPreloadFile, proxyEnv
+  );
   const providers = [
     ...config.Providers
       .flatMap((provider) => toCoreGatewayProviders(withCodexOauthProviderBaseUrl(provider, codexOauthProviderNames)))
@@ -1461,7 +1468,9 @@ async function fusionBuiltinToolArtifacts(
   profiles: unknown[],
   coreEndpoint: string,
   coreAuthToken: string,
-  browserWebSearchMcpIntegration?: BrowserWebSearchMcpIntegration
+  browserWebSearchMcpIntegration?: BrowserWebSearchMcpIntegration,
+  proxyPreloadFile?: string,
+  proxyEnv?: Record<string, string>
 ): Promise<{ mcpServers: GatewayMcpServerConfig[]; providers: CoreGatewayProvider[] }> {
   const providers: CoreGatewayProvider[] = [];
   const mcpServers: GatewayMcpServerConfig[] = [];
@@ -1495,7 +1504,9 @@ async function fusionBuiltinToolArtifacts(
             ...(visionConfig.baseUrl && visionConfig.apiKey ? { VISION_API_KEY: visionConfig.apiKey } : {}),
             ...(visionConfig.timeoutMs ? { VISION_TIMEOUT_MS: String(visionConfig.timeoutMs) } : {})
           },
-          name: `fusion-vision-${sanitizedProfileId}`
+          name: `fusion-vision-${sanitizedProfileId}`,
+          proxyPreloadFile,
+          proxyEnv
         }));
       }
     }
@@ -1528,7 +1539,9 @@ async function fusionBuiltinToolArtifacts(
               ...(webSearchConfig.timeoutMs ? { SEARCH_TIMEOUT_MS: String(webSearchConfig.timeoutMs) } : {}),
               ...(webSearchConfig.env ?? {})
             },
-            name: `fusion-web-search-${sanitizedProfileId}`
+            name: `fusion-web-search-${sanitizedProfileId}`,
+            proxyPreloadFile,
+            proxyEnv
           }));
         }
       }
@@ -1542,25 +1555,32 @@ export async function fusionBuiltinToolArtifactsForTest(
   profiles: unknown[],
   coreEndpoint: string,
   coreAuthToken: string,
-  browserWebSearchMcpIntegration?: BrowserWebSearchMcpIntegration
+  browserWebSearchMcpIntegration?: BrowserWebSearchMcpIntegration,
+  proxyPreloadFile?: string,
+  proxyEnv?: Record<string, string>
 ): Promise<{ mcpServers: GatewayMcpServerConfig[]; providers: unknown[] }> {
-  return fusionBuiltinToolArtifacts(profiles, coreEndpoint, coreAuthToken, browserWebSearchMcpIntegration);
+  return fusionBuiltinToolArtifacts(profiles, coreEndpoint, coreAuthToken, browserWebSearchMcpIntegration, proxyPreloadFile, proxyEnv);
 }
 
 function fusionBuiltinMcpServer({
   entry,
   env,
-  name
+  name,
+  proxyPreloadFile,
+  proxyEnv
 }: {
   entry: string;
   env: Record<string, string>;
   name: string;
+  proxyPreloadFile?: string;
+  proxyEnv?: Record<string, string>;
 }): GatewayMcpServerConfig {
   return {
-    args: [entry],
+    args: proxyPreloadFile ? ["--require", proxyPreloadFile, entry] : [entry],
     command: process.execPath,
     env: {
       ELECTRON_RUN_AS_NODE: "1",
+      ...(proxyEnv ?? {}),
       ...env
     },
     name,


### PR DESCRIPTION
## 概述

当 CCR 运行在 HTTP 代理后方时，fusion-vision-mcp 和 fusion-web-search 子进程未加载 `--require` 代理预加载脚本，导致其 `fetch()` 请求绕过代理，在企业网络环境下无法正常工作。

## 修改内容

- 从环境变量读取代理地址（`CCR_UPSTREAM_PROXY_URL` / `HTTPS_PROXY` / `https_proxy`）
- 将 `proxyPreloadFile` 和 `proxyEnv` 传递给 `fusionBuiltinToolArtifacts()` 和 `fusionBuiltinMcpServer()`
- 在 MCP 子进程启动参数中添加 `--require` 代理预加载脚本
- 将 `CCR_UPSTREAM_PROXY_URL` 和 `CCR_UNDICI_MODULE` 环境变量传递到 MCP 子进程

## 验证

- [ ] 设置 `HTTPS_PROXY`，确认 fusion MCP 子进程使用代理
- [ ] 不设置代理时，行为无变化（预加载被跳过）
- [ ] `pnpm test` 回归测试通过
- [ ] `npx tsc --noEmit` 编译通过