### PR TITLE
fix: Kimi Global Provider's Endpoint Appended with Anthropic

### DIFF
--- a/packages/core/src/providers/url.ts
+++ b/packages/core/src/providers/url.ts
@@ -137,12 +137,18 @@ function shouldProbeOpenAiV1Fallback(value: string): boolean {
 }
 
 function shouldProbeAnthropicPrefixFallback(value: string): boolean {
+  // Only add /anthropic fallback when the URL already shows anthropic affinity:
+  // - hostname contains "anthropic" (e.g. api.anthropic.com)
+  // - path contains "anthropic" (e.g. api.z.ai/api/anthropic)
+  // This prevents false positives where a non-anthropic endpoint
+  // coincidentally responds to /anthropic/* with a 401/403.
   const url = new URL(value);
   const segments = url.pathname
     .split("/")
     .map((segment) => segment.trim().toLowerCase())
     .filter(Boolean);
-  return !segments.includes("anthropic");
+  const hostname = url.hostname.toLowerCase();
+  return hostname.includes("anthropic") || segments.includes("anthropic");
 }
 
 function ensureProviderApiVersion(value: string, version: "v1"): string {

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -1693,15 +1693,17 @@ export function providerDraftSafetyIssue(draft: AddProviderDraft, baseUrl = draf
 
 export function providerProbeCandidates(draft: AddProviderDraft): ProviderProbeCandidate[] {
   const preset = findProviderPreset(draft.presetId);
-  const protocols = providerProtocolOptions.map((option) => option.value);
   if (preset) {
+    // Respect the preset endpoint's declared protocols instead of probing all.
+    // This prevents false protocol detection against unrelated endpoint paths.
     return preset.endpoints.map((endpoint) => ({
-      ...endpoint,
-      protocols,
+      baseUrl: endpoint.baseUrl,
+      protocols: endpoint.protocols,
       source: "preset"
     }));
   }
 
+  const protocols = providerProtocolOptions.map((option) => option.value);
   return [
     {
       baseUrl: draft.baseUrl.trim(),


### PR DESCRIPTION
When adding provider Kimi Global, the endpoint is automatically appended with `/anthropic` endpoint even though it uses OpenAI API format. The final url is wrong and therefore the Kimi Global provider can't be added.


https://github.com/user-attachments/assets/5340b2eb-a4f2-40bc-a353-a555e39be562

**Causes**
In `providerProbeCandidates`, it replaces the declared protocol with every protocol known to the app.
`shouldProbeAnthropicPrefixFallack` at `providers/url.ts` is overly broad. It returns true for any URL that didn't already have "anthropic" in the path. This means the url becomes `https://api.moonshot.ai/anthropic`. This endpoint responds with 401 (auth required), so the probe mis-detects it as a valid Anthropic endpoint.

**Solution**
When a preset is selected, use the endpoint's own declared protocols instead of probing every protocol against every endpoint.
Fallback candidates are only generated when the hostname of path already contains "anthropic".