### PR TITLE
Add MiniMax provider presets

### DIFF
--- a/packages/core/src/providers/presets/index.ts
+++ b/packages/core/src/providers/presets/index.ts
@@ -5,6 +5,7 @@ import { code0ProviderPreset } from "@ccr/core/providers/presets/code0/index";
 import { deepSeekProviderPreset } from "@ccr/core/providers/presets/deepseek/index";
 import { geminiProviderPreset } from "@ccr/core/providers/presets/gemini/index";
 import { kimiCodingProviderPreset } from "@ccr/core/providers/presets/kimi-coding/index";
+import { minimaxChinaProviderPreset, minimaxGlobalProviderPreset } from "@ccr/core/providers/presets/minimax/index";
 import { mistralProviderPreset } from "@ccr/core/providers/presets/mistral/index";
 import { moonshotChinaProviderPreset, moonshotGlobalProviderPreset } from "@ccr/core/providers/presets/moonshot/index";
 import { openaiProviderPreset } from "@ccr/core/providers/presets/openai/index";
@@ -38,6 +39,8 @@ export const providerPresets: ProviderPreset[] = [
   zhipuCnGeneralProviderPreset,
   zaiGlobalCodingProviderPreset,
   zaiGlobalGeneralProviderPreset,
+  minimaxGlobalProviderPreset,
+  minimaxChinaProviderPreset,
   mistralProviderPreset,
   moonshotChinaProviderPreset,
   moonshotGlobalProviderPreset,

--- a/packages/core/src/providers/presets/minimax/index.ts
+++ b/packages/core/src/providers/presets/minimax/index.ts
@@ -1,0 +1,44 @@
+import type { ProviderPreset } from "@ccr/core/providers/presets/types";
+import { standardProviderAccountConfig } from "@ccr/core/providers/presets/types";
+
+export const minimaxGlobalProviderPreset: ProviderPreset = {
+  account: standardProviderAccountConfig,
+  aliases: ["minimax", "minimax global"],
+  defaultModels: ["MiniMax-M3"],
+  endpoints: [
+    {
+      baseUrl: "https://api.minimax.io/v1",
+      protocols: ["openai_chat_completions"],
+      websiteUrl: "https://platform.minimax.io/docs"
+    },
+    {
+      baseUrl: "https://api.minimax.io/anthropic/v1",
+      protocols: ["anthropic_messages"],
+      websiteUrl: "https://platform.minimax.io/docs"
+    }
+  ],
+  id: "minimax-global",
+  name: "MiniMax (Global)",
+  websiteUrl: "https://platform.minimax.io/docs"
+};
+
+export const minimaxChinaProviderPreset: ProviderPreset = {
+  account: standardProviderAccountConfig,
+  aliases: ["minimax", "minimaxi", "minimax china"],
+  defaultModels: ["MiniMax-M3"],
+  endpoints: [
+    {
+      baseUrl: "https://api.minimaxi.com/v1",
+      protocols: ["openai_chat_completions"],
+      websiteUrl: "https://platform.minimaxi.com/docs"
+    },
+    {
+      baseUrl: "https://api.minimaxi.com/anthropic/v1",
+      protocols: ["anthropic_messages"],
+      websiteUrl: "https://platform.minimaxi.com/docs"
+    }
+  ],
+  id: "minimax-cn",
+  name: "MiniMax (China)",
+  websiteUrl: "https://platform.minimaxi.com/docs"
+};


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax Global and China provider presets with OpenAI-compatible and Anthropic Messages endpoints.
- Set MiniMax-M3 as the default model for both MiniMax presets.

## Test plan
- npm --prefix /root/octopatch-4/work/repos/musistudio_claude-code-router ci
- npm --prefix /root/octopatch-4/work/repos/musistudio_claude-code-router run typecheck
- npm --prefix /root/octopatch-4/work/repos/musistudio_claude-code-router test (fails: Electron cannot start because libatk-1.0.so.0 is missing in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)