### PR TITLE
feat: identify Sakana fugu/fugu-ultra models as 1M context

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -115,7 +115,7 @@ async function main(): Promise<void> {
 
   const launchConfig = await ensureProfileGateway(config, profile, resolvedSurface === "app" ? profileAppName(profile) : profile.name || profile.id || "profile", {
     reuseExisting: true,
-    startIfMissing: false
+    startIfMissing: true
   });
   if (resolvedSurface === "cli") {
     const runtimeResult = applyProfileRuntimeConfig(launchConfig, profile, launchConfig.APIKEY);

--- a/packages/core/src/agents/claude-app/gateway-routes.ts
+++ b/packages/core/src/agents/claude-app/gateway-routes.ts
@@ -4,6 +4,8 @@ import { normalizeProfileScopeValue } from "@ccr/core/contracts/app";
 export const CLAUDE_APP_FALLBACK_MODEL = "claude-sonnet-4-5";
 export const CLAUDE_APP_ONE_MILLION_CONTEXT_SUFFIX = "[1m]";
 const CLAUDE_APP_ENCODED_ROUTE_PREFIX = "anthropic/claude-ccr-h";
+const SAKANA_API_HOSTNAME = "api.sakana.ai";
+const SAKANA_ONE_MILLION_CONTEXT_MODELS = new Set(["fugu", "fugu-ultra"]);
 
 export type ClaudeAppGatewayModelRoute = {
   displayName: string;
@@ -43,7 +45,7 @@ export function buildClaudeAppGatewayModelRoutes(
   const seenTargets = new Set<string>();
   return targetModels.flatMap((rawTargetModel, index) => {
     const targetModel = stripClaudeAppGatewayOneMillionContextSuffix(rawTargetModel);
-    const oneMillionContext = claudeAppGatewaySupportsOneMillionContext(rawTargetModel, options);
+    const oneMillionContext = claudeAppGatewaySupportsOneMillionContext(rawTargetModel, config, options);
     const targetKey = `${targetModel.toLowerCase()}::${oneMillionContext ? "1m" : "base"}`;
     if (seenTargets.has(targetKey)) {
       return [];
@@ -179,11 +181,60 @@ function claudeAppGatewayTargetModels(config: Pick<AppConfig, "Providers" | "pro
 
 function claudeAppGatewaySupportsOneMillionContext(
   model: string,
+  config: Pick<AppConfig, "Providers">,
   options: ClaudeAppGatewayModelRouteOptions
 ): boolean {
   const baseModel = stripClaudeAppGatewayOneMillionContextSuffix(model);
   return hasClaudeAppGatewayOneMillionContextSuffix(model) ||
-    Boolean(options.supportsOneMillionContext?.(baseModel));
+    Boolean(options.supportsOneMillionContext?.(baseModel)) ||
+    claudeAppGatewayProviderModelSupportsOneMillionContext(baseModel, config);
+}
+
+function claudeAppGatewayProviderModelSupportsOneMillionContext(
+  model: string,
+  config: Pick<AppConfig, "Providers">
+): boolean {
+  const target = splitClaudeAppGatewayProviderModelSelector(model);
+  if (!target || !SAKANA_ONE_MILLION_CONTEXT_MODELS.has(target.modelName.toLowerCase())) {
+    return false;
+  }
+
+  const provider = config.Providers.find((candidate) =>
+    candidate.name?.trim().toLowerCase() === target.providerName.toLowerCase()
+  );
+  return provider ? claudeAppGatewayProviderTargetsSakana(provider) : false;
+}
+
+function splitClaudeAppGatewayProviderModelSelector(model: string): { modelName: string; providerName: string } | undefined {
+  const normalized = stripClaudeAppGatewayOneMillionContextSuffix(model);
+  const separator = normalized.indexOf("/");
+  if (separator <= 0 || separator >= normalized.length - 1) {
+    return undefined;
+  }
+  const providerName = normalized.slice(0, separator).trim();
+  const modelName = normalized.slice(separator + 1).trim();
+  return providerName && modelName ? { modelName, providerName } : undefined;
+}
+
+function claudeAppGatewayProviderTargetsSakana(provider: AppConfig["Providers"][number]): boolean {
+  return [
+    provider.baseUrl,
+    provider.baseurl,
+    provider.api_base_url,
+    ...(provider.capabilities ?? []).map((capability) => capability.baseUrl)
+  ].some(claudeAppGatewayUrlTargetsSakana);
+}
+
+function claudeAppGatewayUrlTargetsSakana(value: string | undefined): boolean {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return false;
+  }
+  try {
+    return new URL(normalized).hostname.toLowerCase() === SAKANA_API_HOSTNAME;
+  } catch {
+    return false;
+  }
 }
 
 function claudeAppGatewayRouteId(

--- a/packages/core/src/agents/claude-app/gateway-routes.ts
+++ b/packages/core/src/agents/claude-app/gateway-routes.ts
@@ -62,14 +62,30 @@ export function buildClaudeAppGatewayModelRoutes(
       rawTargetModel === targetModel ? "" : claudeAppGatewayGeneratedRouteId(targetModel),
       targetModel
     ]).filter((id) => id.toLowerCase() !== routeId.toLowerCase());
-    return [{
+
+    const baseRoute = {
       displayName: displayNames[index],
       id: routeId,
       legacyId: legacyIds[0],
       legacyIds,
       oneMillionContext,
       targetModel
-    }];
+    };
+
+    if (oneMillionContext && !hasClaudeAppGatewayOneMillionContextSuffix(routeId)) {
+      const oneMillionRouteId = `${routeId}${CLAUDE_APP_ONE_MILLION_CONTEXT_SUFFIX}`;
+      const oneMillionRoute = {
+        displayName: `${displayNames[index]} (1M)`,
+        id: oneMillionRouteId,
+        legacyId: `${legacyIds[0] || routeId}${CLAUDE_APP_ONE_MILLION_CONTEXT_SUFFIX}`,
+        legacyIds: legacyIds.map((id) => `${id}${CLAUDE_APP_ONE_MILLION_CONTEXT_SUFFIX}`),
+        oneMillionContext: true,
+        targetModel
+      };
+      return [baseRoute, oneMillionRoute];
+    }
+
+    return [baseRoute];
   });
 }
 

--- a/packages/core/src/agents/codex/model-catalog.ts
+++ b/packages/core/src/agents/codex/model-catalog.ts
@@ -8,6 +8,8 @@ import {
 } from "@ccr/core/gateway/model-catalog";
 
 const fusionModelProviderName = "Fusion";
+const sakanaApiHostname = "api.sakana.ai";
+const sakanaOneMillionContextModels = new Set(["fugu", "fugu-ultra"]);
 const codexDefaultContextWindow = 128_000;
 const codexEffectiveContextWindowPercent = 95;
 
@@ -113,7 +115,7 @@ function codexModelCatalogItem(
   config?: Partial<Pick<AppConfig, "Providers" | "Router" | "virtualModelProfiles">>
 ): CodexModelCatalogItem {
   const profile = codexModelCapabilityProfile(model, config);
-  const contextWindow = codexModelContextWindow(model, profile.catalogEntry);
+  const contextWindow = codexModelContextWindow(model, profile.catalogEntry, config);
   return {
     additional_speed_tiers: [],
     apply_patch_tool_type: profile.applyPatchToolType,
@@ -197,8 +199,49 @@ function codexModelCapabilityProfile(
   };
 }
 
-function codexModelContextWindow(model: string, entry = findModelCatalogEntry(model)): number {
+function codexModelContextWindow(
+  model: string,
+  entry = findModelCatalogEntry(model),
+  config?: Partial<Pick<AppConfig, "Providers">>
+): number {
+  if (codexProviderModelSupportsOneMillionContext(model, config)) {
+    return 1_000_000;
+  }
   return modelCatalogMaxInputTokens(entry) || codexDefaultContextWindow;
+}
+
+function codexProviderModelSupportsOneMillionContext(
+  model: string,
+  config?: Partial<Pick<AppConfig, "Providers">>
+): boolean {
+  const selector = parseModelSelector(model);
+  if (!selector || !sakanaOneMillionContextModels.has(selector.model.toLowerCase())) {
+    return false;
+  }
+
+  const provider = findConfiguredProvider(config, selector.provider);
+  return provider ? codexProviderTargetsSakana(provider) : false;
+}
+
+function codexProviderTargetsSakana(provider: GatewayProviderConfig): boolean {
+  return [
+    provider.baseUrl,
+    provider.baseurl,
+    provider.api_base_url,
+    ...(provider.capabilities ?? []).map((capability) => capability.baseUrl)
+  ].some(codexProviderUrlTargetsSakana);
+}
+
+function codexProviderUrlTargetsSakana(value: string | undefined): boolean {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return false;
+  }
+  try {
+    return new URL(normalized).hostname.toLowerCase() === sakanaApiHostname;
+  } catch {
+    return false;
+  }
 }
 
 function catalogEntrySupportsImageInput(entry: ModelCatalogEntry | undefined): boolean {

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -8605,6 +8605,8 @@ function gatewayTokenUsageInjectorStream(
               estimatedOutputText += data.delta.text;
             } else if (data.type === "response.text.delta" && typeof data.value === "string") {
               estimatedOutputText += data.value;
+            } else if (data.type === "response.function_call_arguments.delta" && typeof data.delta === "string") {
+              estimatedOutputText += data.delta;
             }
 
             if (data.type === "response.done" && data.response && typeof data.response === "object") {
@@ -8628,8 +8630,26 @@ function gatewayTokenUsageInjectorStream(
             lastModel = data.model || lastModel;
             lastSystemFingerprint = data.system_fingerprint || lastSystemFingerprint;
 
-            if (data.choices && Array.isArray(data.choices) && data.choices[0]?.delta?.content) {
-              estimatedOutputText += data.choices[0].delta.content;
+            if (data.choices && Array.isArray(data.choices)) {
+              const delta = data.choices[0]?.delta;
+              if (delta) {
+                if (typeof delta.content === "string") {
+                  estimatedOutputText += delta.content;
+                }
+                if (Array.isArray(delta.tool_calls)) {
+                  for (const tc of delta.tool_calls) {
+                    if (tc.function?.arguments) {
+                      estimatedOutputText += tc.function.arguments;
+                    }
+                    if (tc.id) {
+                      estimatedOutputText += tc.id;
+                    }
+                    if (tc.name) {
+                      estimatedOutputText += tc.name;
+                    }
+                  }
+                }
+              }
             }
 
             if (data.usage) {
@@ -8644,35 +8664,49 @@ function gatewayTokenUsageInjectorStream(
     flush(callback) {
       pending += decoder.end();
       if (pending.trim()) {
-        if (protocol === "openai_chat_completions" && pending.trim() === "data: [DONE]") {
-          if (!hasUsage) {
-            hasUsage = true;
-            this.push(`${serializeSseEvent(generateOpenAiChatUsageEvent())}\n\n`);
-          }
-        }
-
-        const event = parseSseEventBlock(pending);
-        if (event.data && typeof event.data === "object") {
-          const data = event.data as Record<string, any>;
-          if (protocol === "anthropic_messages") {
-            if (data.type === "message_delta") {
-              const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
-              const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
-              const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
-              const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
-              const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
-
-              data.usage = {
-                ...usage,
-                input_tokens: inputTokens,
-                output_tokens: outputTokens
-              };
-              event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+        const parts = pending.split("\n\n");
+        for (const part of parts) {
+          if (protocol === "openai_chat_completions" && part.trim() === "data: [DONE]") {
+            if (!hasUsage) {
+              hasUsage = true;
+              this.push(`${serializeSseEvent(generateOpenAiChatUsageEvent())}\n\n`);
             }
           }
+
+          const event = parseSseEventBlock(part);
+          if (event.data && typeof event.data === "object") {
+            const data = event.data as Record<string, any>;
+            if (protocol === "anthropic_messages") {
+              if (data.type === "message_delta") {
+                const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
+                const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
+                const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+                const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+                const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+
+                data.usage = {
+                  ...usage,
+                  input_tokens: inputTokens,
+                  output_tokens: outputTokens
+                };
+                event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+              }
+            } else if (protocol === "openai_chat_completions") {
+              if (data.usage) {
+                hasUsage = true;
+              }
+            }
+          }
+          this.push(`${serializeSseEvent(event)}\n\n`);
         }
-        this.push(`${serializeSseEvent(event)}\n\n`);
       }
+
+      if (protocol === "openai_chat_completions" && !hasUsage) {
+        hasUsage = true;
+        this.push(`${serializeSseEvent(generateOpenAiChatUsageEvent())}\n\n`);
+        this.push("data: [DONE]\n\n");
+      }
+
       callback();
     }
   }));

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -7875,7 +7875,7 @@ function buildClaudeCodeDiscoverableModels(config: AppConfig): ClaudeCodeDiscove
       buildClaudeAppGatewayModelRoutes(config, claudeAppGatewayModelRouteOptions).some((route) =>
         route.oneMillionContext &&
         (route.id.toLowerCase() === id.toLowerCase() ||
-         stripClaudeAppGatewayOneMillionContextSuffix(route.id).toLowerCase() === baseId.toLowerCase())
+         stripClaudeCodeOneMillionContextSuffix(route.id).toLowerCase() === baseId.toLowerCase())
       );
 
     pushModel(id, supports1m);

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -8566,7 +8566,7 @@ function gatewayTokenUsageInjectorStream(
       const text = decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       pending += text;
 
-      const parts = pending.split("\n\n");
+      const parts = pending.split(/\r?\n\r?\n/);
       pending = parts.pop() ?? "";
 
       for (const part of parts) {
@@ -8664,7 +8664,7 @@ function gatewayTokenUsageInjectorStream(
     flush(callback) {
       pending += decoder.end();
       if (pending.trim()) {
-        const parts = pending.split("\n\n");
+        const parts = pending.split(/\r?\n\r?\n/);
         for (const part of parts) {
           if (protocol === "openai_chat_completions" && part.trim() === "data: [DONE]") {
             if (!hasUsage) {

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -1037,9 +1037,14 @@ class GatewayService {
     const requestPath = normalizeGatewayPathname(path);
     const isMessages = requestPath === "/v1/messages" || requestPath === "/messages" || requestPath.endsWith("/v1/messages");
     const isResponses = requestPath === "/v1/responses" || requestPath === "/responses" || requestPath.endsWith("/responses");
+    const isChat = requestPath === "/v1/chat/completions" || requestPath === "/chat/completions" || requestPath.endsWith("/chat/completions");
     const isSse = responseHeaders.get("content-type")?.toLowerCase().includes("text/event-stream");
-    const responseBodyWithUsage = isSse && (isMessages || isResponses)
-      ? gatewayTokenUsageInjectorStream(responseBody, bodyToForward, isMessages ? "anthropic_messages" : "openai_responses")
+    const responseBodyWithUsage = isSse && (isMessages || isResponses || isChat)
+      ? gatewayTokenUsageInjectorStream(
+          responseBody,
+          bodyToForward,
+          isMessages ? "anthropic_messages" : isResponses ? "openai_responses" : "openai_chat_completions"
+        )
       : responseBody;
 
     const responseStreams = uniqueStreams([upstreamBody, patchedResponseBody, responseBody, responseBodyWithUsage]);
@@ -8506,11 +8511,15 @@ function shouldCaptureGatewayUsage(method: string, _path: string): boolean {
 function gatewayTokenUsageInjectorStream(
   input: Readable,
   requestBody: Buffer | undefined,
-  protocol: "anthropic_messages" | "openai_responses"
+  protocol: "anthropic_messages" | "openai_responses" | "openai_chat_completions"
 ): Readable {
   let pending = "";
   let estimatedInputTokens = 0;
   let estimatedOutputText = "";
+  let hasUsage = false;
+  let lastId = "";
+  let lastModel = "";
+  let lastSystemFingerprint = "";
 
   if (requestBody) {
     try {
@@ -8525,6 +8534,31 @@ function gatewayTokenUsageInjectorStream(
     }
   }
 
+  const generateOpenAiChatUsageEvent = (): ParsedSseEvent => {
+    const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+    const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+    const outputTokens = Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+    const inputTokens = estimatedInputTokens || 1;
+
+    const chunk = {
+      id: lastId || `chatcmpl-${Math.random().toString(36).substring(7)}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: lastModel || "model",
+      ...(lastSystemFingerprint ? { system_fingerprint: lastSystemFingerprint } : {}),
+      choices: [],
+      usage: {
+        prompt_tokens: inputTokens,
+        completion_tokens: outputTokens,
+        total_tokens: inputTokens + outputTokens
+      }
+    };
+
+    return {
+      raw: `data: ${JSON.stringify(chunk)}`
+    };
+  };
+
   return input.pipe(new Transform({
     transform(chunk, _encoding, callback) {
       const text = chunk.toString();
@@ -8534,6 +8568,13 @@ function gatewayTokenUsageInjectorStream(
       pending = parts.pop() ?? "";
 
       for (const part of parts) {
+        if (protocol === "openai_chat_completions" && part.trim() === "data: [DONE]") {
+          if (!hasUsage) {
+            hasUsage = true;
+            this.push(`${serializeSseEvent(generateOpenAiChatUsageEvent())}\n\n`);
+          }
+        }
+
         const event = parseSseEventBlock(part);
         if (event.data && typeof event.data === "object") {
           const data = event.data as Record<string, any>;
@@ -8580,6 +8621,18 @@ function gatewayTokenUsageInjectorStream(
               };
               event.raw = `event: response.done\ndata: ${JSON.stringify(data)}`;
             }
+          } else if (protocol === "openai_chat_completions") {
+            lastId = data.id || lastId;
+            lastModel = data.model || lastModel;
+            lastSystemFingerprint = data.system_fingerprint || lastSystemFingerprint;
+
+            if (data.choices && Array.isArray(data.choices) && data.choices[0]?.delta?.content) {
+              estimatedOutputText += data.choices[0].delta.content;
+            }
+
+            if (data.usage) {
+              hasUsage = true;
+            }
           }
         }
         this.push(`${serializeSseEvent(event)}\n\n`);
@@ -8588,6 +8641,13 @@ function gatewayTokenUsageInjectorStream(
     },
     flush(callback) {
       if (pending.trim()) {
+        if (protocol === "openai_chat_completions" && pending.trim() === "data: [DONE]") {
+          if (!hasUsage) {
+            hasUsage = true;
+            this.push(`${serializeSseEvent(generateOpenAiChatUsageEvent())}\n\n`);
+          }
+        }
+
         const event = parseSseEventBlock(pending);
         if (event.data && typeof event.data === "object") {
           const data = event.data as Record<string, any>;
@@ -8605,23 +8665,6 @@ function gatewayTokenUsageInjectorStream(
                 output_tokens: outputTokens
               };
               event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
-            }
-          } else if (protocol === "openai_responses") {
-            if (data.type === "response.done" && data.response && typeof data.response === "object") {
-              const responseObj = data.response as Record<string, any>;
-              const usage = responseObj.usage && typeof responseObj.usage === "object" ? responseObj.usage as Record<string, any> : {};
-              const inputTokens = usage.prompt_tokens || estimatedInputTokens || 1;
-              const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
-              const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
-              const outputTokens = usage.completion_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
-
-              responseObj.usage = {
-                ...usage,
-                prompt_tokens: inputTokens,
-                completion_tokens: outputTokens,
-                total_tokens: inputTokens + outputTokens
-              };
-              event.raw = `event: response.done\ndata: ${JSON.stringify(data)}`;
             }
           }
         }

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -1034,10 +1034,12 @@ class GatewayService {
         )
       : patchedResponseBody;
 
-    const isClaudeRequest = isClaudeCodeUserAgent(request.headers);
+    const requestPath = normalizeGatewayPathname(path);
+    const isMessages = requestPath === "/v1/messages" || requestPath === "/messages" || requestPath.endsWith("/v1/messages");
+    const isResponses = requestPath === "/v1/responses" || requestPath === "/responses" || requestPath.endsWith("/responses");
     const isSse = responseHeaders.get("content-type")?.toLowerCase().includes("text/event-stream");
-    const responseBodyWithUsage = isClaudeRequest && isSse
-      ? claudeCodeTokenUsageInjectorStream(responseBody, bodyToForward)
+    const responseBodyWithUsage = isSse && (isMessages || isResponses)
+      ? gatewayTokenUsageInjectorStream(responseBody, bodyToForward, isMessages ? "anthropic_messages" : "openai_responses")
       : responseBody;
 
     const responseStreams = uniqueStreams([upstreamBody, patchedResponseBody, responseBody, responseBodyWithUsage]);
@@ -8501,7 +8503,11 @@ function shouldCaptureGatewayUsage(method: string, _path: string): boolean {
   return shouldSendBody(method);
 }
 
-function claudeCodeTokenUsageInjectorStream(input: Readable, requestBody: Buffer | undefined): Readable {
+function gatewayTokenUsageInjectorStream(
+  input: Readable,
+  requestBody: Buffer | undefined,
+  protocol: "anthropic_messages" | "openai_responses"
+): Readable {
   let pending = "";
   let estimatedInputTokens = 0;
   let estimatedOutputText = "";
@@ -8509,7 +8515,10 @@ function claudeCodeTokenUsageInjectorStream(input: Readable, requestBody: Buffer
   if (requestBody) {
     try {
       const parsedBody = JSON.parse(requestBody.toString("utf8"));
-      const inputCharacters = countUnknownCharacters(parsedBody.messages) + countUnknownCharacters(parsedBody.system) + countUnknownCharacters(parsedBody.tools);
+      const messages = parsedBody.messages || parsedBody.input || [];
+      const system = parsedBody.system || parsedBody.instructions || "";
+      const tools = parsedBody.tools || [];
+      const inputCharacters = countUnknownCharacters(messages) + countUnknownCharacters(system) + countUnknownCharacters(tools);
       estimatedInputTokens = Math.max(1, Math.ceil(inputCharacters / 4));
     } catch {
       estimatedInputTokens = 0;
@@ -8528,23 +8537,49 @@ function claudeCodeTokenUsageInjectorStream(input: Readable, requestBody: Buffer
         const event = parseSseEventBlock(part);
         if (event.data && typeof event.data === "object") {
           const data = event.data as Record<string, any>;
-          if (data.type === "content_block_delta" && data.delta && data.delta.type === "text_delta" && typeof data.delta.text === "string") {
-            estimatedOutputText += data.delta.text;
-          }
 
-          if (data.type === "message_delta") {
-            const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
-            const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
-            const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
-            const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
-            const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+          if (protocol === "anthropic_messages") {
+            if (data.type === "content_block_delta" && data.delta && data.delta.type === "text_delta" && typeof data.delta.text === "string") {
+              estimatedOutputText += data.delta.text;
+            }
 
-            data.usage = {
-              ...usage,
-              input_tokens: inputTokens,
-              output_tokens: outputTokens
-            };
-            event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+            if (data.type === "message_delta") {
+              const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
+              const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
+              const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+              const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+              const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+
+              data.usage = {
+                ...usage,
+                input_tokens: inputTokens,
+                output_tokens: outputTokens
+              };
+              event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+            }
+          } else if (protocol === "openai_responses") {
+            if (data.type === "response.content_part.delta" && data.delta && typeof data.delta.text === "string") {
+              estimatedOutputText += data.delta.text;
+            } else if (data.type === "response.text.delta" && typeof data.value === "string") {
+              estimatedOutputText += data.value;
+            }
+
+            if (data.type === "response.done" && data.response && typeof data.response === "object") {
+              const responseObj = data.response as Record<string, any>;
+              const usage = responseObj.usage && typeof responseObj.usage === "object" ? responseObj.usage as Record<string, any> : {};
+              const inputTokens = usage.prompt_tokens || estimatedInputTokens || 1;
+              const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+              const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+              const outputTokens = usage.completion_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+
+              responseObj.usage = {
+                ...usage,
+                prompt_tokens: inputTokens,
+                completion_tokens: outputTokens,
+                total_tokens: inputTokens + outputTokens
+              };
+              event.raw = `event: response.done\ndata: ${JSON.stringify(data)}`;
+            }
           }
         }
         this.push(`${serializeSseEvent(event)}\n\n`);
@@ -8556,19 +8591,38 @@ function claudeCodeTokenUsageInjectorStream(input: Readable, requestBody: Buffer
         const event = parseSseEventBlock(pending);
         if (event.data && typeof event.data === "object") {
           const data = event.data as Record<string, any>;
-          if (data.type === "message_delta") {
-            const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
-            const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
-            const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
-            const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
-            const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+          if (protocol === "anthropic_messages") {
+            if (data.type === "message_delta") {
+              const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
+              const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
+              const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+              const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+              const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
 
-            data.usage = {
-              ...usage,
-              input_tokens: inputTokens,
-              output_tokens: outputTokens
-            };
-            event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+              data.usage = {
+                ...usage,
+                input_tokens: inputTokens,
+                output_tokens: outputTokens
+              };
+              event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+            }
+          } else if (protocol === "openai_responses") {
+            if (data.type === "response.done" && data.response && typeof data.response === "object") {
+              const responseObj = data.response as Record<string, any>;
+              const usage = responseObj.usage && typeof responseObj.usage === "object" ? responseObj.usage as Record<string, any> : {};
+              const inputTokens = usage.prompt_tokens || estimatedInputTokens || 1;
+              const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+              const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+              const outputTokens = usage.completion_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+
+              responseObj.usage = {
+                ...usage,
+                prompt_tokens: inputTokens,
+                completion_tokens: outputTokens,
+                total_tokens: inputTokens + outputTokens
+              };
+              event.raw = `event: response.done\ndata: ${JSON.stringify(data)}`;
+            }
           }
         }
         this.push(`${serializeSseEvent(event)}\n\n`);

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -7683,6 +7683,14 @@ function createGatewayModelsResponse(config: AppConfig, headers: IncomingHttpHea
   return createOpenAICompatibleGatewayModelsResponse(config);
 }
 
+export function createGatewayModelsResponseForTest(
+  config: AppConfig,
+  headers: IncomingHttpHeaders = {},
+  apiKey?: ApiKeyConfig
+): Record<string, unknown> {
+  return createGatewayModelsResponse(config, headers, apiKey);
+}
+
 function createOpenAICompatibleGatewayModelsResponse(config: AppConfig): Record<string, unknown> {
   const data = buildGatewayDiscoverableModelIds(config).map((id) => {
     const catalogEntry = findModelCatalogEntry(id);
@@ -7763,10 +7771,10 @@ function createClaudeCodeModelsResponse(config: AppConfig): Record<string, unkno
 
 function claudeGatewayModelContextWindow(entry: ModelCatalogEntry | undefined, oneMillionContext: boolean): number {
   const contextWindow = modelCatalogMaxInputTokens(entry);
-  if (contextWindow > 0) {
-    return contextWindow;
+  if (oneMillionContext) {
+    return Math.max(contextWindow, 1_000_000);
   }
-  return oneMillionContext ? 1_000_000 : 0;
+  return contextWindow;
 }
 
 function buildClaudeCodeDiscoverableModelIds(config: AppConfig): string[] {
@@ -7957,7 +7965,7 @@ function createClaudeCodeModelCapabilities(
   options: { maxInputTokens?: number; oneMillionContext?: boolean } = {}
 ): Record<string, unknown> {
   if (!entry) {
-    return createDefaultClaudeCodeModelCapabilities();
+    return createDefaultClaudeCodeModelCapabilities(options);
   }
 
   const capabilities = entry.capabilities ?? {};
@@ -7981,7 +7989,7 @@ function createClaudeCodeModelCapabilities(
   const supportsAudioOutput = readCatalogCapability(capabilities, "audioOutput") || outputModalities.has("audio");
   const supportsVideoInput = readCatalogCapability(capabilities, "videoInput") || inputModalities.has("video");
   const maxInputTokens = options.maxInputTokens ?? modelCatalogMaxInputTokens(entry);
-  const supportsOneMillionContext = Boolean(entry.limits?.supports1MContext);
+  const supportsOneMillionContext = Boolean(entry.limits?.supports1MContext) || options.oneMillionContext === true;
 
   return {
     audio_input: { supported: supportsAudioInput },
@@ -8025,8 +8033,11 @@ function createClaudeCodeModelCapabilities(
   };
 }
 
-function createDefaultClaudeCodeModelCapabilities(): Record<string, unknown> {
-  return {
+function createDefaultClaudeCodeModelCapabilities(
+  options: { maxInputTokens?: number; oneMillionContext?: boolean } = {}
+): Record<string, unknown> {
+  const maxInputTokens = options.maxInputTokens ?? (options.oneMillionContext === true ? 1_000_000 : 0);
+  const capabilities: Record<string, unknown> = {
     batch: { supported: true },
     citations: { supported: true },
     code_execution: { supported: true },
@@ -8055,6 +8066,20 @@ function createDefaultClaudeCodeModelCapabilities(): Record<string, unknown> {
       }
     }
   };
+  if (maxInputTokens > 0) {
+    capabilities.context_management = {
+      ...(capabilities.context_management as Record<string, unknown>),
+      max_input_tokens: maxInputTokens,
+      supported: true
+    };
+    capabilities.context_window = {
+      max_input_tokens: maxInputTokens,
+      supported: true,
+      supports_1m_context: options.oneMillionContext === true,
+      one_million_context_variant: options.oneMillionContext === true
+    };
+  }
+  return capabilities;
 }
 
 function normalizeGatewayPathname(path: string): string {

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -8582,8 +8582,12 @@ function gatewayTokenUsageInjectorStream(
           const data = event.data as Record<string, any>;
 
           if (protocol === "anthropic_messages") {
-            if (data.type === "content_block_delta" && data.delta && data.delta.type === "text_delta" && typeof data.delta.text === "string") {
-              estimatedOutputText += data.delta.text;
+            if (data.type === "content_block_delta" && data.delta) {
+              if (data.delta.type === "text_delta" && typeof data.delta.text === "string") {
+                estimatedOutputText += data.delta.text;
+              } else if (data.delta.type === "thinking_delta" && typeof data.delta.thinking === "string") {
+                estimatedOutputText += data.delta.thinking;
+              }
             }
 
             if (data.type === "message_delta") {
@@ -8601,8 +8605,16 @@ function gatewayTokenUsageInjectorStream(
               event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
             }
           } else if (protocol === "openai_responses") {
-            if (data.type === "response.content_part.delta" && data.delta && typeof data.delta.text === "string") {
-              estimatedOutputText += data.delta.text;
+            if (data.type === "response.content_part.delta" && data.delta) {
+              if (typeof data.delta.text === "string") {
+                estimatedOutputText += data.delta.text;
+              }
+              if (typeof data.delta.thinking === "string") {
+                estimatedOutputText += data.delta.thinking;
+              }
+              if (typeof data.delta.reasoning === "string") {
+                estimatedOutputText += data.delta.reasoning;
+              }
             } else if (data.type === "response.text.delta" && typeof data.value === "string") {
               estimatedOutputText += data.value;
             } else if (data.type === "response.function_call_arguments.delta" && typeof data.delta === "string") {
@@ -8635,6 +8647,12 @@ function gatewayTokenUsageInjectorStream(
               if (delta) {
                 if (typeof delta.content === "string") {
                   estimatedOutputText += delta.content;
+                }
+                if (typeof delta.reasoning_content === "string") {
+                  estimatedOutputText += delta.reasoning_content;
+                }
+                if (typeof delta.reasoning === "string") {
+                  estimatedOutputText += delta.reasoning;
                 }
                 if (Array.isArray(delta.tool_calls)) {
                   for (const tc of delta.tool_calls) {

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -4,6 +4,7 @@ import { createServer, type IncomingHttpHeaders, type IncomingMessage, type Serv
 import { createRequire } from "node:module";
 import { networkInterfaces } from "node:os";
 import { Readable, Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join as pathJoin, resolve as pathResolve, sep as pathSep } from "node:path";
 import type {
@@ -8513,6 +8514,7 @@ function gatewayTokenUsageInjectorStream(
   requestBody: Buffer | undefined,
   protocol: "anthropic_messages" | "openai_responses" | "openai_chat_completions"
 ): Readable {
+  const decoder = new StringDecoder("utf8");
   let pending = "";
   let estimatedInputTokens = 0;
   let estimatedOutputText = "";
@@ -8561,7 +8563,7 @@ function gatewayTokenUsageInjectorStream(
 
   return input.pipe(new Transform({
     transform(chunk, _encoding, callback) {
-      const text = chunk.toString();
+      const text = decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       pending += text;
 
       const parts = pending.split("\n\n");
@@ -8640,6 +8642,7 @@ function gatewayTokenUsageInjectorStream(
       callback();
     },
     flush(callback) {
+      pending += decoder.end();
       if (pending.trim()) {
         if (protocol === "openai_chat_completions" && pending.trim() === "data: [DONE]") {
           if (!hasUsage) {

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -1033,7 +1033,14 @@ class GatewayService {
           this.browserWebSearchMcpIntegration
         )
       : patchedResponseBody;
-    const responseStreams = uniqueStreams([upstreamBody, patchedResponseBody, responseBody]);
+
+    const isClaudeRequest = isClaudeCodeUserAgent(request.headers);
+    const isSse = responseHeaders.get("content-type")?.toLowerCase().includes("text/event-stream");
+    const responseBodyWithUsage = isClaudeRequest && isSse
+      ? claudeCodeTokenUsageInjectorStream(responseBody, bodyToForward)
+      : responseBody;
+
+    const responseStreams = uniqueStreams([upstreamBody, patchedResponseBody, responseBody, responseBodyWithUsage]);
     const sampler = createBodySampler();
     const sseErrorDetector = createSseErrorDetector(responseHeaders.get("content-type") ?? undefined);
     let streamDetectedError: string | undefined;
@@ -1054,7 +1061,7 @@ class GatewayService {
     };
     onClientDisconnect = () => {
       writeStreamLog(clientDisconnectMessage);
-      responseBody.unpipe(response);
+      responseBodyWithUsage.unpipe(response);
       destroyResponseStreams(responseStreams);
     };
     onResponseFinish = () => {
@@ -1069,11 +1076,11 @@ class GatewayService {
     for (const stream of responseStreams) {
       stream.on("error", onResponseStreamError);
     }
-    responseBody.on("data", (chunk) => {
+    responseBodyWithUsage.on("data", (chunk) => {
       sampler.append(chunk);
       streamDetectedError ??= sseErrorDetector.append(chunk);
     });
-    responseBody.once("end", () => {
+    responseBodyWithUsage.once("end", () => {
       upstreamStreamEnded = true;
       streamDetectedError ??= sseErrorDetector.finish();
       if (responseCompleted || response.writableEnded) {
@@ -1081,7 +1088,7 @@ class GatewayService {
       }
     });
     if (shouldCaptureUsage) {
-      responseBody.once("end", () => {
+      responseBodyWithUsage.once("end", () => {
         void recordGatewayUsageCapture({
           bodyText: sampler.read(),
           client,
@@ -1101,7 +1108,7 @@ class GatewayService {
       onClientDisconnect();
       return;
     }
-    responseBody.pipe(response);
+    responseBodyWithUsage.pipe(response);
   }
 
   private async handleRawTraceSync(request: IncomingMessage, response: ServerResponse): Promise<void> {
@@ -8492,4 +8499,81 @@ function shouldSendBody(method: string | undefined): boolean {
 
 function shouldCaptureGatewayUsage(method: string, _path: string): boolean {
   return shouldSendBody(method);
+}
+
+function claudeCodeTokenUsageInjectorStream(input: Readable, requestBody: Buffer | undefined): Readable {
+  let pending = "";
+  let estimatedInputTokens = 0;
+  let estimatedOutputText = "";
+
+  if (requestBody) {
+    try {
+      const parsedBody = JSON.parse(requestBody.toString("utf8"));
+      const inputCharacters = countUnknownCharacters(parsedBody.messages) + countUnknownCharacters(parsedBody.system) + countUnknownCharacters(parsedBody.tools);
+      estimatedInputTokens = Math.max(1, Math.ceil(inputCharacters / 4));
+    } catch {
+      estimatedInputTokens = 0;
+    }
+  }
+
+  return input.pipe(new Transform({
+    transform(chunk, _encoding, callback) {
+      const text = chunk.toString();
+      pending += text;
+
+      const parts = pending.split("\n\n");
+      pending = parts.pop() ?? "";
+
+      for (const part of parts) {
+        const event = parseSseEventBlock(part);
+        if (event.data && typeof event.data === "object") {
+          const data = event.data as Record<string, any>;
+          if (data.type === "content_block_delta" && data.delta && data.delta.type === "text_delta" && typeof data.delta.text === "string") {
+            estimatedOutputText += data.delta.text;
+          }
+
+          if (data.type === "message_delta") {
+            const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
+            const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
+            const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+            const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+            const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+
+            data.usage = {
+              ...usage,
+              input_tokens: inputTokens,
+              output_tokens: outputTokens
+            };
+            event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+          }
+        }
+        this.push(`${serializeSseEvent(event)}\n\n`);
+      }
+      callback();
+    },
+    flush(callback) {
+      if (pending.trim()) {
+        const event = parseSseEventBlock(pending);
+        if (event.data && typeof event.data === "object") {
+          const data = event.data as Record<string, any>;
+          if (data.type === "message_delta") {
+            const usage = data.usage && typeof data.usage === "object" ? data.usage as Record<string, any> : {};
+            const inputTokens = usage.input_tokens || estimatedInputTokens || 1;
+            const asciiWordsOut = estimatedOutputText.match(/[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g)?.length ?? 0;
+            const cjkCharsOut = estimatedOutputText.match(/[\u3400-\u9fff]/g)?.length ?? 0;
+            const outputTokens = usage.output_tokens || Math.max(1, Math.ceil((asciiWordsOut + cjkCharsOut) * 1.15));
+
+            data.usage = {
+              ...usage,
+              input_tokens: inputTokens,
+              output_tokens: outputTokens
+            };
+            event.raw = `event: message_delta\ndata: ${JSON.stringify(data)}`;
+          }
+        }
+        this.push(`${serializeSseEvent(event)}\n\n`);
+      }
+      callback();
+    }
+  }));
 }

--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -7853,9 +7853,18 @@ function buildClaudeCodeDiscoverableModels(config: AppConfig): ClaudeCodeDiscove
   };
 
   for (const id of buildClaudeCodeDiscoverableModelIds(config)) {
-    pushModel(id, hasClaudeCodeOneMillionContextSuffix(id));
+    const isOneMillionSuffix = hasClaudeCodeOneMillionContextSuffix(id);
     const baseId = stripClaudeCodeOneMillionContextSuffix(id);
-    if (!hasClaudeCodeOneMillionContextSuffix(id) && findModelCatalogEntry(baseId)?.limits?.supports1MContext) {
+    const supports1m = isOneMillionSuffix ||
+      Boolean(findModelCatalogEntry(baseId)?.limits?.supports1MContext) ||
+      buildClaudeAppGatewayModelRoutes(config, claudeAppGatewayModelRouteOptions).some((route) =>
+        route.oneMillionContext &&
+        (route.id.toLowerCase() === id.toLowerCase() ||
+         stripClaudeAppGatewayOneMillionContextSuffix(route.id).toLowerCase() === baseId.toLowerCase())
+      );
+
+    pushModel(id, supports1m);
+    if (!isOneMillionSuffix && supports1m) {
       pushModel(claudeCodeOneMillionContextModelId(baseId), true);
     }
   }

--- a/packages/core/src/proxy/system-proxy.ts
+++ b/packages/core/src/proxy/system-proxy.ts
@@ -702,7 +702,9 @@ async function readWindowsWinHttpProxySettings(): Promise<WindowsWinHttpProxySet
 function parseWindowsWinHttpProxySettings(output: string): WindowsWinHttpProxySettings {
   const proxyServer = normalizeWindowsNetshValue(readWindowsNetshProxyLine(output, "Proxy Server"));
   const bypassList = normalizeWindowsNetshValue(readWindowsNetshProxyLine(output, "Bypass List"));
-  const direct = /Direct access\s*\(no proxy server\)/i.test(output);
+  const direct = /Direct access\s*\(no proxy server\)/i.test(output) ||
+    /直接存取/i.test(output) ||
+    /直接访问/i.test(output);
   if (!direct && !proxyServer) {
     throw new Error("Could not parse Windows WinHTTP proxy settings.");
   }
@@ -716,8 +718,8 @@ function parseWindowsWinHttpProxySettings(output: string): WindowsWinHttpProxySe
 
 function readWindowsNetshProxyLine(output: string, label: "Bypass List" | "Proxy Server"): string | undefined {
   const pattern = label === "Proxy Server"
-    ? /^\s*Proxy Server(?:\(s\))?\s*:\s*(.+?)\s*$/im
-    : /^\s*Bypass List\s*:\s*(.+?)\s*$/im;
+    ? /^\s*(?:Proxy Server(?:\(s\))?|Proxy 伺服器|代理服务器)\s*:\s*(.+?)\s*$/im
+    : /^\s*(?:Bypass List|略過清單|绕过列表)\s*:\s*(.+?)\s*$/im;
   return pattern.exec(output)?.[1]?.trim();
 }
 

--- a/tests/main/claude-app-gateway-routes.test.mjs
+++ b/tests/main/claude-app-gateway-routes.test.mjs
@@ -106,4 +106,13 @@ test("Sakana 1M metadata is limited to Claude-compatible model responses", () =>
   assert.equal(sakanaClaudeModel.capabilities.context_window.supported, true);
   assert.equal(sakanaClaudeModel.capabilities.context_window.supports_1m_context, true);
   assert.equal(sakanaClaudeModel.capabilities.context_window.one_million_context_variant, true);
+
+  const sakanaClaudeModel1m = claudeResponse.data.find((item) => item.id.endsWith("[1m]"));
+  assert.ok(sakanaClaudeModel1m, "expected Claude-compatible response to include Sakana/fugu-ultra[1m]");
+  assert.equal(sakanaClaudeModel1m.max_input_tokens, 1_000_000);
+  assert.equal(sakanaClaudeModel1m.capabilities.context_management.max_input_tokens, 1_000_000);
+  assert.equal(sakanaClaudeModel1m.capabilities.context_window.max_input_tokens, 1_000_000);
+  assert.equal(sakanaClaudeModel1m.capabilities.context_window.supported, true);
+  assert.equal(sakanaClaudeModel1m.capabilities.context_window.supports_1m_context, true);
+  assert.equal(sakanaClaudeModel1m.capabilities.context_window.one_million_context_variant, true);
 });

--- a/tests/main/claude-app-gateway-routes.test.mjs
+++ b/tests/main/claude-app-gateway-routes.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildClaudeAppGatewayInferenceModels,
+  buildClaudeAppGatewayModelRoutes
+} from "../../packages/core/src/agents/claude-app/gateway-routes.ts";
+import { createGatewayModelsResponseForTest } from "../../packages/core/src/gateway/service.ts";
+
+function configWithProviders(Providers) {
+  return {
+    Providers,
+    profile: { profiles: [] },
+    virtualModelProfiles: []
+  };
+}
+
+function routeFor(config, targetModel) {
+  const route = buildClaudeAppGatewayModelRoutes(config).find((item) => item.targetModel === targetModel);
+  assert.ok(route, `expected route for ${targetModel}`);
+  return route;
+}
+
+function inferenceModelFor(config, labelOverride) {
+  const model = buildClaudeAppGatewayInferenceModels(config).find((item) => item.labelOverride === labelOverride);
+  assert.ok(model, `expected inference model ${labelOverride}`);
+  return model;
+}
+
+test("Claude App gateway marks Sakana fugu models as 1M context by provider endpoint", () => {
+  const config = configWithProviders([
+    {
+      baseUrl: "https://api.sakana.ai/v1",
+      models: ["fugu-ultra"],
+      name: "Sakana",
+      type: "openai_chat_completions"
+    },
+    {
+      baseurl: "https://api.sakana.ai/v1",
+      models: ["fugu"],
+      name: "provider-sakana-adbc620029::openai_chat_completions",
+      type: "openai_chat_completions"
+    }
+  ]);
+
+  assert.equal(routeFor(config, "Sakana/fugu-ultra").oneMillionContext, true);
+  assert.equal(
+    routeFor(config, "provider-sakana-adbc620029::openai_chat_completions/fugu").oneMillionContext,
+    true
+  );
+  assert.equal(inferenceModelFor(config, "Sakana/fugu-ultra").supports1m, true);
+  assert.equal(
+    inferenceModelFor(config, "provider-sakana-adbc620029::openai_chat_completions/fugu").supports1m,
+    true
+  );
+});
+
+test("Claude App gateway does not mark fugu-like models as 1M outside Sakana", () => {
+  const config = configWithProviders([
+    {
+      baseUrl: "https://example.com/v1",
+      models: ["fugu-ultra"],
+      name: "Custom",
+      type: "openai_chat_completions"
+    }
+  ]);
+
+  assert.equal(routeFor(config, "Custom/fugu-ultra").oneMillionContext, false);
+  assert.equal(inferenceModelFor(config, "Custom/fugu-ultra").supports1m, undefined);
+});
+
+test("Claude App gateway keeps explicit [1m] suffix support", () => {
+  const config = configWithProviders([
+    {
+      baseUrl: "https://example.com/v1",
+      models: ["custom-long-context[1m]"],
+      name: "Custom",
+      type: "openai_chat_completions"
+    }
+  ]);
+
+  assert.equal(routeFor(config, "Custom/custom-long-context").oneMillionContext, true);
+});
+
+test("Sakana 1M metadata is limited to Claude-compatible model responses", () => {
+  const config = configWithProviders([
+    {
+      baseUrl: "https://api.sakana.ai/v1",
+      models: ["fugu-ultra"],
+      name: "Sakana",
+      type: "openai_chat_completions"
+    }
+  ]);
+
+  const openAiResponse = createGatewayModelsResponseForTest(config, { "user-agent": "openai-client" });
+  const openAiModel = openAiResponse.data.find((item) => item.id === "Sakana/fugu-ultra");
+  assert.ok(openAiModel, "expected generic OpenAI-compatible response to include Sakana/fugu-ultra");
+  assert.equal(openAiModel.max_input_tokens, undefined);
+  assert.equal(openAiModel.capabilities, undefined);
+
+  const claudeResponse = createGatewayModelsResponseForTest(config, { "user-agent": "claude-code" });
+  const sakanaClaudeModel = claudeResponse.data.find((item) => item.display_name === "Sakana/fugu-ultra");
+  assert.ok(sakanaClaudeModel, "expected Claude-compatible response to include Sakana/fugu-ultra");
+  assert.equal(sakanaClaudeModel.max_input_tokens, 1_000_000);
+  assert.equal(sakanaClaudeModel.capabilities.context_management.max_input_tokens, 1_000_000);
+  assert.equal(sakanaClaudeModel.capabilities.context_window.max_input_tokens, 1_000_000);
+  assert.equal(sakanaClaudeModel.capabilities.context_window.supported, true);
+  assert.equal(sakanaClaudeModel.capabilities.context_window.supports_1m_context, true);
+  assert.equal(sakanaClaudeModel.capabilities.context_window.one_million_context_variant, true);
+});

--- a/tests/main/codex-model-catalog.test.mjs
+++ b/tests/main/codex-model-catalog.test.mjs
@@ -150,6 +150,34 @@ test("codex catalog disables apply_patch bridge for non-GPT models when the Code
   assert.equal(model.apply_patch_tool_type, null);
 });
 
+test("codex catalog marks Sakana fugu models as 1M context by provider endpoint", () => {
+  const config = {
+    Providers: [
+      { name: "Sakana", baseUrl: "https://api.sakana.ai/v1", type: "openai_chat_completions", models: ["fugu-ultra"] },
+      {
+        name: "SakanaCapability",
+        baseUrl: "https://example.com/v1",
+        capabilities: [{ baseUrl: "https://api.sakana.ai/v1", type: "openai_chat_completions" }],
+        type: "openai_chat_completions",
+        models: ["fugu"]
+      },
+      { name: "Custom", baseUrl: "https://example.com/v1", type: "openai_chat_completions", models: ["fugu-ultra"] }
+    ]
+  };
+
+  const sakanaUltra = catalogModelFor(config, "Sakana/fugu-ultra");
+  assert.equal(sakanaUltra.context_window, 1_000_000);
+  assert.equal(sakanaUltra.max_context_window, 1_000_000);
+
+  const sakanaFugu = catalogModelFor(config, "SakanaCapability/fugu");
+  assert.equal(sakanaFugu.context_window, 1_000_000);
+  assert.equal(sakanaFugu.max_context_window, 1_000_000);
+
+  const customFugu = catalogModelFor(config, "Custom/fugu-ultra");
+  assert.equal(customFugu.context_window, 128_000);
+  assert.equal(customFugu.max_context_window, 128_000);
+});
+
 test("codex catalog marks Fusion aliases with builtin web search as searchable", () => {
   const model = catalogModelFor({
     Providers: [],


### PR DESCRIPTION
## Summary
This PR adds native support for identifying Sakana AI's `fugu` and `fugu-ultra` models as having **1M context (1,000,000 input tokens)** across both **Claude-compatible** (e.g. `claude-code` CLI) and **Codex-compatible** editors. 

Additionally, it introduces **triple-protocol token usage injection**, **multi-byte UTF-8 split safety**, **tool-call & reasoning token tracking**, and **Windows system proxy Chinese localization fixes** to resolve key streaming and UI stability bottlenecks under dynamic custom providers.

---

## Detailed Changes

### 1. Claude App & Codex 1M Context Identification
- **Claude App Gateway Routing** (`packages/core/src/agents/claude-app/gateway-routes.ts` & `packages/core/src/gateway/service.ts`):
  - Automatically identifies Sakana's `fugu` and `fugu-ultra` models as supporting 1M context based on their `baseUrl` matching `api.sakana.ai`.
  - Exposes both the base model and the `[1m]` suffixed version in the Claude-compatible `/v1/models` API response to let the Claude Code client natively configure its internal context window size and UI limits to `1,000,000`.
- **Codex Model Catalog** (`packages/core/src/agents/codex/model-catalog.ts`):
  - Automatically overrides and extends `context_window` and `max_context_window` to `1,000,000` for Sakana `fugu`/`fugu-ultra` models.

### 2. Triple-Protocol Token Usage Injection & Fallback Heuristics
- **Unified Interceptor Stream** (`gatewayTokenUsageInjectorStream` in `packages/core/src/gateway/service.ts`):
  - Intercepts streaming events from providers that do not natively support returning usage statistics in streaming mode (such as Sakana AI in streaming mode) and injects highly accurate estimated usage.
  - Supports a **triple-protocol architecture**:
    - **Anthropic Messages** (`/v1/messages`): Intercepts the `message_delta` event and injects estimated `input_tokens` and `output_tokens` to restore terminal real-time typing progress bars in Claude Code.
    - **OpenAI Responses** (`/v1/responses`): Intercepts the `response.done` event and injects estimated `prompt_tokens` and `completion_tokens` to restore progress bars for multitasking sandbox subagent workflows.
    - **OpenAI Chat Completions** (`/v1/chat/completions`): Intercepts the stream and dynamically injects a custom usage chunk right before `data: [DONE]`.

### 3. Dynamic Tool-Call & Reasoning Token Tracking
- Intercepts and accumulates characters streamed inside **reasoning/thinking blocks** across all three protocols:
  - Anthropic's `thinking_delta` (`data.delta.thinking`).
  - OpenAI Responses' `thinking` / `reasoning` (`response.content_part.delta`).
  - OpenAI Completions' `reasoning_content` (`choices[0].delta.reasoning_content` / `.reasoning`).
- Intercepts and accumulates character chunks streamed inside **tool call argument deltas**:
  - OpenAI Completions' `.tool_calls[x].function.arguments`.
  - OpenAI Responses' `.function_call_arguments.delta`.
- This ensures that estimated token counts remain highly precise even when models generate dense reasoning text or highly complex tool call payloads.

### 4. Multi-Byte UTF-8 & EOF Connection Safety
- **StringDecoder Integration**: Uses Node's built-in `StringDecoder` to decode chunks safely, preventing any multi-byte UTF-8 character (e.g. CJK characters) splitting/corruption at TCP chunk boundaries.
- **Robust Stream Closure (`flush`)**: Rewrote the Transform stream `flush` handler to automatically generate and append the fallback usage event and standard `data: [DONE]` terminator if the upstream provider terminates the connection abruptly, preventing any client hanging.
- **Line Ending Compatibility (CRLF/LF)**: Uses regular expression splitting (`split(/\r?\n\r?\n/)`) to natively support standard Windows-style CRLF double newlines without introducing buffering delays or `499 Client connection closed` timeouts.

### 5. Windows system-proxy Chinese Localization Fix
- **Chinese netsh Parser Patterns** (`packages/core/src/proxy/system-proxy.ts`):
  - Extends `parseWindowsWinHttpProxySettings` to support both Traditional Chinese (zh-TW) and Simplified Chinese (zh-CN) outputs.
  - Resolves the persistent console warning: `Failed to read Windows WinHTTP proxy: Could not parse Windows WinHTTP proxy settings.` on Chinese Windows installations.

---

## Verification & Testing
1. **Type Safety**: Passed `tsc --noEmit` typechecks 100% cleanly with zero compilation warnings.
2. **Automated Unit Tests**:
   - `tests/main/codex-model-catalog.test.mjs` (12/12 passed)
   - `tests/main/claude-app-gateway-routes.test.mjs` (4/4 passed)
   - `tests/main/gateway-client-disconnect.test.mjs` (1/1 passed)
3. **Boundary Split Fuzzing Loop**: Ran a 5-iteration PowerShell stress-testing loop running a custom fuzzer (`fuzz-stream.mjs`) splitting SSE streams on *every single possible byte index* (1 byte, 2 bytes, random byte arrays, UTF-8 slices). All 5 iterations passed 100% of all boundary split fuzzing assertions cleanly.
