### PR TITLE
Fix : Windows CLI launching and desktop app discovery

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,6 +57,7 @@ const serviceStopTimeoutMs = 10_000;
 const webAuthHeader = "x-ccr-web-auth";
 const webAuthQueryParam = "ccr_web_token";
 const defaultCliCommandName = "ccr";
+const prepareProfileOnlyEnv = "CCR_CLI_PREPARE_PROFILE_ONLY";
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
@@ -122,6 +123,9 @@ async function main(): Promise<void> {
     if (!runtimeResult.ok) {
       throw new Error(runtimeResult.message);
     }
+  }
+  if (resolvedSurface === "cli" && process.env[prepareProfileOnlyEnv] === "1") {
+    return;
   }
   if (profile.agent === "claude-code" && resolvedSurface === "app") {
     applyClaudeAppGatewayConfig(launchConfig);

--- a/packages/core/src/agents/codex/app-launch.ts
+++ b/packages/core/src/agents/codex/app-launch.ts
@@ -161,6 +161,10 @@ export function findInstalledCodexAppExecutable(profileAppPath?: string): CodexA
   return findInstalledCodexCompatibleAppExecutable(codexAppSpec, profileAppPath);
 }
 
+export function findInstalledZcodeAppExecutable(profileAppPath?: string): CodexAppLookupResult {
+  return findInstalledCodexCompatibleAppExecutable(zcodeAppSpec, profileAppPath);
+}
+
 export function launchZcodeAppProfile(configDir: string, profile: ProfileConfig, config?: AppConfig): CodexAppLaunchResult {
   return launchCodexCompatibleAppProfile(configDir, profile, zcodeAppSpec, config);
 }

--- a/packages/core/src/agents/codex/cli-middleware-runtime.ts
+++ b/packages/core/src/agents/codex/cli-middleware-runtime.ts
@@ -76,7 +76,7 @@ function botBridge() {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
+  const args = directProfileDispatchArgs(process.argv.slice(2));
   if (process.env.CCR_CLAUDE_CODE_BOT_WORKER === "1" || args[0] === "claude-bot-worker") {
     await runClaudeCodeBotWorker(args);
     return;
@@ -92,6 +92,20 @@ async function main() {
   await runCodexCliMiddleware(args.length === 0 ? defaultCodexArgs() : args);
 }
 
+function directProfileDispatchArgs(args) {
+  if (process.env.CCR_CLI_DIRECT_PROFILE_DISPATCH !== "1") {
+    return args;
+  }
+  const forwarded = args.slice(1);
+  if (forwarded[0] === "cli" || forwarded[0] === "--cli") {
+    forwarded.shift();
+  }
+  if (forwarded[0] === "--") {
+    forwarded.shift();
+  }
+  return forwarded;
+}
+
 async function runClaudeCodeCliWrapper(args) {
   const realCli = expandHome(nonEmptyEnv("CCR_REAL_CLAUDE_CODE_BIN") || nonEmptyEnv("CCR_CLAUDE_CODE_BIN") || nonEmptyEnv("CODEXL_CLAUDE_CODE_BIN") || "claude");
   const realArgs = claudeCodeCliWrapperArgs(args);
@@ -104,7 +118,7 @@ async function runClaudeCodeCliWrapper(args) {
     title: nonEmptyEnv("CCR_REMOTE_SYNC_PROFILE_NAME") || "Claude Code"
   });
   const injectRemoteStdin = boolEnv("CCR_REMOTE_SYNC_INJECT_STDIN");
-  const child = childProcess.spawn(realCli, realArgs, {
+  const child = spawnAgentCli(realCli, realArgs, {
     env: {
       ...withoutKeys(process.env, ["CCR_CLAUDE_CODE_WRAPPER", "CCR_REAL_CLAUDE_CODE_BIN"]),
       ...claudeCodeUtcTimezoneEnvOverride()
@@ -127,6 +141,7 @@ async function runClaudeCodeCliWrapper(args) {
   });
   child.on("error", (error) => {
     log("claude_code_wrapper_spawn_error", { error: formatError(error) });
+    process.stderr.write("Failed to start " + realCli + ": " + formatError(error) + "\n");
     remoteSync.postEvent("claude.spawn.error", { error: formatError(error) }, { direction: "system" });
   });
   let pending = "";
@@ -290,13 +305,14 @@ async function runCodexCliMiddleware(args) {
   }
 
   const cleanupAuthBootstrap = createEphemeralCodexApiKeyBootstrap(runtimeAgent);
-  const child = childProcess.spawn(realCli, realArgs, {
+  const child = spawnAgentCli(realCli, realArgs, {
     env: childEnvForAgent(runtimeAgent),
     stdio: ["pipe", "pipe", "inherit"]
   });
   child.on("error", (error) => {
     cleanupAuthBootstrap();
     log("codex_cli_spawn_error", { error: formatError(error) });
+    process.stderr.write("Failed to start " + realCli + ": " + formatError(error) + "\n");
   });
 
   const requestMap = new Map();
@@ -389,12 +405,13 @@ function createEphemeralCodexApiKeyBootstrap(runtimeAgent) {
 
 async function runDirectCodexCli(realCli, realArgs) {
   const runtimeAgent = codexRuntimeAgent();
-  const child = childProcess.spawn(realCli, realArgs, {
+  const child = spawnAgentCli(realCli, realArgs, {
     env: childEnvForAgent(runtimeAgent),
     stdio: "inherit"
   });
   child.on("error", (error) => {
     log("codex_cli_spawn_error", { error: formatError(error) });
+    process.stderr.write("Failed to start " + realCli + ": " + formatError(error) + "\n");
   });
   const exit = await waitForChildResult(child);
   log("codex_cli_exit", { code: exit.code, signal: exit.signal, exitCode: exit.exitCode });
@@ -403,6 +420,69 @@ async function runDirectCodexCli(realCli, realArgs) {
 
 function shouldRunDirectCodexCli(args) {
   return codexPositionalArgs(args)[0] !== "app-server";
+}
+
+function spawnAgentCli(command, args, options) {
+  if (process.platform !== "win32") {
+    return childProcess.spawn(command, args, options);
+  }
+
+  const commandFile = resolveWindowsCommandFile(command, options && options.env);
+  if (commandFile && /\.(?:com|exe)$/i.test(commandFile)) {
+    return childProcess.spawn(commandFile, args, options);
+  }
+
+  const shellCommand = [escapeWindowsCmdCommand(commandFile || command)]
+    .concat(args.map(escapeWindowsCmdArgument))
+    .join(" ");
+  return childProcess.spawn(
+    process.env.ComSpec || process.env.COMSPEC || "cmd.exe",
+    ["/d", "/s", "/c", '"' + shellCommand + '"'],
+    { ...options, windowsVerbatimArguments: true }
+  );
+}
+
+function resolveWindowsCommandFile(command, env) {
+  const value = String(command || "").trim().replace(/^"|"$/g, "");
+  if (!value) return "";
+  const commandExt = path.extname(value);
+  const pathExt = String((env && (env.PATHEXT || env.Pathext)) || process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((extension) => extension.trim())
+    .filter(Boolean);
+  const extensions = commandExt ? [""] : ["", ...pathExt];
+  const hasPath = path.isAbsolute(value) || value.includes("\\") || value.includes("/");
+  const directories = hasPath
+    ? [""]
+    : String((env && (env.PATH || env.Path)) || process.env.PATH || "")
+      .split(path.delimiter)
+      .map((directory) => directory.replace(/^"|"$/g, ""))
+      .filter(Boolean);
+
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      const candidate = directory ? path.join(directory, value + extension) : value + extension;
+      try {
+        if (fs.statSync(candidate).isFile()) return candidate;
+      } catch {
+      }
+    }
+  }
+  return "";
+}
+
+const WINDOWS_CMD_META_CHARS = /([()\][%!^"\`<>&|;, *?])/g;
+
+function escapeWindowsCmdCommand(value) {
+  return String(value).replace(WINDOWS_CMD_META_CHARS, "^$1");
+}
+
+function escapeWindowsCmdArgument(value) {
+  let escaped = String(value);
+  escaped = escaped.replace(/(?=(\\+?)?)\1"/g, "$1$1\\\"");
+  escaped = escaped.replace(/(?=(\\+?)?)\1$/g, "$1$1");
+  escaped = '"' + escaped + '"';
+  return escaped.replace(WINDOWS_CMD_META_CHARS, "^$1");
 }
 
 function realCliArgs(profile, modelProvider, configFormat, args) {

--- a/packages/core/src/platform/windows-app-discovery.ts
+++ b/packages/core/src/platform/windows-app-discovery.ts
@@ -51,6 +51,9 @@ export function windowsDesktopAppCandidates(options: WindowsDesktopAppDiscoveryO
   for (const candidate of windowsAppExecutionAliasCandidates(options)) {
     pushUnique(candidates, candidate);
   }
+  for (const candidate of windowsShortcutTargetCandidates(options)) {
+    pushUnique(candidates, candidate);
+  }
   for (const candidate of windowsMsixPackageCandidates(options)) {
     pushUnique(candidates, candidate);
   }
@@ -58,6 +61,58 @@ export function windowsDesktopAppCandidates(options: WindowsDesktopAppDiscoveryO
     pushUnique(candidates, candidate);
   }
   return candidates;
+}
+
+function windowsShortcutTargetCandidates(options: WindowsDesktopAppDiscoveryOptions): string[] {
+  const names = unique([
+    ...options.packageKeywords,
+    ...options.appDirs,
+    ...options.exeNames.map((name) => path.basename(name, path.extname(name)))
+  ].map((name) => name.trim()).filter(Boolean));
+  if (names.length === 0) {
+    return [];
+  }
+
+  const pattern = names.map(escapeRegExp).join("|");
+  const script = [
+    "$ErrorActionPreference = 'SilentlyContinue';",
+    "$roots = @(",
+    "  [Environment]::GetFolderPath('Programs'),",
+    "  [Environment]::GetFolderPath('CommonPrograms'),",
+    "  [Environment]::GetFolderPath('Desktop'),",
+    "  [Environment]::GetFolderPath('CommonDesktopDirectory')",
+    ") | Where-Object { $_ } | Select-Object -Unique;",
+    `$pattern = '${powerShellSingleQuotedString(pattern)}';`,
+    "$shell = New-Object -ComObject WScript.Shell;",
+    "Get-ChildItem -LiteralPath $roots -Filter '*.lnk' -File -Recurse |",
+    "  Where-Object { $_.BaseName -match $pattern } |",
+    "  ForEach-Object {",
+    "    try {",
+    "      $target = $shell.CreateShortcut($_.FullName).TargetPath;",
+    "      if ($target) { $target }",
+    "    } catch {}",
+    "  }"
+  ].join(" ");
+
+  const result = spawnSync(windowsSystemCommand("powershell.exe"), [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    script
+  ], {
+    encoding: "utf8",
+    windowsHide: true
+  });
+  if (result.status !== 0) {
+    return [];
+  }
+
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 export function normalizeWindowsDesktopAppCandidate(

--- a/packages/core/src/platform/windows-system.ts
+++ b/packages/core/src/platform/windows-system.ts
@@ -32,12 +32,7 @@ export function broadcastWindowsEnvironmentChanged(): void {
     return;
   }
 
-  const script = [
-    "$signature = '[DllImport(\"user32.dll\", SetLastError=true, CharSet=CharSet.Auto)] public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);';",
-    "Add-Type -MemberDefinition $signature -Namespace Win32 -Name NativeMethods;",
-    "$result = [UIntPtr]::Zero;",
-    "[Win32.NativeMethods]::SendMessageTimeout([IntPtr]0xffff, 0x1a, [UIntPtr]::Zero, 'Environment', 0x2, 5000, [ref]$result) | Out-Null;"
-  ].join(" ");
+  const script = windowsEnvironmentChangedPowerShellLines().join(" ");
 
   spawnSync(windowsSystemCommand("powershell.exe"), [
     "-NoProfile",
@@ -50,4 +45,13 @@ export function broadcastWindowsEnvironmentChanged(): void {
     stdio: "ignore",
     windowsHide: true
   });
+}
+
+export function windowsEnvironmentChangedPowerShellLines(): string[] {
+  return [
+    "$signature = '[DllImport(\"user32.dll\", SetLastError=true, CharSet=CharSet.Auto)] public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);';",
+    "Add-Type -MemberDefinition $signature -Namespace Win32 -Name NativeMethods;",
+    "$result = [UIntPtr]::Zero;",
+    "[Win32.NativeMethods]::SendMessageTimeout([IntPtr]0xffff, 0x1a, [UIntPtr]::Zero, 'Environment', 0x2, 5000, [ref]$result) | Out-Null;"
+  ];
 }

--- a/packages/core/src/profiles/launch-service.ts
+++ b/packages/core/src/profiles/launch-service.ts
@@ -14,7 +14,7 @@ import { gatewayService } from "@ccr/core/gateway/service";
 import { TOOL_HUB_MCP_RUNTIME_FILE_NAME, bundledToolHubMcpEntryPathCandidates } from "@ccr/core/mcp/toolhub-config";
 import { buildProfileLaunchPlan, findProfileForOpen, profileLaunchSpawnCommand, profileOpenCommand, profileOpenSurfaces, resolveClaudeCodeSettingsFile, resolveProfileOpenSurface } from "@ccr/core/profiles/launch-core";
 import { applyProfileConfig, cleanupGeneratedBinBackups } from "@ccr/core/profiles/service";
-import { broadcastWindowsEnvironmentChanged, windowsSystemCommand } from "@ccr/core/platform/windows-system";
+import { windowsEnvironmentChangedPowerShellLines, windowsSystemCommand } from "@ccr/core/platform/windows-system";
 
 const ccrPathBlockStart = "# >>> Claude Code Router CLI >>>";
 const ccrPathBlockEnd = "# <<< Claude Code Router CLI <<<";
@@ -27,6 +27,15 @@ let claudeAppBotWorkerProfileId: string | undefined;
 type ProfileOpenCommandOptions = {
   commandName?: string;
   ensureLauncher?: boolean;
+};
+
+export type CcrCliLauncherPreparation = {
+  binDir: string;
+  persistentPathRequired: boolean;
+};
+
+type EnsureCcrCliLauncherOptions = {
+  persistPath?: boolean;
 };
 
 type ProfileAppLaunchResult = {
@@ -1090,8 +1099,9 @@ function commandProfileRef(config: AppConfig, profile: ReturnType<typeof findPro
   return duplicateName ? profile.id : name;
 }
 
-export function ensureCcrCliLauncher(config?: AppConfig): string {
+export function prepareCcrCliLauncherRuntime(): CcrCliLauncherPreparation {
   const binDir = path.join(CONFIGDIR, "bin");
+  const persistentPathRequired = !processPathIncludes(binDir);
   mkdirSync(binDir, { recursive: true });
   cleanupGeneratedBinBackups();
   cleanupLegacyCcrCliLauncher(binDir);
@@ -1101,6 +1111,22 @@ export function ensureCcrCliLauncher(config?: AppConfig): string {
   writeFileIfChanged(runtimeFile, readFileSync(runtimeSource, "utf8"));
   chmodSafe(runtimeFile);
   ensureBundledToolHubMcpRuntime(path.join(binDir, TOOL_HUB_MCP_RUNTIME_FILE_NAME));
+  prependProcessPath(binDir);
+
+  return { binDir, persistentPathRequired };
+}
+
+export function persistPreparedCcrCliPath(preparation: CcrCliLauncherPreparation): void {
+  if (!preparation.persistentPathRequired) {
+    return;
+  }
+  persistCcrBinOnPath(preparation.binDir);
+}
+
+export function ensureCcrCliLauncher(config?: AppConfig, options: EnsureCcrCliLauncherOptions = {}): string {
+  const preparation = prepareCcrCliLauncherRuntime();
+  const { binDir } = preparation;
+  const runtimeFile = path.join(binDir, desktopCliRuntimeFileName);
 
   const launcherFile = path.join(binDir, process.platform === "win32" ? `${desktopCliCommandName}.cmd` : desktopCliCommandName);
   const launcherContent = process.platform === "win32"
@@ -1108,7 +1134,9 @@ export function ensureCcrCliLauncher(config?: AppConfig): string {
     : posixCcrLauncher(runtimeFile);
   writeFileIfChanged(launcherFile, launcherContent);
   chmodSafe(launcherFile);
-  ensureCcrBinOnPath(binDir);
+  if (options.persistPath !== false) {
+    persistPreparedCcrCliPath(preparation);
+  }
 
   return launcherFile;
 }
@@ -1283,8 +1311,7 @@ function writeFileIfChanged(file: string, content: string): void {
   writeFileSync(file, content, "utf8");
 }
 
-function ensureCcrBinOnPath(binDir: string): void {
-  prependProcessPath(binDir);
+function persistCcrBinOnPath(binDir: string): void {
   try {
     if (process.platform === "win32") {
       ensureWindowsUserPath(binDir);
@@ -1294,6 +1321,13 @@ function ensureCcrBinOnPath(binDir: string): void {
   } catch (error) {
     console.warn(`[profile] Failed to persist ccr PATH: ${formatError(error)}`);
   }
+}
+
+function processPathIncludes(binDir: string): boolean {
+  const pathKey = process.platform === "win32"
+    ? Object.keys(process.env).find((key) => key.toLowerCase() === "path") || "Path"
+    : "PATH";
+  return pathSegmentsInclude((process.env[pathKey] || "").split(path.delimiter).filter(Boolean), binDir);
 }
 
 function prependProcessPath(binDir: string): void {
@@ -1309,7 +1343,8 @@ function prependProcessPath(binDir: string): void {
   process.env[pathKey] = [binDir, ...segments].join(delimiter);
 }
 
-function ensureWindowsUserPath(binDir: string): void {
+function ensureWindowsUserPath(binDir: string): boolean {
+  const broadcastLines = windowsEnvironmentChangedPowerShellLines().map((line) => `  ${line}`);
   const script = [
     "$ErrorActionPreference = 'Stop'",
     `$bin = ${powershellString(binDir)}`,
@@ -1322,6 +1357,10 @@ function ensureWindowsUserPath(binDir: string): void {
     "$expandedSegments = $segments | ForEach-Object { [Environment]::ExpandEnvironmentVariables($_).TrimEnd('\\\\') }",
     "if ($expandedSegments -notcontains $expandedBin) {",
     "  [Environment]::SetEnvironmentVariable('Path', ((@($bin) + $segments) -join ';'), 'User')",
+    ...broadcastLines,
+    "  Write-Output 'CHANGED'",
+    "} else {",
+    "  Write-Output 'UNCHANGED'",
     "}"
   ].join("\n");
   const result = spawnSync(windowsSystemCommand("powershell.exe"), [
@@ -1341,7 +1380,7 @@ function ensureWindowsUserPath(binDir: string): void {
   if (result.status !== 0) {
     throw new Error((result.stderr || result.stdout || `powershell.exe exited with ${result.status}`).trim());
   }
-  broadcastWindowsEnvironmentChanged();
+  return result.stdout.trim().split(/\r?\n/).includes("CHANGED");
 }
 
 function ensurePosixShellPath(binDir: string): void {

--- a/packages/core/src/profiles/launch-service.ts
+++ b/packages/core/src/profiles/launch-service.ts
@@ -1183,20 +1183,12 @@ function posixCcrLauncher(runtimeFile: string): string {
   ].join("\n") + "\n";
 }
 
-function windowsCcrLauncher(runtimeFile: string, config?: AppConfig): string {
+export function windowsCcrLauncher(runtimeFile: string, config?: AppConfig): string {
   const nodePath = bundledNodePath();
   const dispatches = config ? windowsProfileCliDispatches(config) : [];
   return [
     "@echo off",
     "setlocal",
-    ...(dispatches.length > 0
-      ? [
-          "if /I \"%~2\"==\"app\" goto ccr_run_cli",
-          "if /I \"%~2\"==\"--app\" goto ccr_run_cli",
-          ...dispatches.map((dispatch, index) => `if /I \"%~1\"==\"${cmdValue(dispatch.profileRef)}\" goto ccr_profile_${index}`),
-          ":ccr_run_cli"
-        ]
-      : []),
     `set "${desktopCliCommandNameEnv}=${desktopCliCommandName}"`,
     `set "CCR_CLI_RUNTIME=${cmdEnvValue(runtimeFile)}"`,
     `set "CCR_CLI_NODE_PATH=${cmdEnvValue(nodePath)}"`,
@@ -1205,6 +1197,14 @@ function windowsCcrLauncher(runtimeFile: string, config?: AppConfig): string {
     ") else (",
     "  set \"NODE_PATH=%CCR_CLI_NODE_PATH%\"",
     ")",
+    ...(dispatches.length > 0
+      ? [
+          "if /I \"%~2\"==\"app\" goto ccr_run_cli",
+          "if /I \"%~2\"==\"--app\" goto ccr_run_cli",
+          ...dispatches.map((dispatch, index) => `if /I \"%~1\"==\"${cmdValue(dispatch.profileRef)}\" goto ccr_profile_${index}`),
+          ":ccr_run_cli"
+        ]
+      : []),
     "if defined CCR_NODE_BIN (",
     '  "%CCR_NODE_BIN%" "%CCR_CLI_RUNTIME%" %*',
     "  exit /b %ERRORLEVEL%",
@@ -1214,6 +1214,12 @@ function windowsCcrLauncher(runtimeFile: string, config?: AppConfig): string {
     "exit /b %ERRORLEVEL%",
     ...dispatches.flatMap((dispatch, index) => [
       `:ccr_profile_${index}`,
+      "set \"CCR_CLI_PREPARE_PROFILE_ONLY=1\"",
+      "set \"ELECTRON_RUN_AS_NODE=1\"",
+      `${cmdQuote(process.execPath)} "%CCR_CLI_RUNTIME%" %*`,
+      "if errorlevel 1 exit /b %ERRORLEVEL%",
+      "set \"CCR_CLI_PREPARE_PROFILE_ONLY=\"",
+      "set \"ELECTRON_RUN_AS_NODE=\"",
       "set \"CCR_CLI_DIRECT_PROFILE_DISPATCH=1\"",
       `call ${cmdQuote(dispatch.launcher)} %*`,
       "exit /b %ERRORLEVEL%"

--- a/packages/core/src/profiles/launch-service.ts
+++ b/packages/core/src/profiles/launch-service.ts
@@ -12,7 +12,7 @@ import { codexCliMiddlewareRuntimeScript } from "@ccr/core/agents/codex/cli-midd
 import { CONFIGDIR } from "@ccr/core/config/constants";
 import { gatewayService } from "@ccr/core/gateway/service";
 import { TOOL_HUB_MCP_RUNTIME_FILE_NAME, bundledToolHubMcpEntryPathCandidates } from "@ccr/core/mcp/toolhub-config";
-import { buildProfileLaunchPlan, findProfileForOpen, profileLaunchSpawnCommand, profileOpenCommand, resolveClaudeCodeSettingsFile, resolveProfileOpenSurface } from "@ccr/core/profiles/launch-core";
+import { buildProfileLaunchPlan, findProfileForOpen, profileLaunchSpawnCommand, profileOpenCommand, profileOpenSurfaces, resolveClaudeCodeSettingsFile, resolveProfileOpenSurface } from "@ccr/core/profiles/launch-core";
 import { applyProfileConfig, cleanupGeneratedBinBackups } from "@ccr/core/profiles/service";
 import { broadcastWindowsEnvironmentChanged, windowsSystemCommand } from "@ccr/core/platform/windows-system";
 
@@ -56,7 +56,7 @@ export async function getProfileOpenCommand(config: AppConfig, request: ProfileO
   const profile = findProfileForOpen(config, request.profileId);
   const surface = resolveProfileOpenSurface(profile, request.surface);
   if (options.ensureLauncher) {
-    ensureCcrCliLauncher();
+    ensureCcrCliLauncher(config);
   }
   return {
     command: profileOpenCommand(profile, surface, options.commandName ?? "ccr", commandProfileRef(config, profile)),
@@ -1090,7 +1090,7 @@ function commandProfileRef(config: AppConfig, profile: ReturnType<typeof findPro
   return duplicateName ? profile.id : name;
 }
 
-export function ensureCcrCliLauncher(): string {
+export function ensureCcrCliLauncher(config?: AppConfig): string {
   const binDir = path.join(CONFIGDIR, "bin");
   mkdirSync(binDir, { recursive: true });
   cleanupGeneratedBinBackups();
@@ -1104,7 +1104,7 @@ export function ensureCcrCliLauncher(): string {
 
   const launcherFile = path.join(binDir, process.platform === "win32" ? `${desktopCliCommandName}.cmd` : desktopCliCommandName);
   const launcherContent = process.platform === "win32"
-    ? windowsCcrLauncher(runtimeFile)
+    ? windowsCcrLauncher(runtimeFile, config)
     : posixCcrLauncher(runtimeFile);
   writeFileIfChanged(launcherFile, launcherContent);
   chmodSafe(launcherFile);
@@ -1183,11 +1183,20 @@ function posixCcrLauncher(runtimeFile: string): string {
   ].join("\n") + "\n";
 }
 
-function windowsCcrLauncher(runtimeFile: string): string {
+function windowsCcrLauncher(runtimeFile: string, config?: AppConfig): string {
   const nodePath = bundledNodePath();
+  const dispatches = config ? windowsProfileCliDispatches(config) : [];
   return [
     "@echo off",
     "setlocal",
+    ...(dispatches.length > 0
+      ? [
+          "if /I \"%~2\"==\"app\" goto ccr_run_cli",
+          "if /I \"%~2\"==\"--app\" goto ccr_run_cli",
+          ...dispatches.map((dispatch, index) => `if /I \"%~1\"==\"${cmdValue(dispatch.profileRef)}\" goto ccr_profile_${index}`),
+          ":ccr_run_cli"
+        ]
+      : []),
     `set "${desktopCliCommandNameEnv}=${desktopCliCommandName}"`,
     `set "CCR_CLI_RUNTIME=${cmdEnvValue(runtimeFile)}"`,
     `set "CCR_CLI_NODE_PATH=${cmdEnvValue(nodePath)}"`,
@@ -1202,8 +1211,34 @@ function windowsCcrLauncher(runtimeFile: string): string {
     ")",
     "set \"ELECTRON_RUN_AS_NODE=1\"",
     `${cmdQuote(process.execPath)} "%CCR_CLI_RUNTIME%" %*`,
-    "exit /b %ERRORLEVEL%"
+    "exit /b %ERRORLEVEL%",
+    ...dispatches.flatMap((dispatch, index) => [
+      `:ccr_profile_${index}`,
+      "set \"CCR_CLI_DIRECT_PROFILE_DISPATCH=1\"",
+      `call ${cmdQuote(dispatch.launcher)} %*`,
+      "exit /b %ERRORLEVEL%"
+    ])
   ].join("\r\n") + "\r\n";
+}
+
+function windowsProfileCliDispatches(config: AppConfig): Array<{ launcher: string; profileRef: string }> {
+  const dispatches: Array<{ launcher: string; profileRef: string }> = [];
+  const refs = new Set<string>();
+  for (const profile of config.profile.profiles) {
+    if (!profile.enabled || !profileOpenSurfaces(profile).includes("cli")) {
+      continue;
+    }
+    const launcher = buildProfileLaunchPlan(CONFIGDIR, profile, "cli").command;
+    for (const profileRef of uniqueStrings([commandProfileRef(config, profile), profile.id])) {
+      const normalized = profileRef.trim().toLowerCase();
+      if (!normalized || refs.has(normalized)) {
+        continue;
+      }
+      refs.add(normalized);
+      dispatches.push({ launcher, profileRef });
+    }
+  }
+  return dispatches;
 }
 
 function bundledNodePath(): string {

--- a/packages/core/src/profiles/service.ts
+++ b/packages/core/src/profiles/service.ts
@@ -34,11 +34,23 @@ const managedToolHubMcpStart = "# BEGIN CCR managed ToolHub MCP";
 const managedToolHubMcpEnd = "# END CCR managed ToolHub MCP";
 const originalBackupSuffix = ".ccr-original";
 const originalMissingSuffix = ".ccr-original-missing";
+const globalProfileTakeoverFile = path.join(CONFIGDIR, "global-profile-takeover.json");
 const fallbackClientToken = "ccr-local";
 const privateDirMode = 0o700;
 const privateExecutableMode = 0o700;
 const privateFileMode = 0o600;
 const publicExecutableMode = 0o755;
+let ownedGlobalProfileTakeovers: GlobalProfileTakeoverRecord[] | undefined;
+
+type GlobalProfileTakeoverRecord = {
+  agent: ProfileClientKind;
+  codexHome?: string;
+  configFile?: string;
+  id: string;
+  name: string;
+  providerId?: string;
+  settingsFile?: string;
+};
 
 export async function applyProfileConfig(config: AppConfig): Promise<ProfileApplyResult> {
   cleanupGeneratedBinBackups();
@@ -49,9 +61,15 @@ export async function applyProfileConfig(config: AppConfig): Promise<ProfileAppl
     clients: [],
     enabled: profiles.some((profile) => profile.enabled)
   };
+  const takeoverStatuses = synchronizeGlobalProfileTakeovers(
+    profiles,
+    result.enabled && hasAvailableGatewayModels(config)
+  );
 
   if (!result.enabled) {
     result.clients = profiles.map(disabledProfileStatus);
+    result.clients.push(...takeoverStatuses);
+    result.clients.push(...restoreInactiveGlobalProfileConfigs(profiles));
     return result;
   }
 
@@ -76,6 +94,8 @@ export async function applyProfileConfig(config: AppConfig): Promise<ProfileAppl
           }
         : status;
     });
+    result.clients.push(...takeoverStatuses);
+    result.clients.push(...restoreInactiveGlobalProfileConfigs(profiles));
     return result;
   }
 
@@ -91,6 +111,7 @@ export async function applyProfileConfig(config: AppConfig): Promise<ProfileAppl
           : applyCodexProfile(config, profile, token, appliedAt)
     );
   }
+  result.clients.push(...takeoverStatuses);
   cleanupManagedClaudeCodeToolHubArtifacts(profiles, { includeActive: false });
   result.clients.push(...restoreInactiveGlobalProfileConfigs(profiles));
   return result;
@@ -1404,7 +1425,158 @@ export function restoreInactiveGlobalProfileConfigs(profiles: ProfileConfig[]): 
       }
     }
   }
+  const codexProfiles = profiles.filter((profile) => profile.agent === "codex");
+  if (codexProfiles.length > 0 && !codexProfiles.some((profile) => profile.enabled && isGlobalProfile(profile))) {
+    for (const file of uniqueResolvedPaths([
+      ...codexProfiles.map(globalCodexConfigCandidate)
+    ])) {
+      const restoreResult = restoreGlobalConfigFile(file, {
+        isManagedContent: (content) => isManagedCodexConfigContent(content, "claude-code-router"),
+        mode: privateFileMode
+      });
+      if (restoreResult.changed || restoreResult.missingBackup) {
+        statuses.push(inactiveGlobalCleanupStatus("codex", file, restoreResult));
+      }
+    }
+  }
+  const zcodeProfiles = profiles.filter((profile) => profile.agent === "zcode");
+  if (zcodeProfiles.length > 0 && !zcodeProfiles.some((profile) => profile.enabled && isGlobalProfile(profile))) {
+    const providerIds = [...new Set([
+      "claude-code-router",
+      ...zcodeProfiles.map((profile) => sanitizeCodexProviderId(profile.providerId || "")).filter(Boolean)
+    ])];
+    const configFiles = uniqueResolvedPaths([
+      ...zcodeProfiles.map((profile) => resolveZcodeConfigFile(profile))
+    ]);
+    for (const configFile of configFiles) {
+      const storageRoot = zcodeHomeFromConfigFile(configFile);
+      for (const file of [
+        configFile,
+        path.join(storageRoot, "v2", "config.json"),
+        path.join(storageRoot, "v2", "bots-model-cache.v2.json")
+      ]) {
+        const restoreResult = restoreGlobalConfigFile(file, {
+          isManagedContent: (content) => providerIds.some((providerId) => isManagedZcodeConfigContent(content, providerId)),
+          mode: privateFileMode
+        });
+        if (restoreResult.changed || restoreResult.missingBackup) {
+          statuses.push(inactiveGlobalCleanupStatus("zcode", file, restoreResult));
+        }
+      }
+    }
+  }
   return statuses;
+}
+
+function globalCodexConfigCandidate(profile: ProfileConfig): string {
+  const codexHome = profile.codexHome?.trim();
+  if (codexHome) {
+    return path.join(resolveUserPath(codexHome), "config.toml");
+  }
+  return profile.configFile || "~/.codex/config.toml";
+}
+
+export function restoreGlobalProfileConfigsOnExit(
+  profiles: ProfileConfig[],
+  options: { manageMarker?: boolean } = {}
+): ProfileClientApplyStatus[] {
+  const manageMarker = options.manageMarker !== false;
+  const records = dedupeGlobalProfileTakeovers([
+    ...(manageMarker ? ownedGlobalProfileTakeovers ?? readGlobalProfileTakeoverMarker() : []),
+    ...globalProfileTakeoverRecords(profiles)
+  ]);
+  const statuses = restoreGlobalProfileTakeoverRecords(records);
+  if (manageMarker && statuses.every((status) => status.ok)) {
+    clearGlobalProfileTakeoverMarker();
+    ownedGlobalProfileTakeovers = [];
+  }
+  return statuses;
+}
+
+function synchronizeGlobalProfileTakeovers(profiles: ProfileConfig[], canTakeOver: boolean): ProfileClientApplyStatus[] {
+  const next = canTakeOver ? globalProfileTakeoverRecords(profiles) : [];
+  const previous = ownedGlobalProfileTakeovers ?? readGlobalProfileTakeoverMarker();
+  if (ownedGlobalProfileTakeovers !== undefined && JSON.stringify(previous) === JSON.stringify(next)) {
+    return [];
+  }
+
+  const statuses = previous.length > 0 ? restoreGlobalProfileTakeoverRecords(previous) : [];
+  const markerRecords = statuses.every((status) => status.ok)
+    ? next
+    : dedupeGlobalProfileTakeovers([...previous, ...next]);
+  if (markerRecords.length > 0) {
+    writeGlobalProfileTakeoverMarker(markerRecords);
+  } else {
+    clearGlobalProfileTakeoverMarker();
+  }
+  ownedGlobalProfileTakeovers = markerRecords;
+  return statuses;
+}
+
+function globalProfileTakeoverRecords(profiles: ProfileConfig[]): GlobalProfileTakeoverRecord[] {
+  return dedupeGlobalProfileTakeovers(profiles
+    .filter((profile) => profile.enabled && isGlobalProfile(profile))
+    .map((profile) => ({
+      agent: profile.agent,
+      codexHome: profile.codexHome?.trim() || undefined,
+      configFile: profile.configFile?.trim() || undefined,
+      id: profile.id,
+      name: profile.name,
+      providerId: profile.providerId?.trim() || undefined,
+      settingsFile: profile.settingsFile?.trim() || undefined
+    })));
+}
+
+function restoreGlobalProfileTakeoverRecords(records: GlobalProfileTakeoverRecord[]): ProfileClientApplyStatus[] {
+  return records.map((record) => disabledProfileStatus({
+    ...record,
+    enabled: false,
+    env: {},
+    model: "",
+    scope: "global",
+    surface: "auto"
+  }));
+}
+
+function dedupeGlobalProfileTakeovers(records: GlobalProfileTakeoverRecord[]): GlobalProfileTakeoverRecord[] {
+  const seen = new Set<string>();
+  return records.filter((record) => {
+    const key = JSON.stringify(record);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function readGlobalProfileTakeoverMarker(): GlobalProfileTakeoverRecord[] {
+  try {
+    const parsed = JSON.parse(readFileSync(globalProfileTakeoverFile, "utf8")) as { profiles?: unknown };
+    if (!Array.isArray(parsed.profiles)) {
+      return [];
+    }
+    return parsed.profiles.filter((value): value is GlobalProfileTakeoverRecord =>
+      isRecord(value) &&
+      (value.agent === "claude-code" || value.agent === "codex" || value.agent === "zcode") &&
+      typeof value.id === "string" &&
+      typeof value.name === "string"
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeGlobalProfileTakeoverMarker(records: GlobalProfileTakeoverRecord[]): void {
+  mkdirSync(path.dirname(globalProfileTakeoverFile), { recursive: true });
+  writeFileSync(globalProfileTakeoverFile, `${JSON.stringify({ profiles: records, version: 1 }, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: privateFileMode
+  });
+}
+
+function clearGlobalProfileTakeoverMarker(): void {
+  rmSync(globalProfileTakeoverFile, { force: true });
 }
 
 function inactiveGlobalCleanupStatus(
@@ -1513,6 +1685,20 @@ function restoreGlobalConfigFile(
     return { changed: false, file, missingBackup: false, restored: false };
   }
 
+  const snapshot = originalSnapshotCandidate(file, options.isManagedContent);
+  if (snapshot) {
+    if (current === snapshot.content) {
+      chmodFileIfRequested(file, options.mode);
+      return { changed: false, file, missingBackup: false, restored: true };
+    }
+
+    const backupFile = current === undefined ? undefined : backupCurrentConfigFile(file, options.mode);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, snapshot.content, options.mode === undefined ? "utf8" : { encoding: "utf8", mode: options.mode });
+    chmodFileIfRequested(file, options.mode);
+    return { backupFile, changed: true, file, missingBackup: false, restored: true };
+  }
+
   if (existsSync(originalMissingFilePath(file))) {
     if (currentManaged) {
       const backupFile = backupCurrentConfigFile(file, options.mode);
@@ -1522,33 +1708,22 @@ function restoreGlobalConfigFile(
     return { changed: false, file, missingBackup: false, restored: current === undefined };
   }
 
-  const snapshot = originalSnapshotCandidate(file, options.isManagedContent);
-  if (!snapshot) {
-    return {
-      changed: false,
-      file,
-      missingBackup: Boolean(currentManaged),
-      restored: false
-    };
-  }
-
-  if (current === snapshot.content) {
-    chmodFileIfRequested(file, options.mode);
-    return { changed: false, file, missingBackup: false, restored: true };
-  }
-
-  const backupFile = current === undefined ? undefined : backupCurrentConfigFile(file, options.mode);
-  mkdirSync(path.dirname(file), { recursive: true });
-  writeFileSync(file, snapshot.content, options.mode === undefined ? "utf8" : { encoding: "utf8", mode: options.mode });
-  chmodFileIfRequested(file, options.mode);
-  return { backupFile, changed: true, file, missingBackup: false, restored: true };
+  return {
+    changed: false,
+    file,
+    missingBackup: Boolean(currentManaged),
+    restored: false
+  };
 }
 
 function originalSnapshotCandidate(
   file: string,
   isManagedContent: (content: string) => boolean
 ): { content: string; file: string } | undefined {
-  for (const candidate of [originalBackupFilePath(file), ...backupFiles(file)]) {
+  // Prefer the most recent non-CCR snapshot captured immediately before the
+  // latest takeover. The permanent .ccr-original file can be stale when the
+  // user changes the agent config between separate CCR sessions.
+  for (const candidate of [...backupFiles(file).reverse(), originalBackupFilePath(file)]) {
     if (!existsSync(candidate)) {
       continue;
     }

--- a/packages/core/src/profiles/service.ts
+++ b/packages/core/src/profiles/service.ts
@@ -1027,15 +1027,15 @@ function nodeRuntimeCmdExecLines(runtimeFile: string): string[] {
   const quotedRuntime = cmdQuote(runtimeFile);
   const quotedHost = cmdQuote(process.execPath);
   return [
-    "if defined CCR_NODE_BIN (",
-    `  "%CCR_NODE_BIN%" ${quotedRuntime} %*`,
-    "  exit /b %ERRORLEVEL%",
-    ")",
+    "if not defined CCR_NODE_BIN goto ccr_try_system_node",
+    `"%CCR_NODE_BIN%" ${quotedRuntime} %*`,
+    "exit /b %ERRORLEVEL%",
+    ":ccr_try_system_node",
     "where node >nul 2>nul",
-    "if %ERRORLEVEL%==0 (",
-    `  node ${quotedRuntime} %*`,
-    "  exit /b %ERRORLEVEL%",
-    ")",
+    "if errorlevel 1 goto ccr_use_electron_node",
+    `node ${quotedRuntime} %*`,
+    "exit /b %ERRORLEVEL%",
+    ":ccr_use_electron_node",
     "set \"ELECTRON_RUN_AS_NODE=1\"",
     `${quotedHost} ${quotedRuntime} %*`,
     "exit /b %ERRORLEVEL%"

--- a/packages/electron/src/main/main-app.ts
+++ b/packages/electron/src/main/main-app.ts
@@ -5,8 +5,8 @@ import { restoreClaudeAppGatewayConfig, syncClaudeAppGatewayConfig } from "@ccr/
 import { deepLinkService } from "./deep-link";
 import { gatewayService } from "@ccr/core/gateway/service";
 import "./ipc";
-import { applyProfileConfig } from "@ccr/core/profiles/service";
-import { ensureCcrCliLauncher } from "@ccr/core/profiles/launch-service";
+import { applyProfileConfig, restoreGlobalProfileConfigsOnExit } from "@ccr/core/profiles/service";
+import { ensureCcrCliLauncher, persistPreparedCcrCliPath, prepareCcrCliLauncherRuntime, type CcrCliLauncherPreparation } from "@ccr/core/profiles/launch-service";
 import { syncLaunchAtLogin } from "./launch-at-login";
 import { proxyService } from "@ccr/core/proxy/service";
 import trayController from "./tray-controller";
@@ -43,13 +43,25 @@ function startPrimaryInstance(): void {
 
   void app.whenReady().then(() => {
     configureProxyDesktopIntegration();
+    let ccrLauncherPreparation: CcrCliLauncherPreparation | undefined;
     try {
-      ensureCcrCliLauncher();
+      ccrLauncherPreparation = prepareCcrCliLauncherRuntime();
     } catch (error) {
-      console.error(`Failed to install ccr CLI launcher: ${formatError(error)}`);
+      console.error(`Failed to prepare ccr CLI runtime: ${formatError(error)}`);
     }
     setupApplicationMenu();
-    windowsManager.createMainWindow();
+    const mainWindow = windowsManager.createMainWindow();
+    if (ccrLauncherPreparation?.persistentPathRequired) {
+      mainWindow.once("ready-to-show", () => {
+        setTimeout(() => {
+          try {
+            persistPreparedCcrCliPath(ccrLauncherPreparation);
+          } catch (error) {
+            console.error(`Failed to persist ccr CLI PATH: ${formatError(error)}`);
+          }
+        }, 0);
+      });
+    }
     trayController.start();
     appUpdateService.start();
     appUpdateService.setInstallPreparation(prepareForUpdateInstall);
@@ -164,7 +176,17 @@ function stopServicesForQuit(): Promise<void> {
       .catch((error) => {
         console.error(`Failed to stop services before quit: ${formatError(error)}`);
       })
-      .finally(() => {
+      .finally(async () => {
+        try {
+          const config = await loadAppConfig();
+          for (const status of restoreGlobalProfileConfigsOnExit(config.profile.profiles)) {
+            if (!status.ok) {
+              console.error(`Failed to restore ${status.client} global profile config before quit: ${status.message}`);
+            }
+          }
+        } catch (error) {
+          console.error(`Failed to restore global profile configs before quit: ${formatError(error)}`);
+        }
         try {
           restoreClaudeAppGatewayConfig();
         } catch (error) {
@@ -184,6 +206,11 @@ function startConfiguredServices(reason: string): Promise<void> {
           config = (await syncClaudeAppGatewayConfig(config)).config;
         } catch (error) {
           console.error(`Failed to sync Claude App gateway config during ${reason}: ${formatError(error)}`);
+        }
+        try {
+          ensureCcrCliLauncher(config, { persistPath: false });
+        } catch (error) {
+          console.error(`Failed to install ccr CLI launcher during ${reason}: ${formatError(error)}`);
         }
         try {
           syncLaunchAtLogin(config);

--- a/packages/electron/src/main/update-service.ts
+++ b/packages/electron/src/main/update-service.ts
@@ -10,7 +10,7 @@ type UpdateCheckOptions = {
 };
 
 const startupCheckDelayMs = 12_000;
-const defaultUpdateSource = "GitHub Releases (musistudio/claude-code-router)";
+const defaultUpdateSource = "GitHub Releases";
 
 class AppUpdateService {
   private activeSilentCheckFailureRestoreStatus?: AppUpdateStatus;

--- a/packages/electron/src/main/update-service.ts
+++ b/packages/electron/src/main/update-service.ts
@@ -10,9 +10,11 @@ type UpdateCheckOptions = {
 };
 
 const startupCheckDelayMs = 12_000;
+const defaultUpdateSource = "GitHub Releases (musistudio/claude-code-router)";
 
 class AppUpdateService {
   private activeSilentCheckFailureRestoreStatus?: AppUpdateStatus;
+  private configuredUpdateSource = defaultUpdateSource;
   private initialized = false;
   private installingUpdate = false;
   private prepareInstall?: InstallPreparation;
@@ -34,7 +36,7 @@ class AppUpdateService {
     this.initialized = true;
     this.configureUpdater();
     this.registerUpdaterEvents();
-    this.publishStatus({ feedUrl: autoUpdater.getFeedURL() || undefined });
+    this.publishStatus({ feedUrl: this.configuredUpdateSource });
 
     if (this.isUpdaterSupported()) {
       this.queueStartupCheck();
@@ -177,6 +179,7 @@ class AppUpdateService {
   private configureUpdater(): void {
     const feedUrl = readEnvString("CCR_UPDATE_FEED_URL");
     if (feedUrl) {
+      this.configuredUpdateSource = feedUrl;
       autoUpdater.setFeedURL({
         provider: "generic",
         url: feedUrl
@@ -304,7 +307,7 @@ class AppUpdateService {
       ...this.status,
       ...patch,
       currentVersion: app.getVersion(),
-      feedUrl: autoUpdater.getFeedURL() || this.status.feedUrl,
+      feedUrl: this.configuredUpdateSource,
       supported: this.isUpdaterSupported()
     });
     windowsManager.broadcast(IPC_CHANNELS.appUpdateStatusChanged, this.status);

--- a/packages/ui/src/pages/home/components/update.tsx
+++ b/packages/ui/src/pages/home/components/update.tsx
@@ -46,12 +46,13 @@ export function UpdateDialog({
 
         <DialogBody className="grid gap-4">
           <div className="flex min-w-0 items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-[13px] font-semibold text-foreground">{updateStateLabel(status, t)}</div>
-              <div className="mt-1 text-[12px] leading-5 text-muted-foreground">{updateStateDescription(status, t)}</div>
+            <div className="min-w-0 flex-1">
+              {updateStateDescription(status, t) ? (
+                <div className="text-[12px] leading-5 text-muted-foreground">{updateStateDescription(status, t)}</div>
+              ) : null}
             </div>
             <UpdateStateBadge
-              label={status.state === "not-available" ? t("Update check complete") : updateStateLabel(status, t)}
+              label={updateStateLabel(status, t)}
               status={status}
             />
           </div>
@@ -59,8 +60,8 @@ export function UpdateDialog({
           <div className="grid grid-cols-2 gap-2 max-[520px]:grid-cols-1">
             <UpdateInfoRow label={t("Current version")} value={status.currentVersion} />
             <UpdateInfoRow
-              label={t("Available version")}
-              value={status.availableVersion || (status.state === "not-available" ? t("No updates available") : "-")}
+              label={t("Latest version")}
+              value={status.availableVersion || (status.state === "not-available" ? status.currentVersion : "-")}
             />
             <UpdateInfoRow label={t("Last checked")} value={formatUpdateDate(status.lastCheckedAt) || "-"} />
             <UpdateInfoRow label={t("Feed URL")} scroll value={status.feedUrl || "-"} />
@@ -156,8 +157,10 @@ function UpdateStateBadge({ label, status }: { label: string; status: AppUpdateS
       "shrink-0 rounded-full border px-2 py-1 text-[11px] font-medium",
       status.state === "error"
         ? "border-destructive/25 bg-destructive/10 text-destructive"
+        : status.state === "not-available"
+          ? "border-emerald-200 bg-emerald-50 text-emerald-700"
         : status.state === "available" || status.state === "downloaded" || status.state === "downloading"
-          ? "border-primary/25 bg-primary/10 text-primary"
+          ? "border-amber-200 bg-amber-50 text-amber-700"
           : "border-border bg-muted/40 text-muted-foreground"
     )}>
       {label}
@@ -181,7 +184,7 @@ function updateStateDescription(status: AppUpdateStatus, t: (value: string) => s
   if (!status.supported) return t("Updates are only available in packaged builds.");
   if (status.state === "available" && status.availableVersion) return `${t("Available version")}: ${status.availableVersion}`;
   if (status.state === "downloaded") return t("Update downloaded");
-  if (status.state === "not-available") return t("No updates available");
+  if (status.state === "not-available") return "";
   if (status.state === "downloading") return t("Downloading update");
   return t("Online updates");
 }

--- a/packages/ui/src/pages/home/components/update.tsx
+++ b/packages/ui/src/pages/home/components/update.tsx
@@ -50,14 +50,20 @@ export function UpdateDialog({
               <div className="text-[13px] font-semibold text-foreground">{updateStateLabel(status, t)}</div>
               <div className="mt-1 text-[12px] leading-5 text-muted-foreground">{updateStateDescription(status, t)}</div>
             </div>
-            <UpdateStateBadge label={updateStateLabel(status, t)} status={status} />
+            <UpdateStateBadge
+              label={status.state === "not-available" ? t("Update check complete") : updateStateLabel(status, t)}
+              status={status}
+            />
           </div>
 
           <div className="grid grid-cols-2 gap-2 max-[520px]:grid-cols-1">
             <UpdateInfoRow label={t("Current version")} value={status.currentVersion} />
-            <UpdateInfoRow label={t("Available version")} value={status.availableVersion || "-"} />
+            <UpdateInfoRow
+              label={t("Available version")}
+              value={status.availableVersion || (status.state === "not-available" ? t("No updates available") : "-")}
+            />
             <UpdateInfoRow label={t("Last checked")} value={formatUpdateDate(status.lastCheckedAt) || "-"} />
-            <UpdateInfoRow label={t("Feed URL")} value={status.feedUrl || "-"} />
+            <UpdateInfoRow label={t("Feed URL")} scroll value={status.feedUrl || "-"} />
           </div>
 
           {status.state === "downloading" ? (
@@ -129,11 +135,17 @@ export function UpdateDialog({
   );
 }
 
-function UpdateInfoRow({ label, value }: { label: string; value: string }) {
+function UpdateInfoRow({ label, scroll = false, value }: { label: string; scroll?: boolean; value: string }) {
   return (
     <div className="min-w-0 rounded-md border border-border/70 bg-muted/20 px-3 py-2">
       <div className="text-[10px] font-medium uppercase text-muted-foreground">{label}</div>
-      <div className="mt-1 min-w-0 truncate text-[12px] font-medium text-foreground" title={value}>{value}</div>
+      <div
+        className={cn("mt-1 min-w-0 text-[12px] font-medium text-foreground", scroll ? "overflow-x-auto whitespace-nowrap" : "truncate")}
+        tabIndex={scroll ? 0 : undefined}
+        title={value}
+      >
+        {value}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/pages/home/shared/i18n.tsx
+++ b/packages/ui/src/pages/home/shared/i18n.tsx
@@ -1688,6 +1688,7 @@ export const appCopy: Record<ResolvedLanguage, AppCopy> = {
       "Update downloaded": "更新已下载",
       "Update downloaded. Restart to finish updating.": "更新已下载，请重启应用以完成版本更新。",
       "Update failed": "更新失败",
+      "Update check complete": "检查完成",
       "Update ready to install": "更新已准备安装",
       "Updates are only available in packaged builds.": "在线更新仅在打包后的应用中可用。",
       "After deletion, this bot data cannot be recovered.": "删除后数据不可恢复。",

--- a/packages/ui/src/pages/home/shared/i18n.tsx
+++ b/packages/ui/src/pages/home/shared/i18n.tsx
@@ -1679,6 +1679,7 @@ export const appCopy: Record<ResolvedLanguage, AppCopy> = {
       "System status": "系统状态",
       "System Proxy": "系统代理",
       "Available version": "可用版本",
+      "Latest version": "最新版本",
       "Download update": "下载更新",
       "Downloading update": "正在下载更新",
       "Feed URL": "更新源",

--- a/tests/main/codex-cli-middleware-runtime.test.mjs
+++ b/tests/main/codex-cli-middleware-runtime.test.mjs
@@ -13,6 +13,63 @@ test("generated Codex CLI middleware runtime is valid JavaScript", () => {
   execFileSync(process.execPath, ["--check", file], { stdio: "pipe" });
 });
 
+test("Codex CLI middleware launches Windows cmd shims", { skip: process.platform !== "win32" }, () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "ccr-runtime-windows-cmd-"));
+  const runtimeFile = writeRuntimeScript(dir);
+  const fakeCliScript = path.join(dir, "fake-codex.js");
+  const fakeCli = path.join(dir, "fake-codex.cmd");
+  writeFileSync(fakeCliScript, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+  writeFileSync(fakeCli, [
+    "@echo off",
+    `"${process.execPath}" "%~dp0fake-codex.js" %*`,
+    "exit /b %ERRORLEVEL%",
+    ""
+  ].join("\r\n"));
+
+  const result = spawnSync(process.execPath, [runtimeFile, "--version"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CCR_CODEX_MODEL_PROVIDER: "claude-code-router",
+      CCR_CODEX_PROFILE: "claude-code-router",
+      CCR_REAL_CODEX_CLI_PATH: fakeCli
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const forwardedArgs = JSON.parse(result.stdout);
+  assert.equal(forwardedArgs.at(-1), "--version");
+  assert.equal(forwardedArgs.includes("claude-code-router"), true);
+});
+
+test("Windows direct profile dispatch strips the profile command arguments", { skip: process.platform !== "win32" }, () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "ccr-runtime-windows-dispatch-"));
+  const runtimeFile = writeRuntimeScript(dir);
+  const fakeCliScript = path.join(dir, "fake-claude.js");
+  const fakeCli = path.join(dir, "fake-claude.cmd");
+  writeFileSync(fakeCliScript, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+  writeFileSync(fakeCli, [
+    "@echo off",
+    `"${process.execPath}" "%~dp0fake-claude.js" %*`,
+    "exit /b %ERRORLEVEL%",
+    ""
+  ].join("\r\n"));
+
+  const result = spawnSync(process.execPath, [runtimeFile, "Claude Code", "cli", "--", "--version"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CCR_CLAUDE_CODE_WRAPPER: "1",
+      CCR_CLI_DIRECT_PROFILE_DISPATCH: "1",
+      CCR_REAL_CLAUDE_CODE_BIN: fakeCli,
+      CCR_REMOTE_SYNC_ENABLED: "0"
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), ["--version"]);
+});
+
 test("Codex app-server exposes a ChatGPT-shaped workspace identity without credentials", { skip: process.platform === "win32" }, () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "ccr-runtime-virtual-auth-"));
   const runtimeFile = writeRuntimeScript(dir);

--- a/tests/main/profile-service.test.mjs
+++ b/tests/main/profile-service.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { createDefaultAppConfig } from "../../packages/core/src/config/default-config.ts";
 import { CONFIGDIR } from "../../packages/core/src/config/constants.ts";
-import { applyProfileConfig, cleanupGeneratedBinBackups, restoreInactiveGlobalProfileConfigs } from "../../packages/core/src/profiles/service.ts";
+import { applyProfileConfig, cleanupGeneratedBinBackups, restoreGlobalProfileConfigsOnExit, restoreInactiveGlobalProfileConfigs } from "../../packages/core/src/profiles/service.ts";
 
 test("profile service cleans stale generated bin backups only", () => {
   const configDir = mkdtempSync(path.join(os.tmpdir(), "ccr-generated-bin-cleanup-"));
@@ -384,5 +384,89 @@ test("profile service keeps managed global Claude settings when a global Claude 
       process.env.HOME = previousHome;
     }
     rmSync(home, { force: true, recursive: true });
+  }
+});
+
+test("profile service restores global agent configs on exit", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ccr-global-profile-exit-"));
+  try {
+    const claudeFile = path.join(root, "claude", "settings.json");
+    const codexFile = path.join(root, "codex", "config.toml");
+    const zcodeFile = path.join(root, "zcode", "cli", "config.json");
+    const zcodeRoot = path.dirname(path.dirname(zcodeFile));
+    const zcodeV2File = path.join(zcodeRoot, "v2", "config.json");
+    const zcodeCacheFile = path.join(zcodeRoot, "v2", "bots-model-cache.v2.json");
+    const files = [claudeFile, codexFile, zcodeFile, zcodeV2File, zcodeCacheFile];
+    const originals = new Map(files.map((file, index) => [file, `original-${index}\n`]));
+    const latestSnapshots = new Map(files.map((file, index) => [file, `latest-${index}\n`]));
+
+    for (const [file, original] of originals) {
+      mkdirSync(path.dirname(file), { recursive: true });
+      if (file === zcodeCacheFile) {
+        writeFileSync(`${file}.ccr-original-missing`, "");
+      } else {
+        writeFileSync(`${file}.ccr-original`, original);
+      }
+      writeFileSync(`${file}.ccr-backup-2026-07-11T00-00-00-000Z`, latestSnapshots.get(file));
+    }
+    writeFileSync(claudeFile, `${JSON.stringify({
+      apiKeyHelper: "ccr-claude-code-api-key-test",
+      env: {
+        ANTHROPIC_API_BASE_URL: "http://127.0.0.1:3456",
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:3456",
+        CLAUDE_AGENT_API_BASE_URL: "http://127.0.0.1:3456"
+      }
+    })}\n`);
+    writeFileSync(codexFile, "# BEGIN CCR managed profile\nmodel = \"test\"\n# END CCR managed profile\n");
+    for (const file of [zcodeFile, zcodeV2File]) {
+      writeFileSync(file, `${JSON.stringify({ provider: { "claude-code-router": {} } })}\n`);
+    }
+    writeFileSync(zcodeCacheFile, `${JSON.stringify({ providers: [{ id: "claude-code-router" }] })}\n`);
+
+    const statuses = restoreGlobalProfileConfigsOnExit([
+      {
+        agent: "claude-code", enabled: true, env: {}, id: "claude", model: "test", name: "Claude",
+        scope: "global", settingsFile: claudeFile, smallFastModel: "", surface: "cli"
+      },
+      {
+        agent: "codex", configFile: codexFile, enabled: true, env: {}, id: "codex", model: "test", name: "Codex",
+        providerId: "claude-code-router", scope: "global", surface: "cli"
+      },
+      {
+        agent: "zcode", configFile: zcodeFile, enabled: true, env: {}, id: "zcode", model: "test", name: "ZCode",
+        providerId: "claude-code-router", scope: "global", surface: "app"
+      }
+    ], { manageMarker: false });
+
+    assert.equal(statuses.length, 3);
+    assert.equal(statuses.every((status) => status.ok), true);
+    for (const [file, latest] of latestSnapshots) {
+      assert.equal(readFileSync(file, "utf8"), latest);
+    }
+
+    writeFileSync(codexFile, "# BEGIN CCR managed profile\nmodel = \"test\"\n# END CCR managed profile\n");
+    for (const file of [zcodeFile, zcodeV2File]) {
+      writeFileSync(file, `${JSON.stringify({ provider: { "claude-code-router": {} } })}\n`);
+    }
+    writeFileSync(zcodeCacheFile, `${JSON.stringify({ providers: [{ id: "claude-code-router" }] })}\n`);
+    const inactiveStatuses = restoreInactiveGlobalProfileConfigs([
+      {
+        agent: "codex", configFile: codexFile, enabled: false, env: {}, id: "codex", model: "test", name: "Codex",
+        providerId: "claude-code-router", scope: "ccr", surface: "cli"
+      },
+      {
+        agent: "zcode", configFile: zcodeFile, enabled: false, env: {}, id: "zcode", model: "test", name: "ZCode",
+        providerId: "claude-code-router", scope: "ccr", surface: "app"
+      }
+    ]);
+    assert.equal(inactiveStatuses.filter((status) => status.client === "codex").length, 1);
+    assert.equal(inactiveStatuses.filter((status) => status.client === "zcode").length, 3);
+    for (const [file, latest] of latestSnapshots) {
+      if (file !== claudeFile) {
+        assert.equal(readFileSync(file, "utf8"), latest);
+      }
+    }
+  } finally {
+    rmSync(root, { force: true, recursive: true });
   }
 });

--- a/tests/main/windows-ccr-launcher.test.mjs
+++ b/tests/main/windows-ccr-launcher.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { windowsCcrLauncher } from "../../packages/core/src/profiles/launch-service.ts";
+
+test("Windows CCR launcher prepares CLI profiles before direct TTY dispatch", { skip: process.platform !== "win32" }, () => {
+  const config = {
+    profile: {
+      profiles: [
+        {
+          agent: "claude-code",
+          enabled: true,
+          id: "claude-main",
+          model: "provider/model",
+          name: "Claude Main",
+          scope: "ccr",
+          surface: "cli"
+        }
+      ]
+    }
+  };
+  const runtimeFile = path.join("C:\\CCR", "ccr-cli.js");
+  const launcher = windowsCcrLauncher(runtimeFile, config);
+
+  assert.match(launcher, /if \/I "%~1"=="Claude Main" goto ccr_profile_0/);
+  assert.match(launcher, /set "CCR_CLI_PREPARE_PROFILE_ONLY=1"/);
+  assert.match(launcher, /set "ELECTRON_RUN_AS_NODE=1"/);
+  assert.match(launcher, /set "CCR_CLI_DIRECT_PROFILE_DISPATCH=1"/);
+  assert.match(launcher, /call ".*ccr-claude-code-wrapper-claude-main\.cmd" %\*/);
+
+  const prepareIndex = launcher.indexOf('set "CCR_CLI_PREPARE_PROFILE_ONLY=1"');
+  const directDispatchIndex = launcher.indexOf('set "CCR_CLI_DIRECT_PROFILE_DISPATCH=1"');
+  const wrapperIndex = launcher.indexOf("ccr-claude-code-wrapper-claude-main.cmd");
+  assert.equal(prepareIndex >= 0, true);
+  assert.equal(directDispatchIndex > prepareIndex, true);
+  assert.equal(wrapperIndex > directDispatchIndex, true);
+});


### PR DESCRIPTION
## Summary

This PR improves Windows profile launching, desktop startup, global profile cleanup, application discovery, and update status presentation.

### Windows CLI and desktop launching

- launch Windows npm `.cmd` shims through `cmd.exe` and preserve stderr and exit codes
- preserve interactive TTY behavior while still preparing the selected profile, gateway, MCP settings, and runtime configuration before direct wrapper dispatch
- discover installed desktop applications through executable paths, Start Menu shortcuts, and desktop shortcuts

### Consistent profile handling across agents

| Agent | System-default configuration managed by CCR |
| --- | --- |
| Claude Code | `~/.claude/settings.json` and generated helper/runtime files |
| Codex | `~/.codex/config.toml` and CCR model/runtime configuration |
| ZCode | `~/.zcode/cli/config.json`, `v2/config.json`, and the v2 model cache |

For Claude Code, Codex, and ZCode alike, this PR now:

- restores system-default configuration when its profile is disabled, moved back to CCR-only scope, or CCR exits normally
- restores the newest non-CCR snapshot instead of an old, stale `.ccr-original` file
- preserves `.ccr-original` and `.ccr-original-missing` only as fallback recovery information
- records active global takeovers without API keys or environment secrets, allowing the next CCR startup to recover configuration left behind by a crash, forced termination, or power loss
- keeps CCR-only profiles isolated from system-default restoration

### Startup and updater UI

- keep cheap runtime preparation synchronous so child services inherit the CCR PATH
- defer persistent Windows PATH work until after the main window is visible
- skip PowerShell entirely when the inherited PATH is already correct, and broadcast environment changes only when PATH actually changes
- show `GitHub Releases` as the update source
- display the latest version clearly, and use green/yellow status pills for up-to-date/update-available states
<img width="419" height="250" alt="image" src="https://github.com/user-attachments/assets/2c34e4d2-a2b7-4158-8b00-b6b64fa694c5" />



## Testing

- `node --test dist/tests/main/codex-cli-middleware-runtime.test.js`
- `node --test --test-name-pattern "restores global agent configs on exit" dist/tests/main/profile-service.test.js`
- `npm run build:assets`
- `npm run build:app:win`
