### PR TITLE
fix(gateway): strip unsupported thinking from OpenAI upstream requests

### DIFF
--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -5827,29 +5827,62 @@ function prepareUpstreamCredentialAttempt(input: {
   };
 }
 
+const unsupportedOpenAiUpstreamParams = ["thinking", "reasoning_split"] as const;
+
+export function stripUnsupportedOpenAiUpstreamParams(
+  body: Buffer | undefined,
+  providerProtocol: GatewayProviderProtocol | undefined
+): Buffer | undefined {
+  if (
+    !body ||
+    !providerProtocol ||
+    (providerProtocol !== "openai_responses" && providerProtocol !== "openai_chat_completions")
+  ) {
+    return body;
+  }
+
+  const parsedBody = parseJsonObjectSafe(body);
+  if (!parsedBody) {
+    return body;
+  }
+
+  let changed = false;
+  const next = { ...parsedBody };
+  for (const key of unsupportedOpenAiUpstreamParams) {
+    if (key in next) {
+      delete next[key];
+      changed = true;
+    }
+  }
+
+  return changed ? Buffer.from(`${JSON.stringify(next)}\n`, "utf8") : body;
+}
+
 function usageAwareOpenAiChatAttemptBody(input: {
   body: Buffer | undefined;
   config: AppConfig;
   path: string;
   target?: { protocol: GatewayProviderProtocol };
 }): Buffer | undefined {
-  if (input.target?.protocol === "openai_chat_completions") {
-    return usageAwareOpenAiChatBody(input.body);
-  }
-
   const protocol = requestProtocolForPath(input.path);
-  if (!protocol) {
-    return input.body;
-  }
-
   const parsedBody = parseJsonObjectSafe(input.body);
   const modelSelector = resolveConfiguredProviderModelSelector(stringValue(parsedBody?.model), input.config);
-  const providerProtocol = modelSelector
-    ? providerProtocolForClientProtocol(modelSelector.provider, protocol)
-    : undefined;
-  return providerProtocol === "openai_chat_completions"
-    ? usageAwareOpenAiChatBody(input.body)
-    : input.body;
+  const providerProtocol = input.target?.protocol ?? (
+    protocol && modelSelector
+      ? providerProtocolForClientProtocol(modelSelector.provider, protocol)
+      : undefined
+  );
+  const strippedBody = stripUnsupportedOpenAiUpstreamParams(input.body, providerProtocol);
+
+  if (providerProtocol === "openai_chat_completions") {
+    return usageAwareOpenAiChatBody(strippedBody);
+  }
+
+  if (!protocol) {
+    return strippedBody;
+  }
+
+  return strippedBody;
 }
 
 function usageAwareOpenAiChatBody(body: Buffer | undefined): Buffer | undefined {

--- a/tests/main/router-builtins.test.mjs
+++ b/tests/main/router-builtins.test.mjs
@@ -613,6 +613,45 @@ test("OpenAI chat completion streaming attempts request upstream usage chunks", 
   assert.equal(upstreamAttempt.body.stream_options.extra_flag, "keep");
 });
 
+test("gateway strips unsupported thinking from openai_responses upstream requests", () => {
+  const config = {
+    Providers: [
+      {
+        api_base_url: "https://example.openai.azure.com/openai/v1",
+        capabilities: [
+          { baseUrl: "https://example.openai.azure.com/openai/v1", type: "openai_responses" }
+        ],
+        models: ["gpt-4.1"],
+        name: "Azure",
+        type: "openai_responses"
+      }
+    ],
+    Router: {
+      fallback: { mode: "off", models: [], retryCount: 0 },
+      rules: []
+    },
+    virtualModelProfiles: []
+  };
+
+  const upstreamAttempt = prepareGatewayUpstreamAttemptForTest({
+    body: {
+      input: "hello",
+      model: "Azure/gpt-4.1",
+      thinking: { type: "enabled" },
+      reasoning_split: true
+    },
+    config,
+    headers: {
+      "x-target-provider": "Azure"
+    },
+    method: "POST",
+    path: "/v1/responses"
+  });
+
+  assert.equal(upstreamAttempt.body.thinking, undefined);
+  assert.equal(upstreamAttempt.body.reasoning_split, undefined);
+});
+
 test("explicit OpenAI chat provider selectors request upstream usage chunks without credential routing", () => {
   const config = {
     CUSTOM_ROUTER_PATH: "",


### PR DESCRIPTION
## Summary

Strip `thinking` and `reasoning_split` from request bodies before forwarding to `openai_responses` and `openai_chat_completions` upstream providers.

## Motivation

Claude Code Desktop can send `thinking` on Responses API requests. Azure OpenAI and other OpenAI-compatible endpoints reject this with HTTP 400 (`Unknown parameter: 'thinking'`), causing all requests to fail before inference starts.

This is the same class of compatibility issue as #1508 (`reasoning_split`).

## Changes

- Add `stripUnsupportedOpenAiUpstreamParams()` in `packages/core/src/gateway/service.ts`
- Invoke it from `usageAwareOpenAiChatAttemptBody()` during upstream credential attempt preparation
- Add regression test in `tests/main/router-builtins.test.mjs`

## Tests

- `node build/test.mjs main && node build/run-tests.mjs main`
- New test `gateway strips unsupported thinking from openai_responses upstream requests` — **pass**
- 9 pre-existing failures in sqlite-backed usage-store tests (missing `better-sqlite3` native bindings in this environment)

## Notes

- Only strips when the resolved upstream protocol is OpenAI chat/responses; Anthropic/Gemini routes are unchanged.
- `reasoning` is intentionally preserved for o-series Responses API compatibility.

Fixes #1515