### PR TITLE
fix: strip Provider/ prefix from model name before sending to ai-gateway

### DIFF
--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -5775,9 +5775,7 @@ function prepareUpstreamCredentialAttempt(input: {
     target
   });
   if (!target) {
-    const body = bodyHasConfiguredProviderModelSelector(input.attempt.body, input.config)
-      ? input.attempt.body
-      : normalizedBody?.body ?? input.attempt.body;
+    const body = normalizedBody?.body ?? input.attempt.body;
     return {
       ...input.attempt,
       body: attemptBody(body),
@@ -5887,12 +5885,6 @@ function normalizeConfiguredProviderModelBody(
     body: serializeJsonBodyWithModel(parsedBody, selector.model),
     model: selector.model
   };
-}
-
-function bodyHasConfiguredProviderModelSelector(body: Buffer | undefined, config: AppConfig): boolean {
-  const parsedBody = parseJsonObjectSafe(body);
-  const model = stringValue(parsedBody?.model);
-  return Boolean(resolveConfiguredProviderModelSelector(model, config));
 }
 
 function resolveProviderCredentialRoutingTarget(


### PR DESCRIPTION
## Summary

When body.model is `NebulaCoder/nebulacoder-cot-v8.0` (Provider/Model format), the Provider/ prefix is not stripped before sending to ai-gateway. The ai-gateway then fails to match the model against the provider's configured model list which only contains bare model names.

## Root cause

`normalizeConfiguredProviderModelBody` correctly strips the prefix, but `prepareUpstreamCredentialAttempt`'s `!target` branch preferred the original body over the normalized one when the body was parseable.

## Fix

Always use `normalizedBody.body` (which has the provider prefix stripped) when available. Remove the now-unused `bodyHasConfiguredProviderModelSelector` function.

## Impact

- Inline model calls like `NebulaCoder/nebulacoder-cot-v8.0` now work correctly
- The fix applies to providers without credentials configuration
- No behavior change for credentialed providers (target path unaffected)