### PR TITLE
fix: strip Provider/ prefix from model name before sending to ai-gateway

### DIFF
--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -5775,9 +5775,7 @@ function prepareUpstreamCredentialAttempt(input: {
     target
   });
   if (!target) {
-    const body = bodyHasConfiguredProviderModelSelector(input.attempt.body, input.config)
-      ? input.attempt.body
-      : normalizedBody?.body ?? input.attempt.body;
+    const body = normalizedBody?.body ?? input.attempt.body;
     return {
       ...input.attempt,
       body: attemptBody(body),
@@ -5887,12 +5885,6 @@ function normalizeConfiguredProviderModelBody(
     body: serializeJsonBodyWithModel(parsedBody, selector.model),
     model: selector.model
   };
-}
-
-function bodyHasConfiguredProviderModelSelector(body: Buffer | undefined, config: AppConfig): boolean {
-  const parsedBody = parseJsonObjectSafe(body);
-  const model = stringValue(parsedBody?.model);
-  return Boolean(resolveConfiguredProviderModelSelector(model, config));
 }
 
 function resolveProviderCredentialRoutingTarget(


### PR DESCRIPTION
## Summary

When body.model is `NebulaCoder/nebulacoder-cot-v8.0` (Provider/Model format), the Provider/ prefix is not stripped before sending to ai-gateway, causing a 400 error.

## Bug evidence from request_logs.sqlite

Request body:
```json
{"model":"NebulaCoder/nebulacoder-cot-v8.0", ...}
```

Response:
```json
{"error":{"message":"All target providers failed.",
  "attempts":[{"provider":"openai",
    "message":"Model \"NebulaCoder/nebulacoder-cot-v8.0\" is not configured
               for target provider openai.
               Allowed models: nebulacoder-v8.0, nebulacoder-cot-v8.0."}]}}
```

## Root cause

`normalizeConfiguredProviderModelBody` correctly strips the prefix, but `prepareUpstreamCredentialAttempt`'s `!target` branch preferred the original `input.attempt.body` (with `NebulaCoder/` prefix) over `normalizedBody.body` when the body was parseable.

## Fix

Always use `normalizedBody.body` (which has the provider prefix stripped) when available. Remove the now-unused `bodyHasConfiguredProviderModelSelector` function.