### PR TITLE
fix: Provider/Model 格式透传时未剥掉 Provider 前缀导致模型匹配失败

### DIFF
--- a/packages/core/src/gateway/service.ts
+++ b/packages/core/src/gateway/service.ts
@@ -5775,9 +5775,7 @@ function prepareUpstreamCredentialAttempt(input: {
     target
   });
   if (!target) {
-    const body = bodyHasConfiguredProviderModelSelector(input.attempt.body, input.config)
-      ? input.attempt.body
-      : normalizedBody?.body ?? input.attempt.body;
+    const body = normalizedBody?.body ?? input.attempt.body;
     return {
       ...input.attempt,
       body: attemptBody(body),
@@ -5887,12 +5885,6 @@ function normalizeConfiguredProviderModelBody(
     body: serializeJsonBodyWithModel(parsedBody, selector.model),
     model: selector.model
   };
-}
-
-function bodyHasConfiguredProviderModelSelector(body: Buffer | undefined, config: AppConfig): boolean {
-  const parsedBody = parseJsonObjectSafe(body);
-  const model = stringValue(parsedBody?.model);
-  return Boolean(resolveConfiguredProviderModelSelector(model, config));
 }
 
 function resolveProviderCredentialRoutingTarget(


### PR DESCRIPTION
## 问题描述

路由层使用 `Provider/Model` 格式（如 `NebulaCoder/nebulacoder-cot-v8.0`）做内部解析，但在透传给 ai-gateway 时没把 `NebulaCoder/` 前缀去掉。ai-gateway 拿着完整字符串去匹配 provider 的裸模型列表，匹配不上就报 400。

## 触发场景

当请求使用了**已知 inline 模型**（模型名直接匹配到某个 provider 的 models 列表）时触发：

1. **profile 配置了模型名**（如 `"model": "deepseek-v4-flash"`），CCR 自动补全为 `DeepSeek/deepseek-v4-flash`，带前缀的 body 直接透传
2. **Subagent 通过 `<CCR-SUBAGENT-MODEL>Provider/xxx</>` 标签路由时**
3. **请求直接指定 `"model": "NebulaCoder/nebulacoder-v8.0"` 时**

这些场景都走了 `isKnownInlineRoute` 短路路径（`claude-code-router-plugin.ts:196`），跳过了规则系统的 rewrite，body 中的 model 名带 `Provider/` 前缀直接透传。

## 数据库证据

request_logs.sqlite 中 3 次 NebulaCoder 调用全部因此失败：

```
id=125  request:  {"model":"NebulaCoder/nebulacoder-cot-v8.0", ...}
        response: {"error":{"message":"All target providers failed.",
                    "attempts":[{"provider":"openai",
                      "stage":"model_resolution",
                      "message":"Model \"NebulaCoder/nebulacoder-cot-v8.0\" is not configured
                                 for target provider openai.
                                 Allowed models: nebulacoder-v8.0, nebulacoder-cot-v8.0."}
                    ]}}
```

## 根因

`prepareUpstreamCredentialAttempt` 的 `!target` 分支，当 `bodyHasConfiguredProviderModelSelector` 为 true 时，保留了 `input.attempt.body`（带 `NebulaCoder/` 前缀）。而 `normalizeConfiguredProviderModelBody` 已经正确地把前缀剥掉了，但被忽略。

## 修复

1. `!target` 分支始终用 `normalizedBody.body`（已剥掉 Provider/ 前缀）
2. 删除不再使用的 `bodyHasConfiguredProviderModelSelector` 函数

## 验证

修复后 inline 模型调用正常：
```
request:  {"model":"NebulaCoder/nebulacoder-v8.0", ...}
response: 200 OK, "Hello! I'm NebulaCoder..."
```