### PR TITLE
Add MiniMax-M2.7 to provider defaults

### DIFF
--- a/packages/core/src/providers/presets/minimax/index.ts
+++ b/packages/core/src/providers/presets/minimax/index.ts
@@ -4,7 +4,7 @@ import { standardProviderAccountConfig } from "@ccr/core/providers/presets/types
 export const minimaxGlobalProviderPreset: ProviderPreset = {
   account: standardProviderAccountConfig,
   aliases: ["minimax", "minimax global"],
-  defaultModels: ["MiniMax-M3"],
+  defaultModels: ["MiniMax-M3", "MiniMax-M2.7"],
   endpoints: [
     {
       baseUrl: "https://api.minimax.io/v1",
@@ -25,7 +25,7 @@ export const minimaxGlobalProviderPreset: ProviderPreset = {
 export const minimaxChinaProviderPreset: ProviderPreset = {
   account: standardProviderAccountConfig,
   aliases: ["minimax", "minimaxi", "minimax china"],
-  defaultModels: ["MiniMax-M3"],
+  defaultModels: ["MiniMax-M3", "MiniMax-M2.7"],
   endpoints: [
     {
       baseUrl: "https://api.minimaxi.com/v1",


### PR DESCRIPTION
Follow-up to https://github.com/musistudio/claude-code-router/pull/1504.

## Summary
- Add MiniMax-M2.7 to the default models for the Global preset.
- Add MiniMax-M2.7 to the default models for the China preset.

## Validation
- `npm run typecheck`
- `ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron --test dist/tests/main/provider-preset-utils.test.js`
- Verified both preset default model arrays against the official model list.
- Captured unauthenticated requests for both supported protocols in both regions; all four reached the expected endpoint and returned 401.
