### PR TITLE
fix: 顶层 api_key 未自动转为有效凭证导致路由丢失 Provider 上下文

### DIFF
--- a/packages/core/src/providers/runtime-topology.ts
+++ b/packages/core/src/providers/runtime-topology.ts
@@ -81,10 +81,20 @@ export function findProviderByPublicOrInternalName(config: AppConfig, name: stri
 }
 
 export function activeProviderCredentials(provider: GatewayProviderConfig): ProviderCredentialConfig[] {
-  return (provider.credentials ?? []).filter((credential) =>
+  const credentials = (provider.credentials ?? []).filter((credential) =>
     credential.enabled !== false &&
     Boolean(providerCredentialApiKey(credential))
   );
+  if (credentials.length > 0) {
+    return credentials;
+  }
+
+  const topLevelApiKey = provider.apikey || provider.apiKey || provider.api_key;
+  if (topLevelApiKey) {
+    return [{ api_key: topLevelApiKey }];
+  }
+
+  return [];
 }
 
 export function providerCredentialPriority(credential: ProviderCredentialConfig, index: number): number {


### PR DESCRIPTION
## 问题描述

当 Provider 只配置了顶层 `api_key`、没有显式 `credentials` 数组时，`activeProviderCredentials()` 返回空数组。路由系统在 credential 路径下检查 `activeProviderCredentials().length === 0`，判断为无效 provider，丢失 provider 上下文。

丢失上下文的模型名被当作裸模型名，错误地尝试匹配其他 provider，最终报 "Model not configured"。

### 复现配置

```json
{
  "Providers": [
    {
      "name": "CoClaw",
      "api_key": "sk-xxx",
      "models": ["Qwen3-235B-A22B"],
      "capabilities": [{ "type": "openai_chat_completions" }]
    }
  ]
}
```

### 错误信息

```
{"error":{"message":"All target providers failed.",
"attempts":[
  {"stage":"model_resolution","message":"Model \"Qwen3-235B-A22B\" is not configured for target provider openai. Allowed models: nebulacoder-v8.0..."}
]}
```

## 根因

`activeProviderCredentials()` 只检查 `provider.credentials` 数组，完全忽略顶层的 `api_key`。而 `toCoreGatewayProvider()` 发请求时却能正确 fallback 到顶层 `api_key`，两者行为不一致。

## 修复

在 `credentials` 数组为空时，自动从顶层 `api_key` 合成一个隐式 credential：

```diff
 function activeProviderCredentials(provider) {
-  return (provider.credentials ?? []).filter(...);
+  const credentials = (provider.credentials ?? []).filter(...);
+  if (credentials.length > 0) return credentials;
+
+  const topLevelApiKey = provider.apikey || provider.apiKey || provider.api_key;
+  if (topLevelApiKey) return [{ api_key: topLevelApiKey }];
+
+  return [];
 }
```

## 自测

还原 config 中去掉 `credentials` 后，仅凭代码修复三个模型全部正常：

```
CoClaw/Qwen3-235B-A22B       ✅  200 OK
NebulaCoder/nebulacoder-v8.0 ✅  200 OK
DeepSeek/deepseek-v4-flash   ✅  200 OK
```
