### PR TITLE
fix: Provider/Model 格式透传时未剥掉 Provider 前缀导致模型匹配失败

### DIFF
--- a/packages/core/src/gateway/upstream/executor.ts
+++ b/packages/core/src/gateway/upstream/executor.ts
@@ -374,9 +374,7 @@ function prepareUpstreamCredentialAttempt(input: {
     target
   });
   if (!target) {
-    const body = bodyHasConfiguredProviderModelSelector(input.attempt.body, input.config)
-      ? input.attempt.body
-      : normalizedBody?.body ?? input.attempt.body;
+    const body = normalizedBody?.body ?? input.attempt.body;
     return {
       ...input.attempt,
       body: attemptBody(body),
@@ -620,11 +618,6 @@ function normalizeConfiguredProviderModelBody(
 }
 
 
-function bodyHasConfiguredProviderModelSelector(body: Buffer | undefined, config: AppConfig): boolean {
-  const parsedBody = parseJsonObjectSafe(body);
-  const model = stringValue(parsedBody?.model);
-  return Boolean(resolveConfiguredProviderModelSelector(model, config));
-}
 
 
 function resolveProviderCredentialRoutingTarget(


### PR DESCRIPTION
## 问题描述

当请求使用 `Provider/Model` 格式（如 `NebulaCoder/nebulacoder-cot-v8.0`）时，`prepareUpstreamCredentialAttempt` 在 `!target` 分支下优先保留原始 body（含 `NebulaCoder/` 前缀），而非使用 `normalizedBody.body`（已剥前缀）。带前缀的模型名传到 ai-gateway 后，后者只识别裸模型名，匹配失败返回 400。

### 触发场景

当请求使用了已知 inline 模型（模型名直接匹配到某个 provider 的 models 列表）时触发：

- profile 配置了模型名（如 `"model": "deepseek-v4-flash"`），CCR 自动补全为 `DeepSeek/deepseek-v4-flash`，带前缀的 body 直接透传
- Subagent 通过 `<CCR-SUBAGENT-MODEL>Provider/xxx</>` 标签路由时
- 请求直接指定 `"model": "NebulaCoder/nebulacoder-v8.0"` 时

这些场景都走了 `isKnownInlineRoute` 短路路径（`claude-code-router-plugin.ts:196`），跳过了规则系统的 rewrite，body 中的 model 名带 `Provider/` 前缀直接透传。

### 数据库证据

`request_logs.sqlite` 中 3 次 NebulaCoder 调用全部因此失败：

```
id=125  request:  {"model":"NebulaCoder/nebulacoder-cot-v8.0", ...}
        response: {"error":{"message":"All target providers failed.",
                    "attempts":[{"provider":"openai",
                      "stage":"model_resolution",
                      "message":"Model \"NebulaCoder/nebulacoder-cot-v8.0\" is not configured
                                 for target provider openai.
                                 Allowed models: nebulacoder-v8.0, nebulacoder-cot-v8.0."}
                    ]}}
```

## 根因

`prepareUpstreamCredentialAttempt` 在 `!target` 分支下，当 body 能被解析为 `Provider/Model` 格式时，`bodyHasConfiguredProviderModelSelector` 返回 true，选择了保留带前缀的 body。但这个带前缀的模型名传给 ai-gateway 后只识别裸模型名，导致报错。

## 修复

始终使用 `normalizedBody.body`（已剥前缀），移除不再使用的 `bodyHasConfiguredProviderModelSelector` 函数。