### PR TITLE
fix: preserve SSE outcomes, improve upstream diagnostics, and polish UI

### DIFF
--- a/packages/core/src/gateway/http/io.ts
+++ b/packages/core/src/gateway/http/io.ts
@@ -151,8 +151,8 @@ export function formatUpstreamErrorForLog(error: unknown, context: UpstreamError
   const code = firstErrorProperty(chain, "code");
   const errno = firstErrorProperty(chain, "errno");
   const syscall = firstErrorProperty(chain, "syscall");
-  const message = sanitizeUpstreamErrorText(outer?.message || formatError(error)) || "Unknown upstream error";
-  const causeMessage = sanitizeUpstreamErrorText(cause?.message || "");
+  const message = redactUpstreamCredentialValues(outer?.message || formatError(error)) || "Unknown upstream error";
+  const causeMessage = redactUpstreamCredentialValues(cause?.message || "");
   const phase = inferUpstreamErrorPhase({
     code,
     message: `${message} ${causeMessage}`,
@@ -161,10 +161,10 @@ export function formatUpstreamErrorForLog(error: unknown, context: UpstreamError
     syscall
   });
   const fields = [
-    `cause=${sanitizeDiagnosticValue(cause?.name || "UnknownError")}`,
-    code ? `code=${sanitizeDiagnosticValue(code)}` : undefined,
-    errno ? `errno=${sanitizeDiagnosticValue(errno)}` : undefined,
-    syscall ? `syscall=${sanitizeDiagnosticValue(syscall)}` : undefined,
+    `cause=${normalizeDiagnosticValue(cause?.name || "UnknownError")}`,
+    code ? `code=${normalizeDiagnosticValue(code)}` : undefined,
+    errno ? `errno=${normalizeDiagnosticValue(errno)}` : undefined,
+    syscall ? `syscall=${normalizeDiagnosticValue(syscall)}` : undefined,
     `phase=${phase}`,
     `response_started=${context.responseStarted}`,
     `attempts=${Math.max(1, Math.trunc(context.attempts))}`,
@@ -240,23 +240,21 @@ function inferUpstreamErrorPhase(input: {
 }
 
 
-function sanitizeUpstreamErrorText(value: string): string {
+function redactUpstreamCredentialValues(value: string): string {
   return value
-    .replace(/\b(?:https?|wss?):\/\/[^\s"'<>]+/gi, "[redacted-url]")
+    .replace(/(\b(?:https?|wss?):\/\/[^/\s:@]+:)[^@\s/]+@/gi, "$1[redacted]@")
+    .replace(/([?&](?:api[-_]?key|key|token|access[-_]?token|refresh[-_]?token|client[-_]?secret|auth|authorization|password)=)[^&\s#]*/gi, "$1[redacted]")
+    .replace(/\b((?:proxy[-_])?authorization)\s*([:=])\s*(?:(?:Bearer|Basic)\s+)?[^\s,;&#]+/gi, "$1$2[redacted]")
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [redacted]")
     .replace(/\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,}/gi, "[redacted-secret]")
-    .replace(/\b(?:authorization|x-api-key|api-key|api_key|access_token|token)\s*[:=]\s*["']?[^\s,;"']+/gi, (match) => `${match.split(/\s*[:=]/, 1)[0]}=[redacted]`)
-    .replace(/\[[0-9a-f:]+\](?::\d+)?/gi, "[redacted-address]")
-    .replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b/g, "[redacted-address]")
-    .replace(/\b(connect(?:ing)?(?:\s+to)?|from|to)\s+(?:[A-Za-z0-9.-]+|\[[0-9a-f:]+\])(?::\d+)?/gi, "$1 [redacted-address]")
-    .replace(/([?&](?:api_?key|key|token|access_token|auth)=)[^&\s]+/gi, "$1[redacted]")
+    .replace(/\b((?:x[-_](?:[a-z0-9]+[-_])*)?api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|token|password)\s*([:=])\s*(?:"[^"]*"|'[^']*'|[^\s,;&#"']+)/gi, "$1$2[redacted]")
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, 240);
 }
 
 
-function sanitizeDiagnosticValue(value: string): string {
+function normalizeDiagnosticValue(value: string): string {
   const normalized = value.replace(/[^A-Za-z0-9_.:-]/g, "_").slice(0, 80);
   return normalized || "unknown";
 }

--- a/packages/core/src/gateway/http/io.ts
+++ b/packages/core/src/gateway/http/io.ts
@@ -134,6 +134,148 @@ export function formatError(error: unknown): string {
 }
 
 
+export type UpstreamErrorLogContext = {
+  attempts: number;
+  elapsedMs: number;
+  fallbackFailures: number;
+  operation: "fetch" | "stream";
+  responseStarted: boolean;
+  retryDelayMs?: number;
+};
+
+
+export function formatUpstreamErrorForLog(error: unknown, context: UpstreamErrorLogContext): string {
+  const chain = collectErrorChain(error);
+  const outer = chain[0];
+  const cause = chain[chain.length - 1] ?? outer;
+  const code = firstErrorProperty(chain, "code");
+  const errno = firstErrorProperty(chain, "errno");
+  const syscall = firstErrorProperty(chain, "syscall");
+  const message = sanitizeUpstreamErrorText(outer?.message || formatError(error)) || "Unknown upstream error";
+  const causeMessage = sanitizeUpstreamErrorText(cause?.message || "");
+  const phase = inferUpstreamErrorPhase({
+    code,
+    message: `${message} ${causeMessage}`,
+    name: cause?.name,
+    responseStarted: context.responseStarted,
+    syscall
+  });
+  const fields = [
+    `cause=${sanitizeDiagnosticValue(cause?.name || "UnknownError")}`,
+    code ? `code=${sanitizeDiagnosticValue(code)}` : undefined,
+    errno ? `errno=${sanitizeDiagnosticValue(errno)}` : undefined,
+    syscall ? `syscall=${sanitizeDiagnosticValue(syscall)}` : undefined,
+    `phase=${phase}`,
+    `response_started=${context.responseStarted}`,
+    `attempts=${Math.max(1, Math.trunc(context.attempts))}`,
+    `fallback_failures=${Math.max(0, Math.trunc(context.fallbackFailures))}`,
+    `retry_delay_ms=${Math.max(0, Math.trunc(context.retryDelayMs ?? 0))}`,
+    `elapsed_ms=${Math.max(0, Math.trunc(context.elapsedMs))}`,
+    !code && causeMessage && causeMessage !== message ? `detail=${JSON.stringify(causeMessage)}` : undefined
+  ].filter((field): field is string => Boolean(field));
+  return `Upstream ${context.operation} failed: ${message} [${fields.join("; ")}]`;
+}
+
+
+type ErrorChainItem = {
+  error: object;
+  message?: string;
+  name?: string;
+};
+
+
+function collectErrorChain(error: unknown): ErrorChainItem[] {
+  const chain: ErrorChainItem[] = [];
+  const seen = new Set<object>();
+  let current = error;
+  for (let depth = 0; depth < 6 && isObject(current) && !seen.has(current); depth += 1) {
+    seen.add(current);
+    chain.push({
+      error: current,
+      message: typeof readErrorProperty(current, "message") === "string"
+        ? String(readErrorProperty(current, "message"))
+        : undefined,
+      name: typeof readErrorProperty(current, "name") === "string"
+        ? String(readErrorProperty(current, "name"))
+        : undefined
+    });
+    current = readErrorProperty(current, "cause");
+  }
+  return chain;
+}
+
+
+function firstErrorProperty(chain: ErrorChainItem[], key: "code" | "errno" | "syscall"): string | undefined {
+  for (const item of chain) {
+    const value = readErrorProperty(item.error, key);
+    if (typeof value === "string" || typeof value === "number") {
+      const normalized = String(value).trim();
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+  return undefined;
+}
+
+
+function inferUpstreamErrorPhase(input: {
+  code?: string;
+  message: string;
+  name?: string;
+  responseStarted: boolean;
+  syscall?: string;
+}): "aborted" | "connect" | "dns" | "fetch" | "response_body" | "response_headers" | "tls" {
+  const signature = `${input.code ?? ""} ${input.name ?? ""} ${input.message} ${input.syscall ?? ""}`.toUpperCase();
+  if (/ABORT|CANCEL/.test(signature)) return "aborted";
+  if (/ENOTFOUND|EAI_AGAIN|DNS/.test(signature)) return "dns";
+  if (/CERT|TLS|SSL|EPROTO/.test(signature)) return "tls";
+  if (/HEADERS?_TIMEOUT|RESPONSE_HEADERS|WAITING FOR HEADERS/.test(signature)) return "response_headers";
+  if (/BODY_TIMEOUT|RESPONSE_BODY/.test(signature)) return "response_body";
+  if (/ECONNRESET|EPIPE|UND_ERR_SOCKET/.test(signature)) {
+    return input.responseStarted ? "response_body" : "connect";
+  }
+  if (/CONNECT|ECONNREFUSED|ETIMEDOUT/.test(signature)) return "connect";
+  return input.responseStarted ? "response_body" : "fetch";
+}
+
+
+function sanitizeUpstreamErrorText(value: string): string {
+  return value
+    .replace(/\b(?:https?|wss?):\/\/[^\s"'<>]+/gi, "[redacted-url]")
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [redacted]")
+    .replace(/\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,}/gi, "[redacted-secret]")
+    .replace(/\b(?:authorization|x-api-key|api-key|api_key|access_token|token)\s*[:=]\s*["']?[^\s,;"']+/gi, (match) => `${match.split(/\s*[:=]/, 1)[0]}=[redacted]`)
+    .replace(/\[[0-9a-f:]+\](?::\d+)?/gi, "[redacted-address]")
+    .replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b/g, "[redacted-address]")
+    .replace(/\b(connect(?:ing)?(?:\s+to)?|from|to)\s+(?:[A-Za-z0-9.-]+|\[[0-9a-f:]+\])(?::\d+)?/gi, "$1 [redacted-address]")
+    .replace(/([?&](?:api_?key|key|token|access_token|auth)=)[^&\s]+/gi, "$1[redacted]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 240);
+}
+
+
+function sanitizeDiagnosticValue(value: string): string {
+  const normalized = value.replace(/[^A-Za-z0-9_.:-]/g, "_").slice(0, 80);
+  return normalized || "unknown";
+}
+
+
+function readErrorProperty(error: object, key: string): unknown {
+  try {
+    return (error as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
+
+function isObject(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+
 export function abortSignalMessage(signal: AbortSignal): string {
   const reason = signal.reason as unknown;
   if (reason instanceof Error && reason.message) {

--- a/packages/core/src/gateway/http/io.ts
+++ b/packages/core/src/gateway/http/io.ts
@@ -244,6 +244,7 @@ function redactUpstreamCredentialValues(value: string): string {
   return value
     .replace(/(\b(?:https?|wss?):\/\/[^/\s:@]+:)[^@\s/]+@/gi, "$1[redacted]@")
     .replace(/([?&](?:api[-_]?key|key|token|access[-_]?token|refresh[-_]?token|client[-_]?secret|auth|authorization|password)=)[^&\s#]*/gi, "$1[redacted]")
+    .replace(/"((?:proxy[-_])?authorization|(?:x[-_](?:[a-z0-9]+[-_])*)?api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|token|password)"\s*:\s*"(?:\\.|[^"\\])*"/gi, '"$1":"[redacted]"')
     .replace(/\b((?:proxy[-_])?authorization)\s*([:=])\s*(?:(?:Bearer|Basic)\s+)?[^\s,;&#]+/gi, "$1$2[redacted]")
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [redacted]")
     .replace(/\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,}/gi, "[redacted-secret]")

--- a/packages/core/src/gateway/internal/shared.ts
+++ b/packages/core/src/gateway/internal/shared.ts
@@ -235,6 +235,28 @@ export const clientClosedRequestStatusCode = 499;
 
 export const clientDisconnectMessage = "Client connection closed before response completed.";
 
+export function resolveStreamRequestLogOutcome(input: {
+  clientDisconnected: boolean;
+  detectedError?: string;
+  streamError?: string;
+  terminalEventSeen: boolean;
+  upstreamStatus: number;
+}): { error?: string; statusCode: number } {
+  const interrupted = input.clientDisconnected && !input.terminalEventSeen;
+  if (interrupted) {
+    return {
+      error: clientDisconnectMessage,
+      statusCode: clientClosedRequestStatusCode
+    };
+  }
+  return {
+    error: input.clientDisconnected && input.terminalEventSeen
+      ? input.detectedError
+      : input.streamError ?? input.detectedError,
+    statusCode: input.upstreamStatus
+  };
+}
+
 export const localObservabilityHeaderNames = new Set([
   "x-ccr-claude-app-model-rewrite",
   "x-ccr-codex-patch-bridge",

--- a/packages/core/src/gateway/request/pipeline.ts
+++ b/packages/core/src/gateway/request/pipeline.ts
@@ -16,7 +16,7 @@ import { resolveProviderLogName, resolveResponseProviderProtocol, sanitizeHeader
 import { createBodySampler, shouldRecordRequestLogs } from "@ccr/core/observability/raw-trace-sync";
 import { endpoint } from "@ccr/core/gateway/core-runtime/supervisor";
 import { coreGatewayUsageAttributionConfig } from "@ccr/core/gateway/core-runtime/config-compiler";
-import { clientClosedRequestStatusCode, clientDisconnectMessage, UpstreamRequestError } from "@ccr/core/gateway/internal/shared";
+import { clientClosedRequestStatusCode, clientDisconnectMessage, resolveStreamRequestLogOutcome, UpstreamRequestError } from "@ccr/core/gateway/internal/shared";
 import type { BrowserWebSearchMcpIntegration, BrowserWebSearchProtocolRecord, UpstreamFetchResult } from "@ccr/core/gateway/internal/shared";
 import { applyProviderCapabilityRouting, cancelResponseBody, destroyResponseStreams, fetchUpstreamWithFallback, mergeFallbackResponseHeaders, rewriteCapabilityResponseHeaders, uniqueStreams, upstreamResponseHeaders } from "@ccr/core/gateway/upstream/executor";
 import { shouldApplyGatewayRouting } from "@ccr/core/routing/protocol-endpoints";
@@ -418,16 +418,24 @@ export class GatewayRequestPipeline {
           return;
         }
         logRecorded = true;
+        const outcome = resolveStreamRequestLogOutcome({
+          clientDisconnected,
+          detectedError: streamDetectedError,
+          streamError: error,
+          terminalEventSeen: sseErrorDetector.hasTerminalEvent(),
+          upstreamStatus: upstreamResponse.status
+        });
         writeRequestLog(
-          clientDisconnected ? clientClosedRequestStatusCode : upstreamResponse.status,
+          outcome.statusCode,
           responseHeaders,
           sampler.read(),
           sampler.isTruncated(),
-          error ?? streamDetectedError
+          outcome.error
         );
       };
       onClientDisconnect = () => {
-        writeStreamLog(clientDisconnectMessage);
+        streamDetectedError ??= sseErrorDetector.finish();
+        writeStreamLog();
         responseBody.unpipe(response);
         destroyResponseStreams(responseStreams);
       };

--- a/packages/core/src/gateway/request/pipeline.ts
+++ b/packages/core/src/gateway/request/pipeline.ts
@@ -10,7 +10,7 @@ import { reserveApiKeyLimits } from "@ccr/core/gateway/auth/api-key-authorizer";
 import { recordProviderCredentialOutcome } from "@ccr/core/providers/credential-pool";
 import { codexApplyPatchBridgeResponseStream, prepareCodexApplyPatchBridgeRequest } from "@ccr/core/gateway/features/codex-patch-bridge";
 import { prepareCursorOpenAICompatChatBody } from "@ccr/core/gateway/features/cursor-compat";
-import { filteredResponseHeaders, formatError, forwardHeaders, inferGatewayClient, parseJsonObject, readRequestBody, sendJson, shouldCaptureGatewayUsage, shouldSendBody, stripLocalGatewayAuthHeaders } from "@ccr/core/gateway/http/io";
+import { filteredResponseHeaders, formatError, formatUpstreamErrorForLog, forwardHeaders, inferGatewayClient, parseJsonObject, readRequestBody, sendJson, shouldCaptureGatewayUsage, shouldSendBody, stripLocalGatewayAuthHeaders } from "@ccr/core/gateway/http/io";
 import { createGatewayModelsResponse, prepareClaudeAppDiscoveredModelRequest, prepareClaudeCodeDiscoveredModelRequest, shouldServeGatewayModelsResponse } from "@ccr/core/gateway/features/model-discovery";
 import { resolveProviderLogName, resolveResponseProviderProtocol, sanitizeHeaderValue } from "@ccr/core/providers/runtime-topology";
 import { createBodySampler, shouldRecordRequestLogs } from "@ccr/core/observability/raw-trace-sync";
@@ -307,7 +307,15 @@ export class GatewayRequestPipeline {
           upstreamUrl
         });
       } catch (error) {
-        const message = formatError(error);
+        const failedAttempts = error instanceof UpstreamRequestError ? error.failedAttempts : [];
+        const message = formatUpstreamErrorForLog(error, {
+          attempts: Math.max(1, failedAttempts.length),
+          elapsedMs: Date.now() - startedAt,
+          fallbackFailures: Math.max(0, failedAttempts.length - 1),
+          operation: "fetch",
+          responseStarted: false,
+          retryDelayMs: failedAttempts.reduce((total, attempt) => total + Math.max(0, attempt.delayMs ?? 0), 0)
+        });
         if (error instanceof UpstreamRequestError) {
           bodyToForward = error.attempt?.body ?? bodyToForward;
           routedModel = error.attempt?.model ?? routedModel;
@@ -446,7 +454,17 @@ export class GatewayRequestPipeline {
       };
       const onResponseStreamError = (error: Error) => {
         streamDetectedError ??= sseErrorDetector.finish();
-        writeStreamLog(clientDisconnected ? clientDisconnectMessage : formatError(error));
+        writeStreamLog(clientDisconnected ? clientDisconnectMessage : formatUpstreamErrorForLog(error, {
+          attempts: upstreamResult.failedAttempts.length + 1,
+          elapsedMs: Date.now() - startedAt,
+          fallbackFailures: upstreamResult.failedAttempts.length,
+          operation: "stream",
+          responseStarted: true,
+          retryDelayMs: upstreamResult.failedAttempts.reduce(
+            (total, attempt) => total + Math.max(0, attempt.delayMs ?? 0),
+            0
+          )
+        }));
       };
       for (const stream of responseStreams) {
         stream.on("error", onResponseStreamError);

--- a/packages/core/src/observability/request-log-store.ts
+++ b/packages/core/src/observability/request-log-store.ts
@@ -187,6 +187,7 @@ type StreamedToolCallInput = {
 export type SseErrorDetector = {
   append: (chunk: Buffer | string) => string | undefined;
   finish: () => string | undefined;
+  hasTerminalEvent: () => boolean;
   read: () => string | undefined;
 };
 
@@ -199,6 +200,22 @@ const maxBodyBytes = 2 * 1024 * 1024;
 const maxAgentAnalysisRows = 5000;
 const maxAgentSessionDetailRequests = 250;
 const maxTracePayloadPreviewChars = 1600;
+const terminalSseEventNames = new Set([
+  "done",
+  "error",
+  "message_stop",
+  "response.completed",
+  "response.error",
+  "response.failed",
+  "response.incomplete"
+]);
+const terminalSseResponseStatuses = new Set([
+  "cancelled",
+  "completed",
+  "error",
+  "failed",
+  "incomplete"
+]);
 const requestLogBodyMetadataSelect = `
             '' AS request_body_text,
             '' AS response_body_text
@@ -3292,13 +3309,15 @@ export function createSseErrorDetector(contentType?: string, force = false): Sse
   let currentEvent = "";
   let dataLines: string[] = [];
   let detectedError: string | undefined;
+  let finished = false;
   let pendingLine = "";
+  let terminalEventSeen = false;
 
   const read = () => detectedError;
   const flushEvent = () => {
-    if (!detectedError) {
-      detectedError = detectSseEventError(currentEvent, dataLines);
-    }
+    const eventError = detectSseEventError(currentEvent, dataLines);
+    terminalEventSeen ||= Boolean(eventError) || isSseTerminalEvent(currentEvent, dataLines);
+    detectedError ??= eventError;
     currentEvent = "";
     dataLines = [];
   };
@@ -3338,16 +3357,17 @@ export function createSseErrorDetector(contentType?: string, force = false): Sse
 
   return {
     append(chunk: Buffer | string) {
-      if (!active || detectedError) {
+      if (!active || detectedError || finished) {
         return detectedError;
       }
       processText(Buffer.isBuffer(chunk) ? decoder.write(chunk) : chunk);
       return detectedError;
     },
     finish() {
-      if (!active || detectedError) {
+      if (!active || finished) {
         return detectedError;
       }
+      finished = true;
       processText(decoder.end());
       if (pendingLine) {
         processLine(pendingLine.endsWith("\r") ? pendingLine.slice(0, -1) : pendingLine);
@@ -3358,8 +3378,30 @@ export function createSseErrorDetector(contentType?: string, force = false): Sse
       }
       return detectedError;
     },
+    hasTerminalEvent() {
+      return terminalEventSeen;
+    },
     read
   };
+}
+
+function isSseTerminalEvent(eventName: string, dataLines: string[]): boolean {
+  const event = eventName.trim().toLowerCase();
+  const data = dataLines.join("\n").trim();
+  if (data === "[DONE]") {
+    return true;
+  }
+
+  const payload = data ? parseJson(data) : undefined;
+  const payloadType = isRecord(payload) ? asString(payload.type)?.toLowerCase() : undefined;
+  const response = isRecord(payload) && isRecord(payload.response) ? payload.response : undefined;
+  const responseStatus = asString(response?.status)?.toLowerCase();
+
+  return (
+    terminalSseEventNames.has(event) ||
+    Boolean(payloadType && terminalSseEventNames.has(payloadType)) ||
+    Boolean(responseStatus && terminalSseResponseStatuses.has(responseStatus))
+  );
 }
 
 function detectSseEventError(eventName: string, dataLines: string[]): string | undefined {

--- a/packages/electron/src/main/tray-controller.ts
+++ b/packages/electron/src/main/tray-controller.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, Tray, app, nativeImage, screen, type BrowserWindowConstructorOptions } from "electron";
+import { BrowserWindow, Menu, Tray, app, nativeImage, nativeTheme, screen, type BrowserWindowConstructorOptions } from "electron";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { deflateSync } from "node:zlib";
@@ -17,21 +17,8 @@ const popoverDetailWidth = 420;
 const popoverMargin = 8;
 const trayActivationSuppressMs = 750;
 const trayMenuBarIconSize = 20;
-const trayWindowBackgroundColor = "#1c1c1e";
-const trayWindowMaterialOptions: Pick<
-  BrowserWindowConstructorOptions,
-  "backgroundColor" | "transparent" | "vibrancy" | "visualEffectState"
-> = process.platform === "darwin"
-  ? {
-      backgroundColor: "#00000000",
-      transparent: true,
-      vibrancy: "under-window",
-      visualEffectState: "active"
-    }
-  : {
-      backgroundColor: trayWindowBackgroundColor,
-      transparent: false
-    };
+const trayWindowDarkBackgroundColor = "#1c1c1e";
+const trayWindowLightBackgroundColor = "#f2f2f7";
 const trayTokenFallbackTitle = "0 tokens";
 const trayIconFallbackPath = path.join(__dirname, "../assets/tray.png");
 const trayMascotIconIds = ["violet", "orange", "cyan"] as const;
@@ -216,7 +203,7 @@ class TrayController {
       show: false,
       skipTaskbar: true,
       title: `${APP_NAME} Usage`,
-      ...trayWindowMaterialOptions,
+      ...trayWindowMaterialOptions(),
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
@@ -228,7 +215,7 @@ class TrayController {
       width: popoverMenuWidth
     });
 
-    reinforceMacOSTrayMaterial(this.popover);
+    reinforceTrayWindowMaterial(this.popover);
     prepareTrayWindowForSharpRendering(this.popover);
     this.popover.setAlwaysOnTop(true, "pop-up-menu");
     this.popover.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
@@ -261,7 +248,7 @@ class TrayController {
       show: false,
       skipTaskbar: true,
       title: `${APP_NAME} Usage Detail`,
-      ...trayWindowMaterialOptions,
+      ...trayWindowMaterialOptions(),
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
@@ -273,7 +260,7 @@ class TrayController {
       width: popoverDetailWidth
     });
 
-    reinforceMacOSTrayMaterial(this.detailPopover);
+    reinforceTrayWindowMaterial(this.detailPopover);
     prepareTrayWindowForSharpRendering(this.detailPopover);
     this.detailPopover.setAlwaysOnTop(true, "pop-up-menu");
     this.detailPopover.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
@@ -577,20 +564,49 @@ function normalizeDetailProvider(provider?: string): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-function reinforceMacOSTrayMaterial(window: BrowserWindow): void {
-  if (process.platform !== "darwin") {
-    return;
-  }
-
+function reinforceTrayWindowMaterial(window: BrowserWindow): void {
   const applyMaterial = () => {
-    if (!window.isDestroyed()) {
+    if (window.isDestroyed()) {
+      return;
+    }
+    if (process.platform === "darwin") {
       window.setBackgroundColor("#00000000");
       window.setVibrancy("under-window");
+      return;
     }
+    window.setBackgroundColor(trayWindowBackgroundColor());
   };
 
   applyMaterial();
   window.webContents.on("did-finish-load", applyMaterial);
+  if (process.platform !== "darwin") {
+    nativeTheme.on("updated", applyMaterial);
+    window.once("closed", () => nativeTheme.off("updated", applyMaterial));
+  }
+}
+
+function trayWindowBackgroundColor(): string {
+  return nativeTheme.shouldUseDarkColors
+    ? trayWindowDarkBackgroundColor
+    : trayWindowLightBackgroundColor;
+}
+
+function trayWindowMaterialOptions(): Pick<
+  BrowserWindowConstructorOptions,
+  "backgroundColor" | "transparent" | "vibrancy" | "visualEffectState"
+> {
+  if (process.platform === "darwin") {
+    return {
+      backgroundColor: "#00000000",
+      transparent: true,
+      vibrancy: "under-window",
+      visualEffectState: "active"
+    };
+  }
+  return {
+    backgroundColor: trayWindowBackgroundColor(),
+    transparent: false
+  };
 }
 
 function prepareTrayWindowForSharpRendering(window: BrowserWindow): void {

--- a/packages/ui/src/pages/home/components/dashboard.tsx
+++ b/packages/ui/src/pages/home/components/dashboard.tsx
@@ -17,7 +17,7 @@ import {
   providerAccountSnapshotKey, providerAccountSnapshotLabel,
   ProviderAccountMeter, ProviderAccountSnapshot, ReactNode, ReactPointerEvent, rectSortingStrategy, RefreshCw, Select,
   SelectControl, SortableContext, sortableKeyboardCoordinates, systemStatusPointTooltip,
-  systemStatusTooltipPositionClass, Tooltip, translateOptions, Trash2, UsageComparisonRow, usageRangeOptions,
+  Tooltip, translateOptions, Trash2, UsageComparisonRow, usageRangeOptions,
   GatewayProviderConfig, UsageSeriesPoint, UsageStatsRange, UsageStatsSnapshot, usageStatusTone, UsageTotals, useAppText,
   useEffect, useMemo, useRef, useSensor, useSensors, useSortable,
   useState, X, XAxis, YAxis
@@ -28,6 +28,7 @@ import {
   CalendarDays, ChartNoAxesCombined, ChartPie, Cloud, GripHorizontal, Inbox, Layers3,
   Rocket, Server, UsersRound, WalletCards
 } from "lucide-react";
+import { createPortal } from "react-dom";
 
 type OverviewUsageFilters = {
   modelFilter: string;
@@ -2105,6 +2106,43 @@ type SystemStatusPoint = {
   tone: SystemStatusTone;
 };
 
+type SystemStatusTooltipState = {
+  arrowLeft: number;
+  left: number;
+  placement: "above" | "below";
+  segment: SystemStatusPoint;
+  top: number;
+};
+
+const systemStatusTooltipWidth = 190;
+const systemStatusTooltipHeight = 104;
+const systemStatusTooltipGap = 10;
+const systemStatusTooltipViewportMargin = 12;
+
+function resolveSystemStatusTooltipPosition(rect: DOMRect): Omit<SystemStatusTooltipState, "segment"> {
+  const availableWidth = Math.max(0, window.innerWidth - systemStatusTooltipViewportMargin * 2);
+  const width = Math.min(systemStatusTooltipWidth, availableWidth);
+  const maxLeft = Math.max(systemStatusTooltipViewportMargin, window.innerWidth - width - systemStatusTooltipViewportMargin);
+  const left = Math.min(
+    Math.max(systemStatusTooltipViewportMargin, rect.left + rect.width / 2 - width / 2),
+    maxLeft
+  );
+  const spaceAbove = rect.top - systemStatusTooltipViewportMargin - systemStatusTooltipGap;
+  const spaceBelow = window.innerHeight - rect.bottom - systemStatusTooltipViewportMargin - systemStatusTooltipGap;
+  const placement = spaceAbove >= systemStatusTooltipHeight || spaceAbove >= spaceBelow ? "above" : "below";
+  const preferredTop = placement === "above"
+    ? rect.top - systemStatusTooltipGap - systemStatusTooltipHeight
+    : rect.bottom + systemStatusTooltipGap;
+  const maxTop = Math.max(
+    systemStatusTooltipViewportMargin,
+    window.innerHeight - systemStatusTooltipHeight - systemStatusTooltipViewportMargin
+  );
+  const top = Math.min(Math.max(systemStatusTooltipViewportMargin, preferredTop), maxTop);
+  const arrowLeft = Math.min(Math.max(12, rect.left + rect.width / 2 - left), Math.max(12, width - 12));
+
+  return { arrowLeft, left, placement, top };
+}
+
 function SystemStatusBar({
   variant = "timeline",
   usageRange,
@@ -2115,6 +2153,7 @@ function SystemStatusBar({
   usageStats: UsageStatsSnapshot;
 }) {
   const t = useAppText();
+  const [statusTooltip, setStatusTooltip] = useState<SystemStatusTooltipState>();
   const segments = usageStats.series.map((point) => ({
     dateLabel: formatStatusBucketDate(point.bucket, usageRange),
     point,
@@ -2124,6 +2163,23 @@ function SystemStatusBar({
   const overallTone = usageStatusTone(usageStats.totals);
   const StatusIcon = overallTone === "ok" ? Check : CircleAlert;
   const rangeLabel = formatSystemStatusRange(segments, usageRange);
+
+  useEffect(() => {
+    if (!statusTooltip) {
+      return;
+    }
+    const dismiss = () => setStatusTooltip(undefined);
+    window.addEventListener("resize", dismiss);
+    window.addEventListener("scroll", dismiss, true);
+    return () => {
+      window.removeEventListener("resize", dismiss);
+      window.removeEventListener("scroll", dismiss, true);
+    };
+  }, [statusTooltip]);
+
+  const showStatusTooltip = (segment: SystemStatusPoint, target: HTMLElement) => {
+    setStatusTooltip({ segment, ...resolveSystemStatusTooltipPosition(target.getBoundingClientRect()) });
+  };
 
   if (variant === "compact") {
     return (
@@ -2171,40 +2227,58 @@ function SystemStatusBar({
           <div className="flex min-w-0 gap-1" aria-label={t("System status")}>
             {segments.map((segment, index) => (
               <span
-                className="group relative flex h-5 min-w-[3px] flex-1"
+                aria-label={systemStatusPointTooltip(segment, t)}
+                className="relative flex h-5 min-w-[3px] flex-1 outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                 key={`${segment.point.bucket}-${index}`}
+                onBlur={() => setStatusTooltip(undefined)}
+                onFocus={(event) => showStatusTooltip(segment, event.currentTarget)}
+                onMouseEnter={(event) => showStatusTooltip(segment, event.currentTarget)}
+                onMouseLeave={() => setStatusTooltip(undefined)}
+                tabIndex={0}
               >
                 <span
                   aria-label={systemStatusPointTooltip(segment, t)}
                   className="overview-status-segment h-full w-full rounded-[4px]"
                   data-tone={segment.tone}
                 />
-                <span
-                  className={cn(
-                    "pointer-events-none absolute bottom-full z-50 mb-2 hidden w-[190px] max-w-[calc(100vw-32px)] rounded-md border border-border/70 bg-popover px-3 py-2 text-left text-[11px] text-popover-foreground shadow-card-elevated group-hover:block",
-                    systemStatusTooltipPositionClass(index, segments.length)
-                  )}
-                >
-                  <span className="block font-semibold">{segment.dateLabel}</span>
-                  <span className="mt-1 flex justify-between gap-3">
-                    <span className="text-muted-foreground">{t("Requests")}</span>
-                    <span className="font-medium">{formatCompactNumber(segment.point.requestCount)}</span>
-                  </span>
-                  <span className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">{t("Success rate")}</span>
-                    <span className="font-medium">{formatPercent(segment.point.successRate)}</span>
-                  </span>
-                  <span className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">{t("Failed requests")}</span>
-                    <span className="font-medium">{formatCompactNumber(segment.point.errorCount)}</span>
-                  </span>
-                  <span className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">{t("Duration")}</span>
-                    <span className="font-medium">{formatDuration(segment.point.avgDurationMs)}</span>
-                  </span>
-                </span>
               </span>
             ))}
+            {statusTooltip ? createPortal(
+              <span
+                className="pointer-events-none fixed z-[150] w-[190px] max-w-[calc(100vw-24px)] rounded-md border border-border/70 bg-popover px-3 py-2 text-left text-[11px] leading-4 text-popover-foreground shadow-card-elevated ring-1 ring-black/5"
+                role="tooltip"
+                style={{ left: statusTooltip.left, top: statusTooltip.top }}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "absolute h-2 w-2 -translate-x-1/2 rotate-45 bg-popover",
+                    statusTooltip.placement === "above"
+                      ? "-bottom-1 border-b border-r border-border/70"
+                      : "-top-1 border-l border-t border-border/70"
+                  )}
+                  style={{ left: statusTooltip.arrowLeft }}
+                />
+                <span className="block font-semibold">{statusTooltip.segment.dateLabel}</span>
+                <span className="mt-1 flex justify-between gap-3">
+                  <span className="text-muted-foreground">{t("Requests")}</span>
+                  <span className="font-medium">{formatCompactNumber(statusTooltip.segment.point.requestCount)}</span>
+                </span>
+                <span className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">{t("Success rate")}</span>
+                  <span className="font-medium">{formatPercent(statusTooltip.segment.point.successRate)}</span>
+                </span>
+                <span className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">{t("Failed requests")}</span>
+                  <span className="font-medium">{formatCompactNumber(statusTooltip.segment.point.errorCount)}</span>
+                </span>
+                <span className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">{t("Duration")}</span>
+                  <span className="font-medium">{formatDuration(statusTooltip.segment.point.avgDurationMs)}</span>
+                </span>
+              </span>,
+              document.body
+            ) : null}
           </div>
         </div>
       </CardContent>

--- a/packages/ui/src/pages/home/components/network-logs.tsx
+++ b/packages/ui/src/pages/home/components/network-logs.tsx
@@ -459,37 +459,38 @@ export function LogsView({
               value={filter.credential ?? ""}
             />
           ) : null}
-          <span className="network-count rounded-full px-2 py-0.5 text-[11px] font-semibold">{page.total}</span>
-          <button
-            aria-label={t("Previous page")}
-            className="network-control-button flex h-7 w-7 items-center justify-center rounded-md border outline-none disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-ring/30"
-            disabled={page.page <= 1}
-            onClick={() => updateFilter({ page: page.page - 1 }, false)}
-            title={t("上一页")}
-            type="button"
-          >
-            <ChevronLeft className="h-3.5 w-3.5" />
-          </button>
-          <span className="network-count min-w-[132px] rounded-full px-2 py-0.5 text-center text-[11px] font-semibold">
-            {firstItem}-{lastItem} / {page.total}
-          </span>
-          <button
-            aria-label={t("Next page")}
-            className="network-control-button flex h-7 w-7 items-center justify-center rounded-md border outline-none disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-ring/30"
-            disabled={page.page >= page.totalPages}
-            onClick={() => updateFilter({ page: page.page + 1 }, false)}
-            title={t("下一页")}
-            type="button"
-          >
-            <ChevronRight className="h-3.5 w-3.5" />
-          </button>
-          <Select
-            aria-label={t("Request log page size")}
-            className="h-7 w-[92px] bg-[length:14px] px-2 pr-7 text-[11px]"
-            onValueChange={(value) => updateFilter({ pageSize: Number(value) })}
-            options={requestLogPageSizeOptions}
-            value={String(page.pageSize)}
-          />
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              aria-label={t("Previous page")}
+              className="network-control-button flex h-7 w-7 items-center justify-center rounded-md border outline-none disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-ring/30"
+              disabled={page.page <= 1}
+              onClick={() => updateFilter({ page: page.page - 1 }, false)}
+              title={t("上一页")}
+              type="button"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </button>
+            <span className="network-count min-w-[132px] rounded-full px-2 py-0.5 text-center text-[11px] font-semibold">
+              {firstItem}-{lastItem} / {page.total}
+            </span>
+            <button
+              aria-label={t("Next page")}
+              className="network-control-button flex h-7 w-7 items-center justify-center rounded-md border outline-none disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-ring/30"
+              disabled={page.page >= page.totalPages}
+              onClick={() => updateFilter({ page: page.page + 1 }, false)}
+              title={t("下一页")}
+              type="button"
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </button>
+            <Select
+              aria-label={t("Request log page size")}
+              className="h-7 w-[92px] bg-[length:14px] px-2 pr-7 text-[11px]"
+              onValueChange={(value) => updateFilter({ pageSize: Number(value) })}
+              options={requestLogPageSizeOptions}
+              value={String(page.pageSize)}
+            />
+          </div>
           <button
             aria-label={t("Refresh request logs")}
             className="network-control-button flex h-7 w-7 items-center justify-center rounded-md border outline-none focus-visible:ring-2 focus-visible:ring-ring/30"

--- a/packages/ui/src/pages/home/components/network-logs.tsx
+++ b/packages/ui/src/pages/home/components/network-logs.tsx
@@ -884,12 +884,13 @@ function LogJsonPanel({
       <div className="network-pane-header flex h-10 min-w-0 shrink-0 items-center gap-3 border-b px-3">
         <span className="network-pane-title shrink-0 text-[14px] font-bold">{title}</span>
         {subtitle ? <span className="network-muted shrink-0 text-[12px] font-semibold">{subtitle}</span> : null}
-        <div className="flex min-w-0 items-center gap-3">
+        <div className="network-payload-tabs flex min-w-0 items-center rounded-md border p-0.5">
           {(["body", "header"] as const).map((tab) => (
             <button
+              aria-pressed={selectedTab === tab}
               className={cn(
-                "network-tab border-0 bg-transparent p-0 text-[12px] font-semibold capitalize outline-none",
-                selectedTab === tab && "network-tab-active"
+                "network-payload-tab h-6 rounded-[5px] border border-transparent px-2.5 text-[12px] font-semibold capitalize outline-none transition-[background-color,border-color,color,box-shadow] focus-visible:ring-2 focus-visible:ring-ring/30",
+                selectedTab === tab && "network-payload-tab-active"
               )}
               key={tab}
               onClick={() => setSelectedTab(tab)}

--- a/packages/ui/src/pages/home/components/update.tsx
+++ b/packages/ui/src/pages/home/components/update.tsx
@@ -31,13 +31,25 @@ export function UpdateDialog({
   const progressPercent = clampPercent(status.progress?.percent);
   const error = actionError || status.lastError || "";
   const installing = actionBusy === "install" || status.state === "installing";
+  const showStateBadge = status.state === "error" ||
+    status.state === "not-available" ||
+    status.state === "available" ||
+    status.state === "downloaded" ||
+    status.state === "downloading";
+  const stateDescription = updateStateDescription(status, t);
 
   return (
     <Dialog onOpenChange={(open) => !open && !installing && onClose()} open>
       <DialogContent className="max-w-[560px]">
         <DialogHeader>
-          <div className="min-w-0">
+          <div className="flex min-w-0 flex-1 items-center gap-2 pr-2">
             <DialogTitle>{t("Online updates")}</DialogTitle>
+            {showStateBadge ? (
+              <UpdateStateBadge
+                label={updateStateLabel(status, t)}
+                status={status}
+              />
+            ) : null}
           </div>
           <Button aria-label={copy.settings.close} disabled={installing} onClick={onClose} size="iconSm" title={copy.settings.close} type="button" variant="ghost">
             <X className="h-4 w-4" />
@@ -45,17 +57,9 @@ export function UpdateDialog({
         </DialogHeader>
 
         <DialogBody className="grid gap-4">
-          <div className="flex min-w-0 items-start justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              {updateStateDescription(status, t) ? (
-                <div className="text-[12px] leading-5 text-muted-foreground">{updateStateDescription(status, t)}</div>
-              ) : null}
-            </div>
-            <UpdateStateBadge
-              label={updateStateLabel(status, t)}
-              status={status}
-            />
-          </div>
+          {stateDescription ? (
+            <div className="text-[12px] leading-5 text-muted-foreground">{stateDescription}</div>
+          ) : null}
 
           <div className="grid grid-cols-2 gap-2 max-[520px]:grid-cols-1">
             <UpdateInfoRow label={t("Current version")} value={status.currentVersion} />
@@ -154,7 +158,7 @@ function UpdateInfoRow({ label, scroll = false, value }: { label: string; scroll
 function UpdateStateBadge({ label, status }: { label: string; status: AppUpdateStatus }) {
   return (
     <span className={cn(
-      "shrink-0 rounded-full border px-2 py-1 text-[11px] font-medium",
+      "inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium",
       status.state === "error"
         ? "border-destructive/25 bg-destructive/10 text-destructive"
         : status.state === "not-available"
@@ -186,7 +190,7 @@ function updateStateDescription(status: AppUpdateStatus, t: (value: string) => s
   if (status.state === "downloaded") return t("Update downloaded");
   if (status.state === "not-available") return "";
   if (status.state === "downloading") return t("Downloading update");
-  return t("Online updates");
+  return "";
 }
 
 function clampPercent(value: number | undefined): number | undefined {

--- a/packages/ui/src/pages/home/shared/controls.tsx
+++ b/packages/ui/src/pages/home/shared/controls.tsx
@@ -610,16 +610,6 @@ export function systemStatusPointTooltip(segment: SystemStatusPoint, t: (value: 
   ].join("\n");
 }
 
-export function systemStatusTooltipPositionClass(index: number, total: number): string {
-  if (index <= 1) {
-    return "left-0";
-  }
-  if (index >= total - 2) {
-    return "right-0";
-  }
-  return "left-1/2 -translate-x-1/2";
-}
-
 export function systemStatusIconClass(tone: SystemStatusTone): string {
   if (tone === "ok") return "bg-emerald-500 text-white";
   if (tone === "warn") return "bg-amber-400 text-amber-950";

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1221,6 +1221,28 @@
     color: var(--network-text);
   }
 
+  .network-payload-tabs {
+    background: var(--network-panel-muted);
+    border-color: var(--network-control-border);
+  }
+
+  .network-payload-tab {
+    color: var(--network-text-subtle);
+  }
+
+  .network-payload-tab:hover {
+    background: var(--network-control-hover);
+    color: var(--network-text);
+  }
+
+  .network-payload-tab-active,
+  .network-payload-tab-active:hover {
+    background: var(--network-control);
+    border-color: var(--network-border-strong);
+    box-shadow: 0 1px 2px color-mix(in oklab, var(--network-border-strong) 32%, transparent);
+    color: var(--network-accent);
+  }
+
   .network-tab-divider,
   .network-pane-split,
   .network-kv-key-head {

--- a/tests/main/gateway-upstream-error-log.test.mjs
+++ b/tests/main/gateway-upstream-error-log.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatUpstreamErrorForLog } from "../../packages/core/src/gateway/http/io.ts";
+
+test("upstream fetch diagnostics expose timeout phase and fallback counts without secrets", () => {
+  const cause = Object.assign(
+    new Error("Headers timeout at https://api.example.test/v1/responses?api_key=private-value"),
+    {
+      code: "UND_ERR_HEADERS_TIMEOUT",
+      errno: -110,
+      name: "HeadersTimeoutError",
+      syscall: "read"
+    }
+  );
+  const error = new TypeError("fetch failed", { cause });
+
+  const message = formatUpstreamErrorForLog(error, {
+    attempts: 2,
+    elapsedMs: 307655,
+    fallbackFailures: 1,
+    operation: "fetch",
+    responseStarted: false,
+    retryDelayMs: 500
+  });
+
+  assert.match(message, /^Upstream fetch failed: fetch failed/);
+  assert.match(message, /cause=HeadersTimeoutError/);
+  assert.match(message, /code=UND_ERR_HEADERS_TIMEOUT/);
+  assert.match(message, /errno=-110/);
+  assert.match(message, /syscall=read/);
+  assert.match(message, /phase=response_headers/);
+  assert.match(message, /response_started=false/);
+  assert.match(message, /attempts=2/);
+  assert.match(message, /fallback_failures=1/);
+  assert.match(message, /retry_delay_ms=500/);
+  assert.match(message, /elapsed_ms=307655/);
+  assert.doesNotMatch(message, /api\.example\.test|private-value|api_key/i);
+});
+
+test("upstream stream diagnostics redact addresses and bearer credentials", () => {
+  const error = Object.assign(
+    new Error("read ECONNRESET from private.internal:443 using Bearer secret-token-value api_key=another-secret"),
+    {
+      code: "ECONNRESET",
+      name: "SocketError",
+      syscall: "read"
+    }
+  );
+
+  const message = formatUpstreamErrorForLog(error, {
+    attempts: 1,
+    elapsedMs: 8123,
+    fallbackFailures: 0,
+    operation: "stream",
+    responseStarted: true
+  });
+
+  assert.match(message, /^Upstream stream failed:/);
+  assert.match(message, /code=ECONNRESET/);
+  assert.match(message, /phase=response_body/);
+  assert.match(message, /response_started=true/);
+  assert.match(message, /from \[redacted-address\]/);
+  assert.match(message, /Bearer \[redacted\]/);
+  assert.match(message, /api_key=\[redacted\]/);
+  assert.doesNotMatch(message, /private\.internal|secret-token-value|another-secret/);
+});

--- a/tests/main/gateway-upstream-error-log.test.mjs
+++ b/tests/main/gateway-upstream-error-log.test.mjs
@@ -84,3 +84,22 @@ test("upstream diagnostics preserve non-sensitive error details", () => {
   assert.match(message, /failed to parse response from cache/);
   assert.match(message, /http:\/\/10\.0\.0\.5:8080\/v1/);
 });
+
+test("upstream diagnostics hide credential values in JSON error text", () => {
+  const message = formatUpstreamErrorForLog(
+    new Error('{"apiKey":"secret-value","api_key":"other-secret","x-api-key":"third-secret","model":"gpt-5"}'),
+    {
+      attempts: 1,
+      elapsedMs: 25,
+      fallbackFailures: 0,
+      operation: "fetch",
+      responseStarted: false
+    }
+  );
+
+  assert.match(message, /"apiKey":"\[redacted\]"/);
+  assert.match(message, /"api_key":"\[redacted\]"/);
+  assert.match(message, /"x-api-key":"\[redacted\]"/);
+  assert.match(message, /"model":"gpt-5"/);
+  assert.doesNotMatch(message, /secret-value|other-secret|third-secret/);
+});

--- a/tests/main/gateway-upstream-error-log.test.mjs
+++ b/tests/main/gateway-upstream-error-log.test.mjs
@@ -12,7 +12,10 @@ test("upstream fetch diagnostics expose timeout phase and fallback counts withou
       syscall: "read"
     }
   );
-  const error = new TypeError("fetch failed", { cause });
+  const error = new TypeError(
+    "fetch failed for https://api.example.test/v1/responses?api_key=private-value",
+    { cause }
+  );
 
   const message = formatUpstreamErrorForLog(error, {
     attempts: 2,
@@ -24,6 +27,7 @@ test("upstream fetch diagnostics expose timeout phase and fallback counts withou
   });
 
   assert.match(message, /^Upstream fetch failed: fetch failed/);
+  assert.match(message, /https:\/\/api\.example\.test\/v1\/responses\?api_key=\[redacted\]/);
   assert.match(message, /cause=HeadersTimeoutError/);
   assert.match(message, /code=UND_ERR_HEADERS_TIMEOUT/);
   assert.match(message, /errno=-110/);
@@ -34,10 +38,10 @@ test("upstream fetch diagnostics expose timeout phase and fallback counts withou
   assert.match(message, /fallback_failures=1/);
   assert.match(message, /retry_delay_ms=500/);
   assert.match(message, /elapsed_ms=307655/);
-  assert.doesNotMatch(message, /api\.example\.test|private-value|api_key/i);
+  assert.doesNotMatch(message, /private-value/);
 });
 
-test("upstream stream diagnostics redact addresses and bearer credentials", () => {
+test("upstream stream diagnostics redact credentials without hiding the endpoint", () => {
   const error = Object.assign(
     new Error("read ECONNRESET from private.internal:443 using Bearer secret-token-value api_key=another-secret"),
     {
@@ -59,8 +63,24 @@ test("upstream stream diagnostics redact addresses and bearer credentials", () =
   assert.match(message, /code=ECONNRESET/);
   assert.match(message, /phase=response_body/);
   assert.match(message, /response_started=true/);
-  assert.match(message, /from \[redacted-address\]/);
+  assert.match(message, /from private\.internal:443/);
   assert.match(message, /Bearer \[redacted\]/);
   assert.match(message, /api_key=\[redacted\]/);
-  assert.doesNotMatch(message, /private\.internal|secret-token-value|another-secret/);
+  assert.doesNotMatch(message, /secret-token-value|another-secret/);
+});
+
+test("upstream diagnostics preserve non-sensitive error details", () => {
+  const message = formatUpstreamErrorForLog(
+    new Error("failed to parse response from cache at http://10.0.0.5:8080/v1"),
+    {
+      attempts: 1,
+      elapsedMs: 25,
+      fallbackFailures: 0,
+      operation: "fetch",
+      responseStarted: false
+    }
+  );
+
+  assert.match(message, /failed to parse response from cache/);
+  assert.match(message, /http:\/\/10\.0\.0\.5:8080\/v1/);
 });

--- a/tests/main/request-log-store.test.mjs
+++ b/tests/main/request-log-store.test.mjs
@@ -6,7 +6,8 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { getHeapStatistics } from "node:v8";
-import { RequestLogStore } from "../../packages/core/src/observability/request-log-store.ts";
+import { createSseErrorDetector, RequestLogStore } from "../../packages/core/src/observability/request-log-store.ts";
+import { resolveStreamRequestLogOutcome } from "../../packages/core/src/gateway/internal/shared.ts";
 import { createBetterSqliteDatabase } from "../../packages/core/src/storage/sqlite-native.ts";
 
 const execFileAsync = promisify(execFile);
@@ -241,6 +242,95 @@ test("RequestLogStore marks interrupted successful-status streams as errors", as
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
+});
+
+test("SSE terminal detection distinguishes completed streams from interrupted streams", () => {
+  const completed = createSseErrorDetector("text/event-stream");
+  completed.append("event: response.completed\n");
+  completed.append('data: {"type":"response.completed","response":{"status":"completed"}}\n\n');
+  assert.equal(completed.hasTerminalEvent(), true);
+  assert.equal(completed.read(), undefined);
+
+  const done = createSseErrorDetector("text/event-stream");
+  done.append("data: [DONE]\n\n");
+  assert.equal(done.hasTerminalEvent(), true);
+
+  const anthropic = createSseErrorDetector("text/event-stream");
+  anthropic.append('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+  assert.equal(anthropic.hasTerminalEvent(), true);
+
+  const failed = createSseErrorDetector("text/event-stream");
+  failed.append('event: response.failed\ndata: {"type":"response.failed","response":{"status":"failed","error":{"message":"upstream failed"}}}');
+  assert.equal(failed.hasTerminalEvent(), false);
+  assert.match(failed.finish() ?? "", /upstream failed/);
+  assert.equal(failed.hasTerminalEvent(), true);
+
+  const responseStatusError = createSseErrorDetector("text/event-stream");
+  responseStatusError.append('data: {"response":{"status":"error"}}\n\n');
+  assert.equal(responseStatusError.hasTerminalEvent(), true);
+
+  const topLevelError = createSseErrorDetector("text/event-stream");
+  topLevelError.append('data: {"error":{"type":"server_error","message":"provider unavailable"}}\n\n');
+  assert.match(topLevelError.read() ?? "", /provider unavailable/);
+  assert.equal(topLevelError.hasTerminalEvent(), true);
+
+  const interrupted = createSseErrorDetector("text/event-stream");
+  interrupted.append('event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"partial"}\n\n');
+  interrupted.finish();
+  assert.equal(interrupted.hasTerminalEvent(), false);
+});
+
+test("stream request log outcomes preserve completed client closures and mark real interruptions", () => {
+  assert.deepEqual(
+    resolveStreamRequestLogOutcome({
+      clientDisconnected: true,
+      terminalEventSeen: true,
+      upstreamStatus: 200
+    }),
+    {
+      error: undefined,
+      statusCode: 200
+    }
+  );
+
+  assert.deepEqual(
+    resolveStreamRequestLogOutcome({
+      clientDisconnected: true,
+      terminalEventSeen: false,
+      upstreamStatus: 200
+    }),
+    {
+      error: "Client connection closed before response completed.",
+      statusCode: 499
+    }
+  );
+
+  assert.deepEqual(
+    resolveStreamRequestLogOutcome({
+      clientDisconnected: false,
+      streamError: "fetch failed",
+      terminalEventSeen: false,
+      upstreamStatus: 502
+    }),
+    {
+      error: "fetch failed",
+      statusCode: 502
+    }
+  );
+
+  assert.deepEqual(
+    resolveStreamRequestLogOutcome({
+      clientDisconnected: true,
+      detectedError: "upstream failed",
+      streamError: "The operation was aborted",
+      terminalEventSeen: true,
+      upstreamStatus: 200
+    }),
+    {
+      error: "upstream failed",
+      statusCode: 200
+    }
+  );
 });
 
 test("RequestLogStore applies raw trace updates to existing request logs", async () => {


### PR DESCRIPTION
## Summary

This PR fixes incorrect request-log outcomes for streaming responses, adds useful upstream failure diagnostics without storing credential values, and includes several focused UI fixes.

## Stream outcome fixes

Completed SSE responses could previously be recorded as HTTP `499` when the client closed immediately after receiving the terminal event. The response `close` event can arrive before `finish`, so normal stream cleanup was mistaken for a client interruption.

This change:

- Recognizes OpenAI `response.completed`, `[DONE]`, and Anthropic `message_stop` as successful terminal events.
- Recognizes structured SSE failures such as `response.failed`, `response.error`, and top-level error payloads.
- Flushes the final incomplete SSE frame before deciding the outcome.
- Records `499` only when the client disconnects before stream completion.
- Preserves completed HTTP `200` responses and real upstream error statuses such as `502` or `503`.
- Prevents later cleanup or abort events from replacing an outcome that has already been determined.

<p align="center">
  <strong>Completed streaming requests retain HTTP 200</strong><br>
  <img src="https://github.com/user-attachments/assets/f809dab3-bf07-4b4b-8171-efb3fd651658" width="355" alt="Completed streaming requests recorded as HTTP 200">
</p>

## Upstream failure diagnostics

Generic messages such as `fetch failed` did not provide enough information to distinguish DNS, connection, TLS, response-header, and response-body failures.

The request log now records:

- Error type, code, errno, and syscall.
- The inferred failure phase and whether the response had started.
- Attempt count, fallback count, retry delay, and elapsed time.
- Whether the failure happened while fetching the response or streaming its body.

Only credential values are hidden before the diagnostic message is stored. This includes API keys, Authorization/Bearer credentials, access and refresh tokens, client secrets, passwords, and credential values in URL query parameters. URLs, hostnames, IP addresses, ports, and ordinary error text remain visible for troubleshooting.

## UI fixes

### Request logs

- Keep the previous-page button, page range, next-page button, and page-size selector together when the request-log toolbar wraps.
- Remove the duplicate standalone total count beside the model filter.
- Present the request and response Body/Headers selectors as clear segmented buttons with hover, selected, and keyboard-focus states.

### System Status

- Render the timeline tooltip in a viewport-level portal with edge clamping and automatic above/below placement.

<p align="center">
  <strong>The tooltip remains visible near card and viewport edges</strong><br>
  <img src="https://github.com/user-attachments/assets/ba508dca-e368-4ceb-9b21-d1446b6e6117" width="760" alt="System Status timeline tooltip positioned above the timeline">
</p>

### Updates and tray

- Keep update-state pills beside the dialog title and hide the temporary gray checking indicator.
- Match the Windows tray popover background to the active light or dark theme while preserving native macOS vibrancy.

<p align="center">
  <strong>Update state stays beside the dialog title</strong><br>
  <img src="https://github.com/user-attachments/assets/a048e172-78f1-4048-b59f-d67f360c5261" width="520" alt="Online updates dialog with inline update state">
</p>

## Validation

- `npm.cmd run build:assets` - passed.
- `npm.cmd run typecheck` - passed.
- Targeted SSE terminal detection and request-log outcome tests - passed.
  - Completed terminal streams retain HTTP `200`.
  - Early client disconnects are recorded as HTTP `499`.
  - Structured SSE and upstream failures are not overwritten by `499`.
- Targeted upstream diagnostic and credential-filtering tests - passed (`3/3`).
  - Credential values are hidden from stored error messages.
  - URLs, hostnames, IP addresses, and non-sensitive error details remain available.

## Known test-environment limitation

- On Windows, the full request-log test file can encounter an existing SQLite temporary-directory cleanup error (`EPERM`). The targeted regression tests added by this PR pass.
