### PR TITLE
fix(gateway): preserve provider context metadata

### DIFF
--- a/packages/core/src/agents/codex/model-catalog.ts
+++ b/packages/core/src/agents/codex/model-catalog.ts
@@ -116,7 +116,9 @@ function codexModelCatalogItem(
   config?: Partial<Pick<AppConfig, "Providers" | "Router" | "virtualModelProfiles">>
 ): CodexModelCatalogItem {
   const profile = codexModelCapabilityProfile(model, config);
-  const contextWindow = codexModelContextWindow(model, profile.catalogEntry);
+  const contextWindow = positiveInteger(profile.contextWindow) ?? positiveInteger(profile.maxContextWindow) ?? codexModelContextWindow(model, profile.catalogEntry);
+  const maxContextWindow = Math.max(contextWindow, positiveInteger(profile.maxContextWindow) ?? contextWindow);
+  const effectiveContextWindowPercent = percentage(profile.effectiveContextWindowPercent) ?? codexEffectiveContextWindowPercent;
   return {
     additional_speed_tiers: profile.additionalSpeedTiers,
     apply_patch_tool_type: profile.applyPatchToolType,
@@ -127,10 +129,10 @@ function codexModelCatalogItem(
     default_reasoning_summary: profile.defaultReasoningSummary,
     description: `CCR gateway model ${model}`,
     display_name: model,
-    effective_context_window_percent: codexEffectiveContextWindowPercent,
+    effective_context_window_percent: effectiveContextWindowPercent,
     experimental_supported_tools: [],
     input_modalities: profile.inputModalities,
-    max_context_window: contextWindow,
+    max_context_window: maxContextWindow,
     priority,
     service_tiers: profile.serviceTiers,
     shell_type: "shell_command",
@@ -153,11 +155,14 @@ type CodexCapabilityProfile = {
   additionalSpeedTiers: unknown[];
   applyPatchToolType: string | null;
   catalogEntry?: ModelCatalogEntry;
+  contextWindow?: number;
   defaultReasoningLevel: string | null;
   defaultReasoningSummary: string;
+  effectiveContextWindowPercent?: number;
   inputModalities: string[];
   supportedReasoningLevels: Array<{ description: string; effort: string }>;
   serviceTiers: unknown[];
+  maxContextWindow?: number;
   supportsImageInput: boolean;
   supportsParallelToolCalls: boolean;
   supportsReasoning: boolean;
@@ -201,14 +206,17 @@ function codexModelCapabilityProfile(
     additionalSpeedTiers: providerModelMetadata?.additionalSpeedTiers ?? [],
     applyPatchToolType,
     catalogEntry,
+    contextWindow: providerModelMetadata?.contextWindow,
     defaultReasoningLevel: providerModelMetadata && providerModelMetadata.defaultReasoningLevel !== undefined
       ? providerModelMetadata.defaultReasoningLevel
       : supportsReasoning
       ? "medium"
       : null,
     defaultReasoningSummary: providerModelMetadata?.defaultReasoningSummary ?? "none",
+    effectiveContextWindowPercent: providerModelMetadata?.effectiveContextWindowPercent,
     inputModalities: supportsImageInput ? ["text", "image"] : ["text"],
     serviceTiers: providerModelMetadata?.serviceTiers ?? [],
+    maxContextWindow: providerModelMetadata?.maxContextWindow,
     supportedReasoningLevels: metadataReasoningLevels ?? (supportsReasoning ? supportedReasoningLevels(capabilities) : []),
     supportsImageInput,
     supportsParallelToolCalls,
@@ -277,6 +285,18 @@ function effortDescription(effort: string): string {
 
 function codexModelContextWindow(model: string, entry = findModelCatalogEntry(model)): number {
   return modelCatalogMaxInputTokens(entry) || codexDefaultContextWindow;
+}
+
+function percentage(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value) && value > 0 && value <= 100
+    ? value
+    : undefined;
+}
+
+function positiveInteger(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : undefined;
 }
 
 function catalogEntrySupportsImageInput(entry: ModelCatalogEntry | undefined): boolean {

--- a/packages/core/src/agents/local-providers/codex.ts
+++ b/packages/core/src/agents/local-providers/codex.ts
@@ -725,6 +725,9 @@ function codexModelCatalogFromPayload(payload: unknown): LocalAgentModelCatalog 
 
 function codexModelMetadataFromItem(item: Record<string, unknown>): ProviderModelMetadata | undefined {
   const additionalSpeedTiers = readArray(item.additional_speed_tiers) ?? readArray(item.additionalSpeedTiers) ?? readArray(item.speed_tiers) ?? readArray(item.speedTiers);
+  const contextWindow = readPositiveInteger(item.context_window ?? item.contextWindow);
+  const effectiveContextWindowPercent = readPercentage(item.effective_context_window_percent ?? item.effectiveContextWindowPercent);
+  const maxContextWindow = readPositiveInteger(item.max_context_window ?? item.maxContextWindow);
   const serviceTiers = readArray(item.service_tiers) ?? readArray(item.serviceTiers);
   const supportedReasoningLevels =
     readReasoningLevels(item.supported_reasoning_levels) ??
@@ -738,8 +741,11 @@ function codexModelMetadataFromItem(item: Record<string, unknown>): ProviderMode
   const supportsReasoningSummaries = readBoolean(item.supports_reasoning_summaries) ?? readBoolean(item.supportsReasoningSummaries);
   const metadata: ProviderModelMetadata = {
     ...(additionalSpeedTiers ? { additionalSpeedTiers } : {}),
+    ...(contextWindow ? { contextWindow } : {}),
     ...(defaultReasoningLevel !== undefined ? { defaultReasoningLevel } : {}),
     ...(defaultReasoningSummary ? { defaultReasoningSummary } : {}),
+    ...(effectiveContextWindowPercent ? { effectiveContextWindowPercent } : {}),
+    ...(maxContextWindow ? { maxContextWindow } : {}),
     ...(serviceTiers ? { serviceTiers } : {}),
     ...(supportedReasoningLevels ? { supportedReasoningLevels } : {}),
     ...(supportsReasoningSummaries !== undefined ? { supportsReasoningSummaries } : {})
@@ -749,6 +755,18 @@ function codexModelMetadataFromItem(item: Record<string, unknown>): ProviderMode
 
 function readArray(value: unknown): unknown[] | undefined {
   return Array.isArray(value) ? value : undefined;
+}
+
+function readPercentage(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 && value <= 100
+    ? value
+    : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : undefined;
 }
 
 function readNullableString(value: unknown): string | null | undefined {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1134,15 +1134,21 @@ function parseProviderModelMetadata(value: unknown): ProviderModelMetadata | und
     return undefined;
   }
   const supportedReasoningLevels = parseProviderReasoningLevels(value.supportedReasoningLevels ?? value.supported_reasoning_levels);
+  const contextWindow = readPositiveInteger(value.contextWindow ?? value.context_window);
+  const effectiveContextWindowPercent = readPercentage(value.effectiveContextWindowPercent ?? value.effective_context_window_percent);
+  const maxContextWindow = readPositiveInteger(value.maxContextWindow ?? value.max_context_window);
   const metadata: ProviderModelMetadata = {
     ...(Array.isArray(value.additionalSpeedTiers) ? { additionalSpeedTiers: value.additionalSpeedTiers } : {}),
     ...(Array.isArray(value.additional_speed_tiers) ? { additionalSpeedTiers: value.additional_speed_tiers } : {}),
+    ...(contextWindow ? { contextWindow } : {}),
     ...(value.defaultReasoningLevel === null ? { defaultReasoningLevel: null } : {}),
     ...(readString(value.defaultReasoningLevel) ? { defaultReasoningLevel: readString(value.defaultReasoningLevel) } : {}),
     ...(value.default_reasoning_level === null ? { defaultReasoningLevel: null } : {}),
     ...(readString(value.default_reasoning_level) ? { defaultReasoningLevel: readString(value.default_reasoning_level) } : {}),
     ...(readString(value.defaultReasoningSummary) ? { defaultReasoningSummary: readString(value.defaultReasoningSummary) } : {}),
     ...(readString(value.default_reasoning_summary) ? { defaultReasoningSummary: readString(value.default_reasoning_summary) } : {}),
+    ...(effectiveContextWindowPercent ? { effectiveContextWindowPercent } : {}),
+    ...(maxContextWindow ? { maxContextWindow } : {}),
     ...(Array.isArray(value.serviceTiers) ? { serviceTiers: value.serviceTiers } : {}),
     ...(Array.isArray(value.service_tiers) ? { serviceTiers: value.service_tiers } : {}),
     ...(supportedReasoningLevels ? { supportedReasoningLevels } : {}),
@@ -1150,6 +1156,10 @@ function parseProviderModelMetadata(value: unknown): ProviderModelMetadata | und
     ...(typeof value.supports_reasoning_summaries === "boolean" ? { supportsReasoningSummaries: value.supports_reasoning_summaries } : {})
   };
   return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+export function providerModelMetadataFromConfigForTest(value: unknown): ProviderModelMetadata | undefined {
+  return parseProviderModelMetadata(value);
 }
 
 function parseProviderReasoningLevels(value: unknown): ProviderReasoningLevel[] | undefined {
@@ -2818,6 +2828,16 @@ function readNumber(value: unknown): number | undefined {
   }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function readPercentage(value: unknown): number | undefined {
+  const parsed = readNumber(value);
+  return parsed !== undefined && parsed > 0 && parsed <= 100 ? parsed : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  const parsed = readNumber(value);
+  return parsed !== undefined && parsed > 0 ? Math.trunc(parsed) : undefined;
 }
 
 function clampNumber(value: number, min: number, max: number): number {

--- a/packages/core/src/contracts/app.ts
+++ b/packages/core/src/contracts/app.ts
@@ -150,8 +150,11 @@ export type ProviderReasoningLevel = {
 
 export type ProviderModelMetadata = {
   additionalSpeedTiers?: unknown[];
+  contextWindow?: number;
   defaultReasoningLevel?: string | null;
   defaultReasoningSummary?: string;
+  effectiveContextWindowPercent?: number;
+  maxContextWindow?: number;
   serviceTiers?: unknown[];
   supportedReasoningLevels?: ProviderReasoningLevel[];
   supportsReasoningSummaries?: boolean;

--- a/packages/core/src/gateway/features/model-discovery.ts
+++ b/packages/core/src/gateway/features/model-discovery.ts
@@ -2,9 +2,9 @@
  * Extracted from gateway/service.ts. Keep this module focused on its named gateway boundary.
  */
 import type { IncomingHttpHeaders } from "node:http";
-import type { ApiKeyConfig, AppConfig } from "@ccr/core/contracts/app";
+import type { ApiKeyConfig, AppConfig, ProviderModelMetadata } from "@ccr/core/contracts/app";
 import { buildClaudeAppGatewayModelRoutes, resolveClaudeAppGatewayRouteModel } from "@ccr/core/agents/claude-app/gateway-routes";
-import { normalizeRouteSelector } from "@ccr/core/routing/model-registry";
+import { modelRegistryForConfig, normalizeRouteSelector } from "@ccr/core/routing/model-registry";
 import { findModelCatalogEntry, modelCatalogMaxInputTokens, modelCatalogMaxOutputTokens, readCatalogCapability, type ModelCatalogEntry } from "@ccr/core/gateway/model-catalog";
 import { stringValue } from "@ccr/core/gateway/internal/value";
 import { fusionModelSelector } from "@ccr/core/mcp/fusion-config";
@@ -120,7 +120,8 @@ function createClaudeAppGatewayModelsResponse(config: AppConfig): Record<string,
   const data = routes.map((route) => {
     const catalogId = stripClaudeCodeOneMillionContextSuffix(route.targetModel);
     const catalogEntry = findModelCatalogEntry(catalogId);
-    const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, route.oneMillionContext);
+    const modelMetadata = providerModelMetadataForSelector(config, catalogId);
+    const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, route.oneMillionContext, modelMetadata);
     const maxOutputTokens = modelCatalogMaxOutputTokens(catalogEntry);
     return {
       id: route.id,
@@ -151,7 +152,8 @@ function createClaudeCodeModelsResponse(config: AppConfig): Record<string, unkno
     const claudeId = claudeCodeDiscoveryModelId(model.id);
     const catalogId = stripClaudeCodeOneMillionContextSuffix(model.id);
     const catalogEntry = findModelCatalogEntry(catalogId);
-    const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, model.oneMillionContext);
+    const modelMetadata = providerModelMetadataForSelector(config, catalogId);
+    const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, model.oneMillionContext, modelMetadata);
     const maxOutputTokens = modelCatalogMaxOutputTokens(catalogEntry);
     return {
       id: claudeId,
@@ -176,12 +178,59 @@ function createClaudeCodeModelsResponse(config: AppConfig): Record<string, unkno
 }
 
 
-function claudeGatewayModelContextWindow(entry: ModelCatalogEntry | undefined, oneMillionContext: boolean): number {
+function claudeGatewayModelContextWindow(
+  entry: ModelCatalogEntry | undefined,
+  oneMillionContext: boolean,
+  metadata?: ProviderModelMetadata
+): number {
+  const providerContextWindow = effectiveProviderContextWindow(metadata);
+  if (providerContextWindow) {
+    return providerContextWindow;
+  }
   const contextWindow = modelCatalogMaxInputTokens(entry);
   if (contextWindow > 0) {
     return contextWindow;
   }
   return oneMillionContext ? 1_000_000 : 0;
+}
+
+
+function effectiveProviderContextWindow(metadata: ProviderModelMetadata | undefined): number | undefined {
+  const contextWindow = positiveInteger(metadata?.contextWindow) ?? positiveInteger(metadata?.maxContextWindow);
+  if (!contextWindow) {
+    return undefined;
+  }
+  const effectivePercent = percentage(metadata?.effectiveContextWindowPercent) ?? 100;
+  return Math.max(1, Math.floor((contextWindow * effectivePercent) / 100));
+}
+
+
+function providerModelMetadataForSelector(config: AppConfig, selector: string): ProviderModelMetadata | undefined {
+  const resolved = modelRegistryForConfig(config).resolveProviderModel(selector);
+  if (!resolved) {
+    return undefined;
+  }
+  const metadata = resolved.provider.modelMetadata ?? {};
+  const direct = metadata[resolved.model];
+  if (direct) {
+    return direct;
+  }
+  const normalizedModel = resolved.model.toLowerCase();
+  return Object.entries(metadata).find(([model]) => model.trim().toLowerCase() === normalizedModel)?.[1];
+}
+
+
+function percentage(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value) && value > 0 && value <= 100
+    ? value
+    : undefined;
+}
+
+
+function positiveInteger(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : undefined;
 }
 
 
@@ -386,7 +435,7 @@ function createClaudeCodeModelCapabilities(
   options: { maxInputTokens?: number; oneMillionContext?: boolean } = {}
 ): Record<string, unknown> {
   if (!entry) {
-    return createDefaultClaudeCodeModelCapabilities();
+    return createDefaultClaudeCodeModelCapabilities(options);
   }
 
   const capabilities = entry.capabilities ?? {};
@@ -455,7 +504,10 @@ function createClaudeCodeModelCapabilities(
 }
 
 
-function createDefaultClaudeCodeModelCapabilities(): Record<string, unknown> {
+function createDefaultClaudeCodeModelCapabilities(
+  options: { maxInputTokens?: number; oneMillionContext?: boolean } = {}
+): Record<string, unknown> {
+  const maxInputTokens = positiveInteger(options.maxInputTokens);
   return {
     batch: { supported: true },
     citations: { supported: true },
@@ -464,8 +516,19 @@ function createDefaultClaudeCodeModelCapabilities(): Record<string, unknown> {
       clear_thinking_20251015: { supported: true },
       clear_tool_uses_20250919: { supported: true },
       compact_20260112: { supported: true },
+      ...(maxInputTokens ? { max_input_tokens: maxInputTokens } : {}),
       supported: true
     },
+    ...(maxInputTokens
+      ? {
+          context_window: {
+            max_input_tokens: maxInputTokens,
+            one_million_context_variant: options.oneMillionContext === true,
+            supported: true,
+            supports_1m_context: maxInputTokens >= 1_000_000
+          }
+        }
+      : {}),
     effort: {
       high: { supported: true },
       low: { supported: true },

--- a/tests/main/claude-app-gateway-models.test.mjs
+++ b/tests/main/claude-app-gateway-models.test.mjs
@@ -14,7 +14,7 @@ import { ModelRegistry } from "../../packages/core/src/routing/model-registry.ts
 
 function createConfig({ profileModel, providers = [], virtualModelProfiles = [] } = {}) {
   return {
-    Providers: providers.map(({ models, name }) => ({ models, name })),
+    Providers: providers.map((provider) => ({ ...provider })),
     profile: {
       enabled: true,
       profiles: profileModel === undefined
@@ -162,4 +162,58 @@ test("issue 1535 canonical profile resolution preserves the Claude App 1M contex
   assert.equal(routes[0].targetModel, "Anthropic/claude-opus-4-1");
   assert.equal(routes[0].oneMillionContext, true);
   assertPublishedRoutesResolveUniquely(config);
+});
+
+test("Claude App discovery publishes the effective provider context for uncatalogued models", () => {
+  const config = createConfig({
+    providers: [
+      {
+        modelMetadata: {
+          "gpt-5.6-sol": {
+            contextWindow: 272000,
+            effectiveContextWindowPercent: 95,
+            maxContextWindow: 272000
+          }
+        },
+        models: ["gpt-5.6-sol"],
+        name: "Codex API",
+        type: "openai_responses"
+      }
+    ]
+  });
+  const route = buildClaudeAppGatewayModelRoutes(config)[0];
+  const response = createClaudeModelsResponse(config);
+  const model = response.data.find((item) => item.id === route.id);
+
+  assert.ok(model);
+  assert.equal(model.max_input_tokens, 258400);
+  assert.equal(model.capabilities.context_management.max_input_tokens, 258400);
+  assert.equal(model.capabilities.context_window.max_input_tokens, 258400);
+});
+
+test("Claude App discovery prefers provider context metadata over the static catalog", () => {
+  const config = createConfig({
+    providers: [
+      {
+        modelMetadata: {
+          "gpt-5-codex": {
+            contextWindow: 272000,
+            effectiveContextWindowPercent: 90,
+            maxContextWindow: 272000
+          }
+        },
+        models: ["gpt-5-codex"],
+        name: "Codex API",
+        type: "openai_responses"
+      }
+    ]
+  });
+  const route = buildClaudeAppGatewayModelRoutes(config)[0];
+  const response = createClaudeModelsResponse(config);
+  const model = response.data.find((item) => item.id === route.id);
+
+  assert.ok(model);
+  assert.equal(model.max_input_tokens, 244800);
+  assert.equal(model.capabilities.context_management.max_input_tokens, 244800);
+  assert.equal(model.capabilities.context_window.max_input_tokens, 244800);
 });

--- a/tests/main/codex-model-catalog.test.mjs
+++ b/tests/main/codex-model-catalog.test.mjs
@@ -71,8 +71,11 @@ test("codex catalog uses provider model metadata for reasoning effort and speed 
         modelMetadata: {
           "gpt-5-codex": {
             additionalSpeedTiers: [{ id: "fast", label: "Fast" }],
+            contextWindow: 272000,
             defaultReasoningLevel: "high",
             defaultReasoningSummary: "auto",
+            effectiveContextWindowPercent: 91,
+            maxContextWindow: 300000,
             serviceTiers: [{ id: "auto" }],
             supportedReasoningLevels: [
               { description: "Low", effort: "low" },
@@ -89,8 +92,11 @@ test("codex catalog uses provider model metadata for reasoning effort and speed 
   }, "Codex API/gpt-5-codex");
 
   assert.deepEqual(model.additional_speed_tiers, [{ id: "fast", label: "Fast" }]);
+  assert.equal(model.context_window, 272000);
   assert.equal(model.default_reasoning_level, "high");
   assert.equal(model.default_reasoning_summary, "auto");
+  assert.equal(model.effective_context_window_percent, 91);
+  assert.equal(model.max_context_window, 300000);
   assert.deepEqual(model.service_tiers, [{ id: "auto" }]);
   assert.deepEqual(model.supported_reasoning_levels, [
     { description: "Low", effort: "low" },
@@ -112,7 +118,10 @@ test("codex catalog falls back to local Codex model cache metadata", () => {
       models: [
         {
           additional_speed_tiers: [{ id: "fast", label: "Fast" }],
+          context_window: 272000,
           default_reasoning_level: "high",
+          effective_context_window_percent: 92,
+          max_context_window: 300000,
           service_tiers: [{ id: "auto" }],
           slug: "gpt-5-codex",
           supported_reasoning_levels: [
@@ -137,7 +146,10 @@ test("codex catalog falls back to local Codex model cache metadata", () => {
     }, "Codex API/gpt-5-codex");
 
     assert.deepEqual(model.additional_speed_tiers, [{ id: "fast", label: "Fast" }]);
+    assert.equal(model.context_window, 272000);
     assert.equal(model.default_reasoning_level, "high");
+    assert.equal(model.effective_context_window_percent, 92);
+    assert.equal(model.max_context_window, 300000);
     assert.deepEqual(model.service_tiers, [{ id: "auto" }]);
     assert.deepEqual(model.supported_reasoning_levels.map((level) => level.effort), ["low", "high"]);
   } finally {

--- a/tests/main/local-agent-provider-codex.test.mjs
+++ b/tests/main/local-agent-provider-codex.test.mjs
@@ -211,8 +211,11 @@ test("Codex model catalog parser accepts live model endpoint shapes", () => {
     data: [
       {
         additional_speed_tiers: [{ id: "fast", label: "Fast" }],
+        context_window: 272000,
         default_reasoning_level: "high",
         display_name: "GPT-5 Codex",
+        effective_context_window_percent: 95,
+        max_context_window: 300000,
         service_tiers: [{ id: "auto" }],
         slug: "gpt-5-codex",
         supported_reasoning_levels: [
@@ -237,7 +240,10 @@ test("Codex model catalog parser accepts live model endpoint shapes", () => {
   });
   assert.deepEqual(catalog.modelMetadata["gpt-5-codex"], {
     additionalSpeedTiers: [{ id: "fast", label: "Fast" }],
+    contextWindow: 272000,
     defaultReasoningLevel: "high",
+    effectiveContextWindowPercent: 95,
+    maxContextWindow: 300000,
     serviceTiers: [{ id: "auto" }],
     supportedReasoningLevels: [
       { description: "Low", effort: "low" },
@@ -245,4 +251,19 @@ test("Codex model catalog parser accepts live model endpoint shapes", () => {
     ],
     supportsReasoningSummaries: true
   });
+});
+
+test("Codex model catalog parser ignores invalid context metadata", () => {
+  const catalog = codexModelCatalogFromPayloadForTest({
+    models: [
+      {
+        context_window: -1,
+        effective_context_window_percent: 101,
+        max_context_window: 0,
+        slug: "invalid-context-model"
+      }
+    ]
+  });
+
+  assert.equal(catalog.modelMetadata?.["invalid-context-model"], undefined);
 });

--- a/tests/main/provider-model-metadata.test.mjs
+++ b/tests/main/provider-model-metadata.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { providerModelMetadataFromConfigForTest } from "../../packages/core/src/config/config.ts";
+
+test("provider model metadata config preserves context fields", () => {
+  assert.deepEqual(providerModelMetadataFromConfigForTest({
+    contextWindow: 272000,
+    effectiveContextWindowPercent: 95,
+    maxContextWindow: 300000
+  }), {
+    contextWindow: 272000,
+    effectiveContextWindowPercent: 95,
+    maxContextWindow: 300000
+  });
+
+  assert.deepEqual(providerModelMetadataFromConfigForTest({
+    context_window: 128000,
+    effective_context_window_percent: 90,
+    max_context_window: 200000
+  }), {
+    contextWindow: 128000,
+    effectiveContextWindowPercent: 90,
+    maxContextWindow: 200000
+  });
+});
+
+test("provider model metadata config ignores invalid context fields", () => {
+  assert.equal(providerModelMetadataFromConfigForTest({
+    context_window: 0,
+    effective_context_window_percent: 101,
+    max_context_window: -1
+  }), undefined);
+});


### PR DESCRIPTION
## Summary

- preserve provider-reported context, maximum-context, and effective-window metadata
- prefer provider-specific limits over static catalog fallbacks in generated model catalogs and gateway discovery
- publish the effective usable input limit for uncatalogued provider models

## Why

Local provider discovery already returned current context limits, but the configuration and catalog layers discarded them. Dynamic provider models therefore inherited stale fallback values, while gateway discovery could advertise a raw or generic window instead of the provider-specific usable limit.

## Test plan

- [x] `npm run typecheck`
- [x] `TZ=UTC npm run test:main` — 300 passed, 5 skipped
- [x] `TZ=UTC npm run test:renderer` — 67 passed
- [x] `npm run build:assets`
- [x] `gitleaks git --staged`
