### PR TITLE
fix: translate Claude effort for OpenAI Responses

### DIFF
--- a/packages/core/src/gateway/upstream/executor.ts
+++ b/packages/core/src/gateway/upstream/executor.ts
@@ -23,6 +23,12 @@ import { claudeCodeOauthBetaHeader, claudeCodeOauthRequiredBeta, UpstreamRequest
 import type { ApiKeyLimitUsage, ProviderCredentialRoutingTarget, UpstreamAttempt, UpstreamFailedAttempt, UpstreamFetchResult } from "@ccr/core/gateway/internal/shared";
 
 const providerCredentialSpilloverThreshold = 0.8;
+const openAiResponsesReasoningEffortOrder = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+const defaultOpenAiResponsesReasoningEfforts = new Map(
+  openAiResponsesReasoningEffortOrder
+    .filter((effort) => effort !== "max")
+    .map((effort) => [effort, effort])
+);
 
 
 export function applyProviderCapabilityRouting(input: {
@@ -546,7 +552,7 @@ function usageAwareOpenAiChatAttemptBody(input: {
   body: Buffer | undefined;
   config: AppConfig;
   path: string;
-  target?: { protocol: GatewayProviderProtocol };
+  target?: Pick<ProviderCredentialRoutingTarget, "model" | "protocol" | "provider">;
 }): Buffer | undefined {
   const clientProtocol = requestProtocolForPath(input.path);
   const parsedBody = parseJsonObjectSafe(input.body);
@@ -559,22 +565,105 @@ function usageAwareOpenAiChatAttemptBody(input: {
   if (providerProtocol !== "openai_chat_completions" && providerProtocol !== "openai_responses") {
     return input.body;
   }
-  const sanitizedBody = stripUnsupportedOpenAiRequestParameters(input.body);
+  const sanitizedBody = stripUnsupportedOpenAiRequestParameters(input.body, {
+    model: input.target?.model ?? modelSelector?.model ?? stringValue(parsedBody?.model),
+    protocol: providerProtocol,
+    provider: input.target?.provider ?? modelSelector?.provider
+  });
   return providerProtocol === "openai_chat_completions"
     ? usageAwareOpenAiChatBody(sanitizedBody)
     : sanitizedBody;
 }
 
 
-function stripUnsupportedOpenAiRequestParameters(body: Buffer | undefined): Buffer | undefined {
+function stripUnsupportedOpenAiRequestParameters(
+  body: Buffer | undefined,
+  target: {
+    model?: string;
+    protocol: GatewayProviderProtocol;
+    provider?: GatewayProviderConfig;
+  }
+): Buffer | undefined {
   const parsedBody = parseJsonObjectSafe(body);
-  if (!parsedBody || (!("thinking" in parsedBody) && !("reasoning_split" in parsedBody))) {
+  const hasResponsesOutputConfig = target.protocol === "openai_responses" && Boolean(parsedBody && "output_config" in parsedBody);
+  if (!parsedBody || (!("thinking" in parsedBody) && !("reasoning_split" in parsedBody) && !hasResponsesOutputConfig)) {
     return body;
   }
   const next = { ...parsedBody };
   delete next.thinking;
   delete next.reasoning_split;
+  if (hasResponsesOutputConfig) {
+    const outputConfig = isRecord(next.output_config) ? next.output_config : undefined;
+    const requestedEffort = stringValue(outputConfig?.effort);
+    const reasoning = isRecord(next.reasoning) ? { ...next.reasoning } : undefined;
+    delete next.output_config;
+
+    if (requestedEffort && !stringValue(reasoning?.effort)) {
+      const effort = openAiResponsesReasoningEffort(requestedEffort, target.provider, target.model);
+      if (effort) {
+        next.reasoning = {
+          ...(reasoning ?? {}),
+          effort
+        };
+      }
+    }
+  }
   return Buffer.from(`${JSON.stringify(next)}\n`, "utf8");
+}
+
+
+function openAiResponsesReasoningEffort(
+  requestedEffort: string,
+  provider: GatewayProviderConfig | undefined,
+  model: string | undefined
+): string | undefined {
+  const requested = requestedEffort.trim().toLowerCase();
+  const requestedIndex = openAiResponsesReasoningEffortOrder.findIndex((effort) => effort === requested);
+  if (requestedIndex < 0) {
+    return undefined;
+  }
+  const supported = providerModelReasoningEfforts(provider, model) ?? defaultOpenAiResponsesReasoningEfforts;
+  const exact = supported.get(requested);
+  if (exact) {
+    return exact;
+  }
+  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+    const fallback = supported.get(openAiResponsesReasoningEffortOrder[index]);
+    if (fallback) {
+      return fallback;
+    }
+  }
+  for (let index = requestedIndex + 1; index < openAiResponsesReasoningEffortOrder.length; index += 1) {
+    const fallback = supported.get(openAiResponsesReasoningEffortOrder[index]);
+    if (fallback) {
+      return fallback;
+    }
+  }
+  return undefined;
+}
+
+
+function providerModelReasoningEfforts(
+  provider: GatewayProviderConfig | undefined,
+  model: string | undefined
+): Map<string, string> | undefined {
+  if (!provider || !model) {
+    return undefined;
+  }
+  const normalizedModel = model.trim().toLowerCase();
+  const metadata = Object.entries(provider.modelMetadata ?? {})
+    .find(([candidate]) => candidate.trim().toLowerCase() === normalizedModel)?.[1];
+  if (!metadata?.supportedReasoningLevels) {
+    return undefined;
+  }
+  const efforts = new Map<string, string>();
+  for (const level of metadata.supportedReasoningLevels) {
+    const effort = stringValue(level.effort);
+    if (effort) {
+      efforts.set(effort.toLowerCase(), effort);
+    }
+  }
+  return efforts;
 }
 
 

--- a/tests/main/router-builtins.test.mjs
+++ b/tests/main/router-builtins.test.mjs
@@ -1257,6 +1257,125 @@ test("gateway strips unsupported OpenAI upstream request parameters", () => {
   }
 });
 
+test("gateway maps Claude output_config effort to OpenAI Responses reasoning", () => {
+  const config = {
+    CUSTOM_ROUTER_PATH: "",
+    Providers: [
+      {
+        api_base_url: "https://responses-compatible.example/v1",
+        capabilities: [
+          { baseUrl: "https://responses-compatible.example/v1", type: "openai_responses" }
+        ],
+        credentials: [{ apiKey: "provider-key", id: "provider-main" }],
+        modelMetadata: {
+          "gpt-high": {
+            supportedReasoningLevels: [
+              { description: "Low", effort: "low" },
+              { description: "High", effort: "high" }
+            ]
+          },
+          "gpt-all": {
+            supportedReasoningLevels: [
+              { description: "Low", effort: "low" },
+              { description: "Medium", effort: "medium" },
+              { description: "High", effort: "high" },
+              { description: "Extra high", effort: "xhigh" },
+              { description: "Maximum", effort: "max" }
+            ]
+          }
+        },
+        models: ["gpt-all", "gpt-high", "gpt-unknown"],
+        name: "Responses Compatible"
+      }
+    ],
+    Router: {
+      fallback: { mode: "off", models: [], retryCount: 0 },
+      rules: []
+    },
+    virtualModelProfiles: []
+  };
+
+  const prepare = (model, body = {}) => prepareGatewayUpstreamAttemptForTest({
+    body: {
+      messages: [{ content: "hi", role: "user" }],
+      model,
+      output_config: { effort: "xhigh" },
+      ...body
+    },
+    config,
+    headers: {
+      "x-target-provider": "Responses Compatible"
+    },
+    method: "POST",
+    path: "/v1/messages",
+    routedModel: model
+  });
+
+  for (const effort of ["low", "medium", "high", "xhigh", "max"]) {
+    const supported = prepare("gpt-all", { output_config: { effort } });
+    assert.equal(supported.credentialProtocol, "openai_responses");
+    assert.equal(supported.body.output_config, undefined);
+    assert.deepEqual(supported.body.reasoning, { effort });
+  }
+
+  const downgraded = prepare("gpt-high");
+  assert.equal(downgraded.body.output_config, undefined);
+  assert.deepEqual(downgraded.body.reasoning, { effort: "high" });
+
+  const unknown = prepare("gpt-unknown", { output_config: { effort: "max" } });
+  assert.equal(unknown.body.output_config, undefined);
+  assert.deepEqual(unknown.body.reasoning, { effort: "xhigh" });
+
+  const invalid = prepare("gpt-unknown", { output_config: { effort: "ultracode" } });
+  assert.equal(invalid.body.output_config, undefined);
+  assert.equal(invalid.body.reasoning, undefined);
+
+  const nativeReasoning = prepare("gpt-all", {
+    output_config: { effort: "low" },
+    reasoning: { effort: "high", summary: "auto" }
+  });
+  assert.equal(nativeReasoning.body.output_config, undefined);
+  assert.deepEqual(nativeReasoning.body.reasoning, { effort: "high", summary: "auto" });
+});
+
+test("gateway keeps output_config for OpenAI chat compatibility plugins", () => {
+  const config = {
+    CUSTOM_ROUTER_PATH: "",
+    Providers: [
+      {
+        api_base_url: "https://chat-compatible.example/v1",
+        credentials: [{ apiKey: "provider-key", id: "provider-main" }],
+        models: ["deepseek-compatible"],
+        name: "Chat Compatible",
+        type: "openai_chat_completions"
+      }
+    ],
+    Router: {
+      fallback: { mode: "off", models: [], retryCount: 0 },
+      rules: []
+    },
+    virtualModelProfiles: []
+  };
+  const attempt = prepareGatewayUpstreamAttemptForTest({
+    body: {
+      messages: [{ content: "hi", role: "user" }],
+      model: "deepseek-compatible",
+      output_config: { effort: "high" }
+    },
+    config,
+    headers: {
+      "x-target-provider": "Chat Compatible"
+    },
+    method: "POST",
+    path: "/v1/messages",
+    routedModel: "deepseek-compatible"
+  });
+
+  assert.equal(attempt.credentialProtocol, "openai_chat_completions");
+  assert.deepEqual(attempt.body.output_config, { effort: "high" });
+  assert.equal(attempt.body.reasoning, undefined);
+});
+
 test("built-in Claude Code route overrides explicit virtual gateway models", async () => {
   const plugin = createRouterPlugin({
     profileModel: "Provider/claude-sonnet",


### PR DESCRIPTION
## Summary

- Translate Claude `output_config.effort` into OpenAI Responses `reasoning.effort`.
- Use target-model metadata to preserve or safely downgrade unsupported reasoning levels.
- Preserve an existing native `reasoning` configuration.
- Leave `output_config` unchanged for chat-completions targets so compatibility plugins can still consume it.

## Why

Claude Code can send reasoning effort as:

```json
{
  output_config: {
    effort: xhigh
  }
}
```

When that request was routed to an OpenAI Responses provider, the field could be forwarded unchanged and the upstream returned HTTP 400:

```text
Unsupported parameter: output_config
```

This change normalizes the parameter at CCR's upstream boundary before the protocol adapter builds the Responses request.

## Effort handling

- Supported levels are preserved: `low`, `medium`, `high`, `xhigh`, and `max`.
- If the target model does not support the requested level, CCR selects the closest supported level without exceeding it when possible.
- Without model metadata, standard Responses levels are used, so `max` falls back to `xhigh`.
- Unknown effort values are removed and the target model uses its default.
- An explicitly supplied native `reasoning.effort` takes precedence.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run build:assets`
- `node --test dist/tests/main/router-builtins.test.js` — 46 tests passed
- Manually verified the original Claude Code → OpenAI Responses request no longer fails with `Unsupported parameter: output_config`.