### PR TITLE
fix(gateway): honor provider context limits

### DIFF
--- a/packages/core/src/agents/claude-app/gateway-routes.ts
+++ b/packages/core/src/agents/claude-app/gateway-routes.ts
@@ -1,6 +1,7 @@
 import type { AppConfig } from "@ccr/core/contracts/app";
 import { availableGatewayModelIds, normalizeProfileScopeValue } from "@ccr/core/contracts/app";
 import { modelRegistryForConfig } from "@ccr/core/routing/model-registry";
+import { resolveUsageModelAttribution } from "@ccr/core/usage/model-attribution";
 
 export const CLAUDE_APP_ONE_MILLION_CONTEXT_SUFFIX = "[1m]";
 const CLAUDE_APP_ENCODED_ROUTE_PREFIX = "anthropic/claude-ccr-h";
@@ -131,16 +132,21 @@ export function effectiveProviderModelContextWindow(
   config: Pick<AppConfig, "Providers" | "virtualModelProfiles">,
   model: string
 ): number | undefined {
-  const resolved = modelRegistryForConfig(config).resolveProviderModel(
-    stripClaudeAppGatewayOneMillionContextSuffix(model)
+  const registry = modelRegistryForConfig(config);
+  const normalizedModel = stripClaudeAppGatewayOneMillionContextSuffix(model);
+  const direct = registry.resolveProviderModel(normalizedModel);
+  const attribution = direct ? undefined : resolveUsageModelAttribution(config, normalizedModel);
+  const physicalModel = direct?.model ?? attribution?.model;
+  const provider = direct?.provider ?? (
+    attribution?.provider ? registry.findProvider(attribution.provider) : undefined
   );
-  if (!resolved) {
+  if (!provider || !physicalModel) {
     return undefined;
   }
 
-  const modelMetadata = resolved.provider.modelMetadata ?? {};
-  const metadata = modelMetadata[resolved.model] ?? Object.entries(modelMetadata).find(
-    ([candidate]) => candidate.trim().toLowerCase() === resolved.model.toLowerCase()
+  const modelMetadata = provider.modelMetadata ?? {};
+  const metadata = modelMetadata[physicalModel] ?? Object.entries(modelMetadata).find(
+    ([candidate]) => candidate.trim().toLowerCase() === physicalModel.toLowerCase()
   )?.[1];
   const contextWindow = positiveMetadataInteger(metadata?.contextWindow) ??
     positiveMetadataInteger(metadata?.maxContextWindow);

--- a/packages/core/src/agents/claude-app/gateway-routes.ts
+++ b/packages/core/src/agents/claude-app/gateway-routes.ts
@@ -40,13 +40,8 @@ export function buildClaudeAppGatewayModelRoutes(
   options: ClaudeAppGatewayModelRouteOptions = {}
 ): ClaudeAppGatewayModelRoute[] {
   const targetModels = claudeAppGatewayTargetModels(config);
-  const displayNames = claudeAppGatewayDisplayNames(targetModels, options);
-  const configuredTargetKeys = new Set(targetModels.map((model) =>
-    stripClaudeAppGatewayOneMillionContextSuffix(model).toLowerCase()
-  ));
-  const usedRouteIds = new Set<string>();
   const seenTargets = new Set<string>();
-  return targetModels.flatMap((rawTargetModel, index) => {
+  const effectiveTargets = targetModels.flatMap((rawTargetModel) => {
     const targetModel = stripClaudeAppGatewayOneMillionContextSuffix(rawTargetModel);
     const oneMillionContext = claudeAppGatewaySupportsOneMillionContext(rawTargetModel, config, options);
     const targetKey = `${targetModel.toLowerCase()}::${oneMillionContext ? "1m" : "base"}`;
@@ -54,7 +49,17 @@ export function buildClaudeAppGatewayModelRoutes(
       return [];
     }
     seenTargets.add(targetKey);
-
+    return [{ oneMillionContext, rawTargetModel, targetModel }];
+  });
+  const displayNames = claudeAppGatewayDisplayNames(
+    effectiveTargets.map(({ rawTargetModel }) => rawTargetModel),
+    options
+  );
+  const configuredTargetKeys = new Set(targetModels.map((model) =>
+    stripClaudeAppGatewayOneMillionContextSuffix(model).toLowerCase()
+  ));
+  const usedRouteIds = new Set<string>();
+  return effectiveTargets.flatMap(({ oneMillionContext, rawTargetModel, targetModel }, index) => {
     const routeId = claudeAppGatewayRouteId(targetModel, usedRouteIds, configuredTargetKeys);
     if (!routeId) {
       return [];
@@ -122,6 +127,40 @@ export function stripClaudeAppGatewayOneMillionContextSuffix(id: string): string
   return id.trim().replace(/\[1m\]$/i, "").trim();
 }
 
+export function effectiveProviderModelContextWindow(
+  config: Pick<AppConfig, "Providers" | "virtualModelProfiles">,
+  model: string
+): number | undefined {
+  const resolved = modelRegistryForConfig(config).resolveProviderModel(
+    stripClaudeAppGatewayOneMillionContextSuffix(model)
+  );
+  if (!resolved) {
+    return undefined;
+  }
+
+  const modelMetadata = resolved.provider.modelMetadata ?? {};
+  const metadata = modelMetadata[resolved.model] ?? Object.entries(modelMetadata).find(
+    ([candidate]) => candidate.trim().toLowerCase() === resolved.model.toLowerCase()
+  )?.[1];
+  const contextWindow = positiveMetadataInteger(metadata?.contextWindow) ??
+    positiveMetadataInteger(metadata?.maxContextWindow);
+  if (!contextWindow) {
+    return undefined;
+  }
+
+  const effectivePercent = metadataPercentage(metadata?.effectiveContextWindowPercent) ?? 100;
+  return Math.max(1, Math.floor((contextWindow * effectivePercent) / 100));
+}
+
+export function providerModelSupportsOneMillionContext(
+  config: Pick<AppConfig, "Providers" | "virtualModelProfiles">,
+  model: string,
+  fallback = false
+): boolean {
+  const contextWindow = effectiveProviderModelContextWindow(config, model);
+  return contextWindow === undefined ? fallback : contextWindow >= 1_000_000;
+}
+
 function inferGlobalClaudeProfileModel(config: Pick<AppConfig, "profile">): string {
   return config.profile.profiles.find((profile) =>
     profile.enabled &&
@@ -144,11 +183,16 @@ function canonicalClaudeAppGatewayTargetModel(
   model: string,
   config: Pick<AppConfig, "Providers" | "virtualModelProfiles">
 ): string | undefined {
-  const oneMillionContext = hasClaudeAppGatewayOneMillionContextSuffix(model);
+  const requestedOneMillionContext = hasClaudeAppGatewayOneMillionContextSuffix(model);
   const resolved = modelRegistryForConfig(config).resolve(stripClaudeAppGatewayOneMillionContextSuffix(model));
   if (!resolved) {
     return undefined;
   }
+  const oneMillionContext = requestedOneMillionContext && providerModelSupportsOneMillionContext(
+    config,
+    resolved.canonicalSelector,
+    true
+  );
   return oneMillionContext
     ? `${resolved.canonicalSelector}${CLAUDE_APP_ONE_MILLION_CONTEXT_SUFFIX}`
     : resolved.canonicalSelector;
@@ -160,41 +204,18 @@ function claudeAppGatewaySupportsOneMillionContext(
   options: ClaudeAppGatewayModelRouteOptions
 ): boolean {
   const baseModel = stripClaudeAppGatewayOneMillionContextSuffix(model);
-  if (hasClaudeAppGatewayOneMillionContextSuffix(model)) {
-    return true;
-  }
-
-  const providerOverride = claudeAppGatewayProviderSupportsOneMillionContext(baseModel, config);
-  return providerOverride ?? Boolean(options.supportsOneMillionContext?.(baseModel));
+  const fallback = hasClaudeAppGatewayOneMillionContextSuffix(model) ||
+    Boolean(options.supportsOneMillionContext?.(baseModel));
+  return providerModelSupportsOneMillionContext(config, baseModel, fallback);
 }
 
-function claudeAppGatewayProviderSupportsOneMillionContext(
-  model: string,
-  config: Pick<AppConfig, "Providers" | "virtualModelProfiles">
-): boolean | undefined {
-  const resolved = modelRegistryForConfig(config).resolveProviderModel(model);
-  if (!resolved) {
-    return undefined;
-  }
-  const normalizedModel = resolved.model.trim().toLowerCase();
-  const metadata = resolved.provider.modelMetadata?.[resolved.model] ??
-    Object.entries(resolved.provider.modelMetadata ?? {})
-      .find(([candidate]) => candidate.trim().toLowerCase() === normalizedModel)?.[1];
-  const contextWindow = positiveInteger(metadata?.contextWindow) ?? positiveInteger(metadata?.maxContextWindow);
-  if (!contextWindow) {
-    return undefined;
-  }
-  const effectivePercent = percentage(metadata?.effectiveContextWindowPercent) ?? 100;
-  return Math.floor((contextWindow * effectivePercent) / 100) >= 1_000_000;
-}
-
-function positiveInteger(value: number | undefined): number | undefined {
+function positiveMetadataInteger(value: number | undefined): number | undefined {
   return value !== undefined && Number.isFinite(value) && value > 0
     ? Math.trunc(value)
     : undefined;
 }
 
-function percentage(value: number | undefined): number | undefined {
+function metadataPercentage(value: number | undefined): number | undefined {
   return value !== undefined && Number.isFinite(value) && value > 0 && value <= 100
     ? value
     : undefined;

--- a/packages/core/src/agents/claude-app/gateway-routes.ts
+++ b/packages/core/src/agents/claude-app/gateway-routes.ts
@@ -1,4 +1,4 @@
-import type { AppConfig } from "@ccr/core/contracts/app";
+import type { AppConfig, ProviderModelMetadata } from "@ccr/core/contracts/app";
 import { availableGatewayModelIds, normalizeProfileScopeValue } from "@ccr/core/contracts/app";
 import { modelRegistryForConfig } from "@ccr/core/routing/model-registry";
 import { resolveUsageModelAttribution } from "@ccr/core/usage/model-attribution";
@@ -132,24 +132,8 @@ export function effectiveProviderModelContextWindow(
   config: Pick<AppConfig, "Providers" | "virtualModelProfiles">,
   model: string
 ): number | undefined {
-  const registry = modelRegistryForConfig(config);
-  const normalizedModel = stripClaudeAppGatewayOneMillionContextSuffix(model);
-  const direct = registry.resolveProviderModel(normalizedModel);
-  const attribution = direct ? undefined : resolveUsageModelAttribution(config, normalizedModel);
-  const physicalModel = direct?.model ?? attribution?.model;
-  const provider = direct?.provider ?? (
-    attribution?.provider ? registry.findProvider(attribution.provider) : undefined
-  );
-  if (!provider || !physicalModel) {
-    return undefined;
-  }
-
-  const modelMetadata = provider.modelMetadata ?? {};
-  const metadata = modelMetadata[physicalModel] ?? Object.entries(modelMetadata).find(
-    ([candidate]) => candidate.trim().toLowerCase() === physicalModel.toLowerCase()
-  )?.[1];
-  const contextWindow = positiveMetadataInteger(metadata?.contextWindow) ??
-    positiveMetadataInteger(metadata?.maxContextWindow);
+  const metadata = providerModelMetadata(config, model);
+  const contextWindow = providerEffectiveContextWindow(metadata);
   if (!contextWindow) {
     return undefined;
   }
@@ -163,8 +147,44 @@ export function providerModelSupportsOneMillionContext(
   model: string,
   fallback = false
 ): boolean {
-  const contextWindow = effectiveProviderModelContextWindow(config, model);
+  const contextWindow = providerMaximumContextWindow(providerModelMetadata(config, model));
   return contextWindow === undefined ? fallback : contextWindow >= 1_000_000;
+}
+
+function providerModelMetadata(
+  config: Pick<AppConfig, "Providers" | "virtualModelProfiles">,
+  model: string
+): ProviderModelMetadata | undefined {
+  const registry = modelRegistryForConfig(config);
+  const normalizedModel = stripClaudeAppGatewayOneMillionContextSuffix(model);
+  const direct = registry.resolveProviderModel(normalizedModel);
+  const attribution = direct ? undefined : resolveUsageModelAttribution(config, normalizedModel);
+  const physicalModel = direct?.model ?? attribution?.model;
+  const provider = direct?.provider ?? (
+    attribution?.provider ? registry.findProvider(attribution.provider) : undefined
+  );
+  if (!provider || !physicalModel) {
+    return undefined;
+  }
+
+  const modelMetadata = provider.modelMetadata ?? {};
+  return modelMetadata[physicalModel] ?? Object.entries(modelMetadata).find(
+    ([candidate]) => candidate.trim().toLowerCase() === physicalModel.toLowerCase()
+  )?.[1];
+}
+
+function providerEffectiveContextWindow(
+  metadata: ProviderModelMetadata | undefined
+): number | undefined {
+  return positiveMetadataInteger(metadata?.contextWindow) ??
+    positiveMetadataInteger(metadata?.maxContextWindow);
+}
+
+function providerMaximumContextWindow(
+  metadata: ProviderModelMetadata | undefined
+): number | undefined {
+  return positiveMetadataInteger(metadata?.maxContextWindow) ??
+    positiveMetadataInteger(metadata?.contextWindow);
 }
 
 function inferGlobalClaudeProfileModel(config: Pick<AppConfig, "profile">): string {

--- a/packages/core/src/agents/claude-app/gateway-service.ts
+++ b/packages/core/src/agents/claude-app/gateway-service.ts
@@ -7,11 +7,10 @@ import { saveAppConfig } from "@ccr/core/config/config";
 import { CONFIGDIR } from "@ccr/core/config/constants";
 import {
   buildClaudeAppGatewayInferenceModels,
-  type ClaudeAppGatewayInferenceModel,
-  type ClaudeAppGatewayModelRouteOptions
+  type ClaudeAppGatewayInferenceModel
 } from "@ccr/core/agents/claude-app/gateway-routes";
+import { claudeAppGatewayModelRouteOptions } from "@ccr/core/agents/claude-app/model-route-options";
 import { NO_AVAILABLE_GATEWAY_MODELS_MESSAGE, hasAvailableGatewayModels, type ApiKeyConfig, type AppConfig, type ClaudeAppGatewayApplyResult } from "@ccr/core/contracts/app";
-import { findModelCatalogEntry } from "@ccr/core/gateway/model-catalog";
 
 const CLAUDE_APP_CONFIG_ID = "8f69f2f1-3275-4ad8-9317-4aa7e972f311";
 const CLAUDE_APP_CONFIG_NAME = "Claude Code Router";
@@ -19,11 +18,6 @@ const CLAUDE_APP_CONFIG_FILE = "claude_desktop_config.json";
 const CLAUDE_APP_CONFIG_LIBRARY_DIR = "configLibrary";
 const CLAUDE_APP_CONFIG_META_FILE = "_meta.json";
 const CLAUDE_APP_GATEWAY_BACKUP_FILE = path.join(CONFIGDIR, "claude-app-gateway-backup.json");
-const claudeAppGatewayModelRouteOptions: ClaudeAppGatewayModelRouteOptions = {
-  displayName: (model) => findModelCatalogEntry(model)?.displayName,
-  supportsOneMillionContext: (model) => Boolean(findModelCatalogEntry(model)?.limits?.supports1MContext)
-};
-
 type ClaudeAppGatewayConfig = {
   inferenceCredentialKind: "static";
   inferenceGatewayApiKey: string;
@@ -123,7 +117,10 @@ export function applyClaudeAppGatewayConfig(config: AppConfig, options: ClaudeAp
   const state = ensureClaudeAppGatewayState(config);
   const paths = getClaudeAppGatewayPaths(options.dataDir);
   const endpoint = gatewayEndpoint(state.config);
-  const models = buildClaudeAppGatewayInferenceModels(state.config, claudeAppGatewayModelRouteOptions);
+  const models = buildClaudeAppGatewayInferenceModels(
+    state.config,
+    claudeAppGatewayModelRouteOptions(state.config)
+  );
   const model = models[0]?.name ?? "";
   const modelsVersion = claudeAppGatewayModelsVersion(endpoint, models);
   const gatewayConfig: ClaudeAppGatewayConfig = {

--- a/packages/core/src/agents/claude-app/model-route-options.ts
+++ b/packages/core/src/agents/claude-app/model-route-options.ts
@@ -1,0 +1,24 @@
+import {
+  type ClaudeAppGatewayModelRouteOptions,
+  providerModelSupportsOneMillionContext
+} from "@ccr/core/agents/claude-app/gateway-routes";
+import type { AppConfig } from "@ccr/core/contracts/app";
+import { findModelCatalogEntry } from "@ccr/core/gateway/model-catalog";
+
+type ClaudeAppGatewayModelRouteConfig = Pick<
+  AppConfig,
+  "Providers" | "virtualModelProfiles"
+>;
+
+export function claudeAppGatewayModelRouteOptions(
+  config: ClaudeAppGatewayModelRouteConfig
+): ClaudeAppGatewayModelRouteOptions {
+  return {
+    displayName: (model) => findModelCatalogEntry(model)?.displayName,
+    supportsOneMillionContext: (model) => providerModelSupportsOneMillionContext(
+      config,
+      model,
+      Boolean(findModelCatalogEntry(model)?.limits?.supports1MContext)
+    )
+  };
+}

--- a/packages/core/src/gateway/claude-code-router-plugin.ts
+++ b/packages/core/src/gateway/claude-code-router-plugin.ts
@@ -292,7 +292,7 @@ async function resolveConfiguredRouteDecision(
   const explicitModel = normalizeRouteSelector(requestedModel);
   const resolvedExplicitModel = compiled.modelRegistry.resolve(explicitModel) ?? compiled.modelRegistry.resolve(
     explicitModel
-      ? resolveClaudeAppGatewayRouteModel(explicitModel, config, claudeAppGatewayModelRouteOptions)
+      ? resolveClaudeAppGatewayRouteModel(explicitModel, config, claudeAppGatewayModelRouteOptions(config))
       : undefined
   );
   const explicitDecision: ConfiguredRouteDecision | undefined = resolvedExplicitModel
@@ -488,7 +488,7 @@ function resolveConfiguredClaudeCodeModel(
 ): RouteModelRef | undefined {
   const target = normalizeRouteSelector(selector);
   const discoveredTarget = target
-    ? resolveClaudeAppGatewayRouteModel(target, config, claudeAppGatewayModelRouteOptions)
+    ? resolveClaudeAppGatewayRouteModel(target, config, claudeAppGatewayModelRouteOptions(config))
     : undefined;
   return modelRegistry.resolve(discoveredTarget ?? target);
 }

--- a/packages/core/src/gateway/claude-code-router-plugin.ts
+++ b/packages/core/src/gateway/claude-code-router-plugin.ts
@@ -6,7 +6,7 @@ import { type AppConfig, type ProfileClientKind, type RequestRouteTraceChange, t
 import { CONFIGDIR } from "@ccr/core/config/constants";
 import { applyAgentRequestEnrichers } from "@ccr/core/agents/request-enricher";
 import { buildClaudeAppGatewayModelRoutes, type ClaudeAppGatewayModelRoute, resolveClaudeAppGatewayRouteModel } from "@ccr/core/agents/claude-app/gateway-routes";
-import { claudeAppGatewayModelRouteOptions } from "@ccr/core/gateway/internal/shared";
+import { claudeAppGatewayModelRouteOptions } from "@ccr/core/agents/claude-app/model-route-options";
 import { compileRouterConfig, type CompiledRouterConfig, type CompiledRouterRule } from "@ccr/core/routing/config-compiler";
 import type { RouteDecision, RouteDiagnostic, RouteModelRef, RouteRequest, RouteSource } from "@ccr/core/routing/contracts";
 import { ModelRegistry, normalizeRouteSelector } from "@ccr/core/routing/model-registry";
@@ -423,7 +423,11 @@ function resolveBuiltInClaudeCodeSubagentRouteDecision(
   }
   const target = normalizeRouteSelector(request.builtInSubagentModel);
   const discoveredTarget = target
-    ? resolveClaudeAppGatewayRouteModel(target, config, claudeAppGatewayModelRouteOptions)
+    ? resolveClaudeAppGatewayRouteModel(
+        target,
+        config,
+        claudeAppGatewayModelRouteOptions(config)
+      )
     : undefined;
   const configuredTarget = modelRegistry.resolve(discoveredTarget ?? target);
   if (!target || isSubagentModelPlaceholder(target) || !configuredTarget) {
@@ -872,7 +876,10 @@ function claudeCodeAgentToolInstructions(config: AppConfig): { prompt: string; t
 
 function configuredSubagentModelDescriptionRows(config: AppConfig): string[] {
   const routeByTarget = new Map<string, ClaudeAppGatewayModelRoute>();
-  for (const route of buildClaudeAppGatewayModelRoutes(config, claudeAppGatewayModelRouteOptions)) {
+  for (const route of buildClaudeAppGatewayModelRoutes(
+    config,
+    claudeAppGatewayModelRouteOptions(config)
+  )) {
     const key = route.targetModel.toLowerCase();
     const current = routeByTarget.get(key);
     if (!current || (current.oneMillionContext && !route.oneMillionContext)) {

--- a/packages/core/src/gateway/features/model-discovery.ts
+++ b/packages/core/src/gateway/features/model-discovery.ts
@@ -3,14 +3,17 @@
  */
 import type { IncomingHttpHeaders } from "node:http";
 import type { ApiKeyConfig, AppConfig, ProviderModelMetadata } from "@ccr/core/contracts/app";
-import { buildClaudeAppGatewayModelRoutes, resolveClaudeAppGatewayRouteModel } from "@ccr/core/agents/claude-app/gateway-routes";
+import {
+  buildClaudeAppGatewayModelRoutes,
+  effectiveProviderModelContextWindow,
+  resolveClaudeAppGatewayRouteModel
+} from "@ccr/core/agents/claude-app/gateway-routes";
 import { modelRegistryForConfig, normalizeRouteSelector } from "@ccr/core/routing/model-registry";
 import { findModelCatalogEntry, modelCatalogMaxInputTokens, modelCatalogMaxOutputTokens, readCatalogCapability, type ModelCatalogEntry } from "@ccr/core/gateway/model-catalog";
 import { stringValue } from "@ccr/core/gateway/internal/value";
 import { fusionModelSelector } from "@ccr/core/mcp/fusion-config";
 import { readHeader } from "@ccr/core/gateway/http/io";
 import { claudeAppGatewayModelRouteOptions, claudeCodeOneMillionContextSuffix } from "@ccr/core/gateway/internal/shared";
-import type { ClaudeCodeDiscoverableModel } from "@ccr/core/gateway/internal/shared";
 import { parseJsonObjectSafe, serializeJsonBodyWithModel } from "@ccr/core/gateway/http/body";
 import { uniqueStrings } from "@ccr/core/gateway/internal/collections";
 
@@ -126,7 +129,8 @@ function createClaudeAppGatewayModelsResponse(
     const catalogId = stripClaudeCodeOneMillionContextSuffix(route.targetModel);
     const catalogEntry = findModelCatalogEntry(catalogId);
     const modelMetadata = providerModelMetadataForSelector(config, catalogId);
-    const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, route.oneMillionContext, modelMetadata);
+    const providerContextWindow = effectiveProviderModelContextWindow(config, catalogId);
+    const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, route.oneMillionContext, providerContextWindow);
     const maxOutputTokens = modelCatalogMaxOutputTokens(catalogEntry);
     const exposeOneMillionContextVariant = options.claudeCode && route.oneMillionContext;
     return {
@@ -134,6 +138,7 @@ function createClaudeAppGatewayModelsResponse(
       capabilities: createClaudeCodeModelCapabilities(catalogEntry, {
         maxInputTokens,
         oneMillionContext: route.oneMillionContext,
+        supportsOneMillionContext: route.oneMillionContext,
         ...providerModelCapabilityOverrides(modelMetadata)
       }),
       created_at: "1970-01-01T00:00:00Z",
@@ -155,45 +160,11 @@ function createClaudeAppGatewayModelsResponse(
 }
 
 
-function createClaudeCodeModelsResponse(config: AppConfig): Record<string, unknown> {
-  const models = buildClaudeCodeDiscoverableModels(config);
-  const data = models.map((model) => {
-    const claudeId = claudeCodeDiscoveryModelId(model.id);
-    const catalogId = stripClaudeCodeOneMillionContextSuffix(model.id);
-    const catalogEntry = findModelCatalogEntry(catalogId);
-    const modelMetadata = providerModelMetadataForSelector(config, catalogId);
-    const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, model.oneMillionContext, modelMetadata);
-    const maxOutputTokens = modelCatalogMaxOutputTokens(catalogEntry);
-    return {
-      id: claudeId,
-      capabilities: createClaudeCodeModelCapabilities(catalogEntry, {
-        maxInputTokens,
-        oneMillionContext: model.oneMillionContext,
-        ...providerModelCapabilityOverrides(modelMetadata)
-      }),
-      created_at: "1970-01-01T00:00:00Z",
-      display_name: formatClaudeCodeModelDisplayName(claudeId, catalogEntry, model.oneMillionContext),
-      max_input_tokens: maxInputTokens,
-      max_tokens: maxOutputTokens,
-      type: "model"
-    };
-  });
-
-  return {
-    data,
-    first_id: data[0]?.id ?? null,
-    has_more: false,
-    last_id: data[data.length - 1]?.id ?? null
-  };
-}
-
-
 function claudeGatewayModelContextWindow(
   entry: ModelCatalogEntry | undefined,
   oneMillionContext: boolean,
-  metadata?: ProviderModelMetadata
+  providerContextWindow?: number
 ): number {
-  const providerContextWindow = effectiveProviderContextWindow(metadata);
   if (providerContextWindow) {
     return providerContextWindow;
   }
@@ -205,17 +176,10 @@ function claudeGatewayModelContextWindow(
 }
 
 
-function effectiveProviderContextWindow(metadata: ProviderModelMetadata | undefined): number | undefined {
-  const contextWindow = positiveInteger(metadata?.contextWindow) ?? positiveInteger(metadata?.maxContextWindow);
-  if (!contextWindow) {
-    return undefined;
-  }
-  const effectivePercent = percentage(metadata?.effectiveContextWindowPercent) ?? 100;
-  return Math.max(1, Math.floor((contextWindow * effectivePercent) / 100));
-}
-
-
-function providerModelMetadataForSelector(config: AppConfig, selector: string): ProviderModelMetadata | undefined {
+function providerModelMetadataForSelector(
+  config: AppConfig,
+  selector: string
+): ProviderModelMetadata | undefined {
   const resolved = modelRegistryForConfig(config).resolveProviderModel(selector);
   if (!resolved) {
     return undefined;
@@ -226,14 +190,9 @@ function providerModelMetadataForSelector(config: AppConfig, selector: string): 
     return direct;
   }
   const normalizedModel = resolved.model.toLowerCase();
-  return Object.entries(metadata).find(([model]) => model.trim().toLowerCase() === normalizedModel)?.[1];
-}
-
-
-function percentage(value: number | undefined): number | undefined {
-  return value !== undefined && Number.isFinite(value) && value > 0 && value <= 100
-    ? value
-    : undefined;
+  return Object.entries(metadata).find(
+    ([model]) => model.trim().toLowerCase() === normalizedModel
+  )?.[1];
 }
 
 
@@ -305,35 +264,6 @@ function gatewayModelOwner(id: string): string {
 }
 
 
-function buildClaudeCodeDiscoverableModels(config: AppConfig): ClaudeCodeDiscoverableModel[] {
-  const seen = new Set<string>();
-  const models: ClaudeCodeDiscoverableModel[] = [];
-
-  const pushModel = (id: string, oneMillionContext: boolean) => {
-    const normalized = id.trim();
-    if (!normalized) {
-      return;
-    }
-    const key = normalized.toLowerCase();
-    if (seen.has(key)) {
-      return;
-    }
-    seen.add(key);
-    models.push({ id: normalized, oneMillionContext });
-  };
-
-  for (const id of buildClaudeCodeDiscoverableModelIds(config)) {
-    pushModel(id, hasClaudeCodeOneMillionContextSuffix(id));
-    const baseId = stripClaudeCodeOneMillionContextSuffix(id);
-    if (!hasClaudeCodeOneMillionContextSuffix(id) && findModelCatalogEntry(baseId)?.limits?.supports1MContext) {
-      pushModel(claudeCodeOneMillionContextModelId(baseId), true);
-    }
-  }
-
-  return models;
-}
-
-
 function isVisibleVirtualModelProfile(profile: NonNullable<AppConfig["virtualModelProfiles"]>[number]): boolean {
   return profile.enabled !== false &&
     profile.materialization?.enabled !== false &&
@@ -399,16 +329,6 @@ function isConfiguredGatewayModelSelector(model: string, config: AppConfig): boo
 }
 
 
-function claudeCodeDiscoveryModelId(value: string): string {
-  return value.toLowerCase().startsWith("claude-") ? value : `claude-${value}`;
-}
-
-
-function claudeCodeOneMillionContextModelId(id: string): string {
-  return hasClaudeCodeOneMillionContextSuffix(id) ? id : `${id}${claudeCodeOneMillionContextSuffix}`;
-}
-
-
 function hasClaudeCodeOneMillionContextSuffix(id: string): boolean {
   return id.trim().toLowerCase().endsWith(claudeCodeOneMillionContextSuffix);
 }
@@ -416,27 +336,6 @@ function hasClaudeCodeOneMillionContextSuffix(id: string): boolean {
 
 function stripClaudeCodeOneMillionContextSuffix(id: string): string {
   return id.trim().replace(/\[1m\]$/i, "").trim();
-}
-
-
-function formatClaudeCodeModelDisplayName(
-  id: string,
-  entry?: ModelCatalogEntry,
-  oneMillionContext = hasClaudeCodeOneMillionContextSuffix(id)
-): string {
-  if (entry?.displayName) {
-    return oneMillionContext ? `${entry.displayName} (1M context)` : entry.displayName;
-  }
-
-  const normalized = stripClaudeCodeOneMillionContextSuffix(id.replace(/^claude-/i, ""));
-  const model = normalized.includes("/") ? normalized.slice(normalized.lastIndexOf("/") + 1) : normalized;
-  const words = model
-    .split(/[-_]+/)
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .map((part) => (/^\d+$/.test(part) ? part : part.slice(0, 1).toUpperCase() + part.slice(1)));
-  const displayName = ["Claude", ...words].filter(Boolean).join(" ");
-  return oneMillionContext ? `${displayName} (1M context)` : displayName;
 }
 
 
@@ -448,6 +347,7 @@ function createClaudeCodeModelCapabilities(
     oneMillionContext?: boolean;
     reasoning?: boolean;
     reasoningLevels?: string[];
+    supportsOneMillionContext?: boolean;
   } = {}
 ): Record<string, unknown> {
   if (!entry) {
@@ -481,7 +381,8 @@ function createClaudeCodeModelCapabilities(
   const supportsAudioOutput = readCatalogCapability(capabilities, "audioOutput") || outputModalities.has("audio");
   const supportsVideoInput = readCatalogCapability(capabilities, "videoInput") || inputModalities.has("video");
   const maxInputTokens = options.maxInputTokens ?? modelCatalogMaxInputTokens(entry);
-  const supportsOneMillionContext = maxInputTokens >= 1_000_000 || Boolean(entry.limits?.supports1MContext);
+  const supportsOneMillionContext = options.supportsOneMillionContext ??
+    (maxInputTokens >= 1_000_000 || Boolean(entry.limits?.supports1MContext));
 
   return {
     audio_input: { supported: supportsAudioInput },
@@ -534,6 +435,7 @@ function createDefaultClaudeCodeModelCapabilities(
     oneMillionContext?: boolean;
     reasoning?: boolean;
     reasoningLevels?: string[];
+    supportsOneMillionContext?: boolean;
   } = {}
 ): Record<string, unknown> {
   const maxInputTokens = positiveInteger(options.maxInputTokens);
@@ -559,7 +461,7 @@ function createDefaultClaudeCodeModelCapabilities(
             max_input_tokens: maxInputTokens,
             one_million_context_variant: options.oneMillionContext === true,
             supported: true,
-            supports_1m_context: maxInputTokens >= 1_000_000
+            supports_1m_context: options.supportsOneMillionContext ?? maxInputTokens >= 1_000_000
           }
         }
       : {}),

--- a/packages/core/src/gateway/features/model-discovery.ts
+++ b/packages/core/src/gateway/features/model-discovery.ts
@@ -8,12 +8,13 @@ import {
   effectiveProviderModelContextWindow,
   resolveClaudeAppGatewayRouteModel
 } from "@ccr/core/agents/claude-app/gateway-routes";
+import { claudeAppGatewayModelRouteOptions } from "@ccr/core/agents/claude-app/model-route-options";
 import { modelRegistryForConfig, normalizeRouteSelector } from "@ccr/core/routing/model-registry";
 import { findModelCatalogEntry, modelCatalogMaxInputTokens, modelCatalogMaxOutputTokens, readCatalogCapability, type ModelCatalogEntry } from "@ccr/core/gateway/model-catalog";
 import { stringValue } from "@ccr/core/gateway/internal/value";
 import { fusionModelSelector } from "@ccr/core/mcp/fusion-config";
 import { readHeader } from "@ccr/core/gateway/http/io";
-import { claudeAppGatewayModelRouteOptions, claudeCodeOneMillionContextSuffix } from "@ccr/core/gateway/internal/shared";
+import { claudeCodeOneMillionContextSuffix } from "@ccr/core/gateway/internal/shared";
 import { parseJsonObjectSafe, serializeJsonBodyWithModel } from "@ccr/core/gateway/http/body";
 import { uniqueStrings } from "@ccr/core/gateway/internal/collections";
 
@@ -76,7 +77,7 @@ export function prepareClaudeAppDiscoveredModelRequest(
   const routedModel = resolveClaudeAppGatewayRouteModel(
     normalizedModel,
     config,
-    claudeAppGatewayModelRouteOptions
+    claudeAppGatewayModelRouteOptions(config)
   );
   if (!routedModel || routedModel.toLowerCase() === normalizedModel.toLowerCase()) {
     return undefined;
@@ -124,7 +125,10 @@ function createClaudeAppGatewayModelsResponse(
   config: AppConfig,
   options: { claudeCode?: boolean } = {}
 ): Record<string, unknown> {
-  const routes = buildClaudeAppGatewayModelRoutes(config, claudeAppGatewayModelRouteOptions);
+  const routes = buildClaudeAppGatewayModelRoutes(
+    config,
+    claudeAppGatewayModelRouteOptions(config)
+  );
   const data = routes.map((route) => {
     const catalogId = stripClaudeCodeOneMillionContextSuffix(route.targetModel);
     const catalogEntry = findModelCatalogEntry(catalogId);
@@ -303,7 +307,11 @@ export function resolveGatewayPublicModelId(model: string | undefined, config: A
     return undefined;
   }
   return resolveClaudeCodeDiscoveredModelId(normalized, config) ??
-    resolveClaudeAppGatewayRouteModel(normalized, config, claudeAppGatewayModelRouteOptions);
+    resolveClaudeAppGatewayRouteModel(
+      normalized,
+      config,
+      claudeAppGatewayModelRouteOptions(config)
+    );
 }
 
 

--- a/packages/core/src/gateway/features/model-discovery.ts
+++ b/packages/core/src/gateway/features/model-discovery.ts
@@ -337,6 +337,13 @@ function isConfiguredGatewayModelSelector(model: string, config: AppConfig): boo
 }
 
 
+function claudeCodeOneMillionContextModelId(id: string): string {
+  return hasClaudeCodeOneMillionContextSuffix(id)
+    ? id
+    : `${id}${claudeCodeOneMillionContextSuffix}`;
+}
+
+
 function hasClaudeCodeOneMillionContextSuffix(id: string): boolean {
   return id.trim().toLowerCase().endsWith(claudeCodeOneMillionContextSuffix);
 }

--- a/packages/core/src/gateway/internal/shared.ts
+++ b/packages/core/src/gateway/internal/shared.ts
@@ -164,12 +164,6 @@ export type CursorOpenAICompatPreparation = {
 };
 
 
-export type ClaudeCodeDiscoverableModel = {
-  id: string;
-  oneMillionContext: boolean;
-};
-
-
 export type UpstreamAttempt = {
   body?: Buffer;
   credentialChain?: string[];

--- a/packages/core/src/gateway/internal/shared.ts
+++ b/packages/core/src/gateway/internal/shared.ts
@@ -4,9 +4,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createRequire } from "node:module";
 import type { ApiKeyConfig, GatewayMcpServerConfig, GatewayProviderCapabilityProtocol, GatewayProviderConfig, GatewayProviderProtocol, VirtualModelFusionWebSearchProvider } from "@ccr/core/contracts/app";
-import type { ClaudeAppGatewayModelRouteOptions } from "@ccr/core/agents/claude-app/gateway-routes";
 import type { RouteModelRef } from "@ccr/core/routing/contracts";
-import { findModelCatalogEntry } from "@ccr/core/gateway/model-catalog";
 
 
 export type CoreGatewayProvider = {
@@ -26,12 +24,6 @@ export const defaultFusionWebSearchProvider: VirtualModelFusionWebSearchProvider
 export const fusionModelProviderName = "Fusion";
 
 export const claudeCodeOneMillionContextSuffix = "[1m]";
-
-export const claudeAppGatewayModelRouteOptions: ClaudeAppGatewayModelRouteOptions = {
-  displayName: (model) => findModelCatalogEntry(model)?.displayName,
-  supportsOneMillionContext: (model) => Boolean(findModelCatalogEntry(model)?.limits?.supports1MContext)
-};
-
 
 export type ApiKeyAuthorizationResult =
   | { ok: true; apiKey?: ApiKeyConfig }

--- a/packages/core/test/unit/agents/claude-app-gateway-models.test.mjs
+++ b/packages/core/test/unit/agents/claude-app-gateway-models.test.mjs
@@ -388,13 +388,14 @@ test("Claude App discovery prefers provider context metadata over the static cat
   assert.equal(model.capabilities.context_window.one_million_context_variant, false);
 });
 
-test("Claude App discovery lets provider metadata enable one-million context", () => {
+test("Claude App discovery uses physical provider capacity for one-million support", () => {
   const config = createConfig({
     providers: [
       {
         modelMetadata: {
           "custom-frontier": {
             contextWindow: 1_000_000,
+            effectiveContextWindowPercent: 95,
             maxContextWindow: 1_000_000
           }
         },
@@ -412,7 +413,37 @@ test("Claude App discovery lets provider metadata enable one-million context", (
   assert.ok(model);
   assert.equal(route.oneMillionContext, true);
   assert.equal(inferenceModel.supports1m, true);
-  assert.equal(model.max_input_tokens, 1_000_000);
+  assert.equal(model.max_input_tokens, 950_000);
+  assert.equal(model.capabilities.context_window.supports_1m_context, true);
+  assert.equal(model.capabilities.context_window.one_million_context_variant, true);
+});
+
+test("Claude App discovery uses maximum capacity for optional one-million support", () => {
+  const config = createConfig({
+    providers: [
+      {
+        modelMetadata: {
+          "custom-frontier": {
+            contextWindow: 272_000,
+            effectiveContextWindowPercent: 95,
+            maxContextWindow: 1_000_000
+          }
+        },
+        models: ["custom-frontier"],
+        name: "Gateway",
+        type: "openai_responses"
+      }
+    ]
+  });
+  const route = buildClaudeAppGatewayModelRoutes(config)[0];
+  const inferenceModel = buildClaudeAppGatewayInferenceModels(config)[0];
+  const response = createClaudeModelsResponse(config);
+  const model = response.data.find((item) => item.id === route.id);
+
+  assert.ok(model);
+  assert.equal(route.oneMillionContext, true);
+  assert.equal(inferenceModel.supports1m, true);
+  assert.equal(model.max_input_tokens, 258_400);
   assert.equal(model.capabilities.context_window.supports_1m_context, true);
   assert.equal(model.capabilities.context_window.one_million_context_variant, true);
 });

--- a/packages/core/test/unit/agents/claude-app-gateway-models.test.mjs
+++ b/packages/core/test/unit/agents/claude-app-gateway-models.test.mjs
@@ -254,9 +254,13 @@ test("Claude App discovery publishes the effective provider context for uncatalo
   const model = response.data.find((item) => item.id === route.id);
 
   assert.ok(model);
+  assert.equal(route.oneMillionContext, false);
+  assert.equal(buildClaudeAppGatewayInferenceModels(config)[0].supports1m, undefined);
   assert.equal(model.max_input_tokens, 258400);
   assert.equal(model.capabilities.context_management.max_input_tokens, 258400);
   assert.equal(model.capabilities.context_window.max_input_tokens, 258400);
+  assert.equal(model.capabilities.context_window.supports_1m_context, false);
+  assert.equal(model.capabilities.context_window.one_million_context_variant, false);
 });
 
 test("Claude App discovery honors configured reasoning levels for uncatalogued models", () => {
@@ -318,7 +322,94 @@ test("Claude App discovery prefers provider context metadata over the static cat
   const model = response.data.find((item) => item.id === route.id);
 
   assert.ok(model);
+  assert.equal(route.oneMillionContext, false);
+  assert.equal(buildClaudeAppGatewayInferenceModels(config)[0].supports1m, undefined);
   assert.equal(model.max_input_tokens, 244800);
   assert.equal(model.capabilities.context_management.max_input_tokens, 244800);
   assert.equal(model.capabilities.context_window.max_input_tokens, 244800);
+  assert.equal(model.capabilities.context_window.supports_1m_context, false);
+  assert.equal(model.capabilities.context_window.one_million_context_variant, false);
+});
+
+test("Claude App discovery lets provider metadata enable one-million context", () => {
+  const config = createConfig({
+    providers: [
+      {
+        modelMetadata: {
+          "custom-frontier": {
+            contextWindow: 1_000_000,
+            maxContextWindow: 1_000_000
+          }
+        },
+        models: ["custom-frontier"],
+        name: "Gateway",
+        type: "openai_responses"
+      }
+    ]
+  });
+  const route = buildClaudeAppGatewayModelRoutes(config)[0];
+  const inferenceModel = buildClaudeAppGatewayInferenceModels(config)[0];
+  const response = createClaudeModelsResponse(config);
+  const model = response.data.find((item) => item.id === route.id);
+
+  assert.ok(model);
+  assert.equal(route.oneMillionContext, true);
+  assert.equal(inferenceModel.supports1m, true);
+  assert.equal(model.max_input_tokens, 1_000_000);
+  assert.equal(model.capabilities.context_window.supports_1m_context, true);
+  assert.equal(model.capabilities.context_window.one_million_context_variant, true);
+});
+
+test("Claude App discovery rejects an explicit one-million suffix for a bounded provider model", () => {
+  const config = createConfig({
+    profileModel: "Codex API/gpt-5-codex[1m]",
+    providers: [
+      {
+        modelMetadata: {
+          "gpt-5-codex": {
+            contextWindow: 272000,
+            effectiveContextWindowPercent: 90,
+            maxContextWindow: 272000
+          }
+        },
+        models: ["gpt-5-codex"],
+        name: "Codex API",
+        type: "openai_responses"
+      }
+    ]
+  });
+  const route = buildClaudeAppGatewayModelRoutes(config)[0];
+  const response = createClaudeModelsResponse(config);
+  const model = response.data.find((item) => item.id === route.id);
+
+  assert.ok(model);
+  assert.equal(inferClaudeAppGatewayTargetModel(config), "Codex API/gpt-5-codex");
+  assert.equal(route.oneMillionContext, false);
+  assert.equal(route.targetModel, "Codex API/gpt-5-codex");
+  assert.equal(model.max_input_tokens, 244800);
+  assert.equal(model.capabilities.context_window.supports_1m_context, false);
+  assert.equal(model.capabilities.context_window.one_million_context_variant, false);
+});
+
+test("Claude App discovery does not number a deduplicated bounded context route", () => {
+  const config = createConfig({
+    profileModel: "Codex API/gpt-5-codex[1m]",
+    providers: [
+      {
+        modelMetadata: {
+          "gpt-5-codex": {
+            contextWindow: 272000,
+            maxContextWindow: 272000
+          }
+        },
+        models: ["gpt-5-codex"],
+        name: "Codex API",
+        type: "openai_responses"
+      }
+    ]
+  });
+  const routes = buildClaudeAppGatewayModelRoutes(config);
+
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].displayName, "Codex API/gpt-5-codex");
 });

--- a/packages/core/test/unit/agents/claude-app-gateway-models.test.mjs
+++ b/packages/core/test/unit/agents/claude-app-gateway-models.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   buildClaudeAppGatewayInferenceModels,
   buildClaudeAppGatewayModelRoutes,
+  effectiveProviderModelContextWindow,
   inferClaudeAppGatewayTargetModel,
   resolveClaudeAppGatewayRouteModel
 } from "@ccr/core/agents/claude-app/gateway-routes.ts";
@@ -42,6 +43,62 @@ function createClaudeModelsResponse(config) {
 
 function createClaudeCodeModelsResponse(config) {
   return createGatewayModelsResponse(config, { "user-agent": "claude-cli/2.1.215" });
+}
+
+function createFrontierProvider() {
+  return {
+    modelMetadata: {
+      "custom-frontier": {
+        contextWindow: 1_000_000,
+        maxContextWindow: 1_000_000
+      }
+    },
+    models: ["custom-frontier"],
+    name: "Gateway",
+    type: "openai_responses"
+  };
+}
+
+function createVirtualModelProfile({ baseModel, exactAliases = [], id, prefixes = [], suffixes = [] }) {
+  return {
+    baseModel,
+    displayName: id,
+    enabled: true,
+    execution: {
+      clientToolsPolicy: "allow",
+      maxToolCalls: 1,
+      maxTurns: 1,
+      mode: "decorate_only",
+      streamMode: "buffered"
+    },
+    id,
+    key: id,
+    match: { exactAliases, prefixes, suffixes },
+    materialization: { enabled: true, includeInGatewayModels: true },
+    tools: []
+  };
+}
+
+function findPublishedClaudeAppRoute(config, targetModel) {
+  const route = buildClaudeAppGatewayModelRoutes(config).find((item) => item.targetModel === targetModel);
+  assert.ok(route, `expected published route for ${targetModel}`);
+  const inferenceModel = buildClaudeAppGatewayInferenceModels(config).find((item) => item.name === route.id);
+  assert.ok(inferenceModel, `expected inference model for ${targetModel}`);
+  const model = createClaudeModelsResponse(config).data.find((item) => item.id === route.id);
+  assert.ok(model, `expected model discovery entry for ${targetModel}`);
+  return { inferenceModel, model, route };
+}
+
+function assertOneMillionVirtualRoute(config, targetModel) {
+  const { inferenceModel, model, route } = findPublishedClaudeAppRoute(config, targetModel);
+
+  assert.equal(route.oneMillionContext, true);
+  assert.equal(inferenceModel.supports1m, true);
+  assert.equal(model.max_input_tokens, 1_000_000);
+  assert.equal(model.capabilities.context_management.max_input_tokens, 1_000_000);
+  assert.equal(model.capabilities.context_window.max_input_tokens, 1_000_000);
+  assert.equal(model.capabilities.context_window.supports_1m_context, true);
+  assert.equal(model.capabilities.context_window.one_million_context_variant, true);
 }
 
 function assertPublishedRoutesResolveUniquely(config) {
@@ -358,6 +415,117 @@ test("Claude App discovery lets provider metadata enable one-million context", (
   assert.equal(model.max_input_tokens, 1_000_000);
   assert.equal(model.capabilities.context_window.supports_1m_context, true);
   assert.equal(model.capabilities.context_window.one_million_context_variant, true);
+});
+
+test("Claude App discovery resolves provider context through a virtual prefix profile", () => {
+  const config = createConfig({
+    providers: [createFrontierProvider()],
+    virtualModelProfiles: [
+      createVirtualModelProfile({
+        baseModel: { mode: "strip_prefix" },
+        id: "tools-prefix",
+        prefixes: ["tools-"]
+      })
+    ]
+  });
+
+  assertOneMillionVirtualRoute(config, "Gateway/tools-custom-frontier");
+});
+
+test("Claude App discovery resolves provider context through a virtual suffix profile", () => {
+  const config = createConfig({
+    providers: [createFrontierProvider()],
+    virtualModelProfiles: [
+      createVirtualModelProfile({
+        baseModel: { mode: "strip_suffix" },
+        id: "tools-suffix",
+        suffixes: ["-tools"]
+      })
+    ]
+  });
+
+  assertOneMillionVirtualRoute(config, "Gateway/custom-frontier-tools");
+});
+
+test("Claude App discovery resolves provider context through a fixed-alias profile", () => {
+  const config = createConfig({
+    providers: [createFrontierProvider()],
+    virtualModelProfiles: [
+      createVirtualModelProfile({
+        baseModel: { fixedModel: "Gateway/custom-frontier", mode: "fixed" },
+        exactAliases: ["frontier-tools"],
+        id: "frontier-tools"
+      })
+    ]
+  });
+
+  assertOneMillionVirtualRoute(config, "Fusion/frontier-tools");
+});
+
+test("Claude App discovery keeps physical metadata distinct from a colliding fixed alias", () => {
+  const config = createConfig({
+    providers: [
+      createFrontierProvider(),
+      {
+        modelMetadata: {
+          tiny: {
+            contextWindow: 128_000,
+            maxContextWindow: 128_000
+          }
+        },
+        models: ["tiny"],
+        name: "Small",
+        type: "openai_responses"
+      }
+    ],
+    virtualModelProfiles: [
+      createVirtualModelProfile({
+        baseModel: { fixedModel: "Small/tiny", mode: "fixed" },
+        exactAliases: ["custom-frontier"],
+        id: "custom-frontier-alias"
+      })
+    ]
+  });
+  const physical = findPublishedClaudeAppRoute(config, "Gateway/custom-frontier");
+  const virtual = findPublishedClaudeAppRoute(config, "Fusion/custom-frontier");
+
+  assert.notEqual(physical.route.id, virtual.route.id);
+  assert.equal(effectiveProviderModelContextWindow(config, physical.route.targetModel), 1_000_000);
+  assert.equal(physical.route.oneMillionContext, true);
+  assert.equal(physical.inferenceModel.supports1m, true);
+  assert.equal(physical.model.max_input_tokens, 1_000_000);
+  assert.equal(physical.model.capabilities.context_window.max_input_tokens, 1_000_000);
+
+  assert.equal(effectiveProviderModelContextWindow(config, virtual.route.targetModel), 128_000);
+  assert.equal(virtual.route.oneMillionContext, false);
+  assert.equal(virtual.inferenceModel.supports1m, undefined);
+  assert.equal(virtual.model.max_input_tokens, 128_000);
+  assert.equal(virtual.model.capabilities.context_window.max_input_tokens, 128_000);
+});
+
+test("Claude App discovery falls back safely for cyclic fixed-alias profiles", () => {
+  const config = createConfig({
+    providers: [createFrontierProvider()],
+    virtualModelProfiles: [
+      createVirtualModelProfile({
+        baseModel: { fixedModel: "Fusion/loop-b", mode: "fixed" },
+        exactAliases: ["loop-a"],
+        id: "loop-a"
+      }),
+      createVirtualModelProfile({
+        baseModel: { fixedModel: "Fusion/loop-a", mode: "fixed" },
+        exactAliases: ["loop-b"],
+        id: "loop-b"
+      })
+    ]
+  });
+  const { inferenceModel, model, route } = findPublishedClaudeAppRoute(config, "Fusion/loop-a");
+
+  assert.equal(effectiveProviderModelContextWindow(config, "Fusion/loop-a"), undefined);
+  assert.equal(route.oneMillionContext, false);
+  assert.equal(inferenceModel.supports1m, undefined);
+  assert.equal(model.max_input_tokens, 0);
+  assert.equal(model.capabilities.context_window, undefined);
 });
 
 test("Claude App discovery rejects an explicit one-million suffix for a bounded provider model", () => {


### PR DESCRIPTION
## Summary

- derive effective input windows from provider metadata and its configured percentage
- use maximum provider capacity for optional one-million-context capability while keeping normal token budgets on the effective window
- keep published routes, capabilities, inference hints, subagent routing, and display labels consistent
- deduplicate routes after applying effective limits
- remove an unreachable alternate discovery builder

## Why

The static catalog can disagree with the provider that actually serves a model. A bounded provider could be advertised with a larger normal window, while an uncatalogued provider with a larger configured capacity could lose an optional route.

Effective input limits and physical maximum capacity are separate. A provider can use a bounded normal window while still supporting an explicitly selected one-million-context variant. Provider metadata is authoritative when present, and catalog values remain the fallback when metadata is absent.

## Test plan

- [x] focused gateway model-discovery coverage, including bounded normal windows and larger optional capacity
- [x] core unit suite: 265 passed, 2 skipped, 0 failed
- [x] typecheck
- [x] production asset build
- [x] whitespace validation
- [x] secret scan
- [ ] full main suite: 416 passed and 5 skipped; one unrelated observability bounded-heap assertion failed under Node 24.18.0 because its generated body did not exceed the reported heap limit
