### PR TITLE
fix(gateway):网关对子代理模型配置的处理，并规范化 Responses API 请求(@the-next-ai/ai-gateway 升级到 1.0.10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@the-next-ai/ai-gateway": "^1.0.9",
+        "@the-next-ai/ai-gateway": "^1.0.10",
         "@the-next-ai/bot-gateway-sdk": "^0.1.0",
         "better-sqlite3": "^12.11.1",
         "electron-updater": "^6.8.9",
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/@the-next-ai/ai-gateway": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@the-next-ai/ai-gateway/-/ai-gateway-1.0.9.tgz",
-      "integrity": "sha512-/nt/1ZciUgarfyJW6itfDIgKMa8HOgmt0RyPyvmUCDcbJGEEl0BNmd85Zz5boSwT70xcjNojds9DPsQXG7N+sQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@the-next-ai/ai-gateway/-/ai-gateway-1.0.10.tgz",
+      "integrity": "sha512-7jarwmnIAUqkPIZgSFCCNAXN52CofQD+oUa3uMaBmkLcOLf61vCNgD7kipo25MSE08795Dz7FcS1+nF5rIRiNQ==",
       "license": "MIT",
       "dependencies": {
         "diff": "^8.0.3",
@@ -9545,7 +9545,7 @@
       "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
-        "@the-next-ai/ai-gateway": "^1.0.9",
+        "@the-next-ai/ai-gateway": "^1.0.10",
         "@the-next-ai/bot-gateway-sdk": "^0.1.0",
         "better-sqlite3": "^12.11.1",
         "node-forge": "^1.4.0",
@@ -9562,7 +9562,7 @@
       "name": "@claude-code-router/core",
       "version": "3.0.6",
       "dependencies": {
-        "@the-next-ai/ai-gateway": "^1.0.9",
+        "@the-next-ai/ai-gateway": "^1.0.10",
         "@the-next-ai/bot-gateway-sdk": "^0.1.0",
         "better-sqlite3": "^12.11.1",
         "node-forge": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rebuild:sqlite3": "electron-rebuild -f -w better-sqlite3"
   },
   "dependencies": {
-    "@the-next-ai/ai-gateway": "^1.0.9",
+    "@the-next-ai/ai-gateway": "^1.0.10",
     "@the-next-ai/bot-gateway-sdk": "^0.1.0",
     "better-sqlite3": "^12.11.1",
     "electron-updater": "^6.8.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "test:integration": "node ../../build/test.mjs cli --scope integration && node ../../build/run-tests.mjs cli"
   },
   "dependencies": {
-    "@the-next-ai/ai-gateway": "^1.0.9",
+    "@the-next-ai/ai-gateway": "^1.0.10",
     "@the-next-ai/bot-gateway-sdk": "^0.1.0",
     "better-sqlite3": "^12.11.1",
     "node-forge": "^1.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "test:integration": "node ../../build/test.mjs core --scope integration && node ../../build/run-tests.mjs core"
   },
   "dependencies": {
-    "@the-next-ai/ai-gateway": "^1.0.9",
+    "@the-next-ai/ai-gateway": "^1.0.10",
     "@the-next-ai/bot-gateway-sdk": "^0.1.0",
     "better-sqlite3": "^12.11.1",
     "node-forge": "^1.4.0",

--- a/packages/core/src/gateway/claude-code-router-plugin.ts
+++ b/packages/core/src/gateway/claude-code-router-plugin.ts
@@ -66,7 +66,7 @@ export class ClaudeCodeRouterPlugin {
       enrich: (matchedRequest) => {
         injectClaudeCodeAgentToolDescription(matchedRequest.body, this.config);
         injectClaudeCodeToolHubInstructions(matchedRequest.body, this.config);
-        removeClaudeCodeBillingSystemHeader(matchedRequest.body);
+        matchedRequest.builtInClaudeCodeSubagent = removeClaudeCodeBillingSystemHeader(matchedRequest.body);
         matchedRequest.builtInSubagentModel = extractAndRemoveClaudeCodeSubagentModelTag(matchedRequest.body);
       },
       id: "claude-code",
@@ -268,6 +268,13 @@ function resolveConfiguredRouteDecision(
   const requestedModel = readString(request.body.model);
   const explicitModel = normalizeRouteSelector(requestedModel);
   const builtInDecision = resolveBuiltInAgentRouteDecision(request, config, compiled.modelRegistry, compiled.fallback);
+  const subagentEnvDecision = resolveBuiltInClaudeCodeSubagentEnvRouteDecision(
+    request,
+    config,
+    compiled.modelRegistry,
+    compiled.fallback
+  );
+  const builtInRuleBaseDecision = subagentEnvDecision ?? builtInDecision;
   const policies: Array<RoutePolicy<MutableRequestLike, ConfiguredRouteDecision>> = [
     {
       evaluate: () => customModel
@@ -293,12 +300,16 @@ function resolveConfiguredRouteDecision(
     ...compiled.rules.map((rule): RoutePolicy<MutableRequestLike, ConfiguredRouteDecision> => ({
       evaluate: (context) => {
         const decision = resolveRouterRule(rule, context, compiled.fallback);
-        return decision && builtInDecision
-          ? mergeConfiguredRouteDecisions(builtInDecision, decision)
+        return decision && builtInRuleBaseDecision
+          ? mergeConfiguredRouteDecisions(builtInRuleBaseDecision, decision)
           : decision;
       },
       id: `rule:${rule.rule.id}`
     })),
+    {
+      evaluate: () => subagentEnvDecision,
+      id: "builtin-agent-claude-code-subagent-env"
+    },
     {
       evaluate: () => builtInDecision,
       id: builtInDecision ? builtInAgentPolicyId(builtInDecision) : "builtin-agent"
@@ -373,6 +384,57 @@ function resolveBuiltInClaudeCodeSubagentRouteDecision(
     rewrites: [],
     source: "subagent",
   };
+}
+
+function resolveBuiltInClaudeCodeSubagentEnvRouteDecision(
+  request: MutableRequestLike,
+  config: AppConfig,
+  modelRegistry: ModelRegistry,
+  fallback: RouterFallbackConfig
+): ConfiguredRouteDecision | undefined {
+  if (!builtInAgentRouteMatches(request, config, "claude-code")) {
+    return undefined;
+  }
+  if (request.builtInClaudeCodeSubagent !== true) {
+    return undefined;
+  }
+  const profile = resolveAuthenticatedProfile(request, config, "claude-code");
+  const configuredTarget = resolveConfiguredClaudeCodeModel(
+    profile?.env?.[claudeCodeSubagentModelEnv],
+    config,
+    modelRegistry
+  );
+  const requestedTarget = resolveConfiguredClaudeCodeModel(
+    readString(request.body.model),
+    config,
+    modelRegistry
+  );
+  if (
+    !configuredTarget ||
+    !requestedTarget ||
+    configuredTarget.canonicalSelector.toLowerCase() !== requestedTarget.canonicalSelector.toLowerCase()
+  ) {
+    return undefined;
+  }
+  return {
+    fallback,
+    model: configuredTarget,
+    reason: "builtin:claude-code-subagent-env",
+    rewrites: [],
+    source: "subagent"
+  };
+}
+
+function resolveConfiguredClaudeCodeModel(
+  selector: string | undefined,
+  config: AppConfig,
+  modelRegistry: ModelRegistry
+): RouteModelRef | undefined {
+  const target = normalizeRouteSelector(selector);
+  const discoveredTarget = target
+    ? resolveClaudeAppGatewayRouteModel(target, config, claudeAppGatewayModelRouteOptions)
+    : undefined;
+  return modelRegistry.resolve(discoveredTarget ?? target);
 }
 
 function resolveBuiltInAgentRouteDecision(
@@ -508,6 +570,7 @@ const ccrSubagentModelCloseTag = "</CCR-SUBAGENT-MODEL>";
 const ccrSubagentModelTagExample = `${ccrSubagentModelOpenTag}Provider/model${ccrSubagentModelCloseTag}`;
 const ccrSubagentModelPlaceholder = "provider/model";
 const claudeCodeBillingSystemHeaderPrefix = "x-anthropic-billing-header";
+const claudeCodeSubagentModelEnv = "CLAUDE_CODE_SUBAGENT_MODEL";
 const ccrSubagentToolModelInstruction =
   `CCR subagent routing is enabled. When calling this tool, the prompt parameter MUST start with ` +
   `${ccrSubagentModelTagExample} on its own first line, replacing Provider/model with the best client model ID from the list below. ` +
@@ -796,10 +859,10 @@ function compareCodeUnitStrings(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
-function removeClaudeCodeBillingSystemHeader(body: Record<string, unknown>): void {
+function removeClaudeCodeBillingSystemHeader(body: Record<string, unknown>): boolean {
   const system = body.system;
   if (!Array.isArray(system) || system.length === 0) {
-    return;
+    return false;
   }
   const firstBlock = system[0];
   const firstText = typeof firstBlock === "string"
@@ -808,12 +871,45 @@ function removeClaudeCodeBillingSystemHeader(body: Record<string, unknown>): voi
       ? firstBlock.text
       : undefined;
   if (!firstText?.startsWith(claudeCodeBillingSystemHeaderPrefix)) {
-    return;
+    return false;
   }
+  const isSubagent = claudeCodeBillingMetadataIsSubagent(firstText);
   system.shift();
   if (system.length === 0) {
     delete body.system;
   }
+  return isSubagent;
+}
+
+function claudeCodeBillingMetadataIsSubagent(text: string): boolean {
+  const prefix = `${claudeCodeBillingSystemHeaderPrefix}:`;
+  if (!text.startsWith(prefix)) {
+    return false;
+  }
+  const payload = text.slice(prefix.length).trim();
+  if (!payload) {
+    return false;
+  }
+  if (payload.startsWith("{")) {
+    try {
+      const metadata = JSON.parse(payload) as unknown;
+      return isRecord(metadata) && metadata.cc_is_subagent === true;
+    } catch {
+      return false;
+    }
+  }
+  const values = payload
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .flatMap((part) => {
+      const separator = part.indexOf("=");
+      if (separator < 0 || part.slice(0, separator).trim() !== "cc_is_subagent") {
+        return [];
+      }
+      return [part.slice(separator + 1).trim()];
+    });
+  return values.length === 1 && values[0] === "true";
 }
 
 function extractAndRemoveClaudeCodeSubagentModelTag(body: Record<string, unknown>): string | undefined {

--- a/packages/core/src/gateway/core-runtime/config-compiler.ts
+++ b/packages/core/src/gateway/core-runtime/config-compiler.ts
@@ -475,7 +475,7 @@ function withCodexBackendRequestTransform(request: unknown): Record<string, unkn
     : [];
   return {
     ...currentRequest,
-    bodyRemove: uniqueStrings([...bodyRemove, "max_output_tokens"])
+    bodyRemove: uniqueStrings([...bodyRemove, "max_output_tokens", "stop"])
   };
 }
 

--- a/packages/core/src/routing/contracts.ts
+++ b/packages/core/src/routing/contracts.ts
@@ -44,6 +44,7 @@ export type RouteDecision = {
 };
 
 export type RouteRequest = {
+  builtInClaudeCodeSubagent?: boolean;
   builtInSubagentModel?: string;
   body: Record<string, unknown>;
   headers: Record<string, string | string[] | undefined>;

--- a/packages/core/test/unit/gateway/gateway-billing-sync.test.mjs
+++ b/packages/core/test/unit/gateway/gateway-billing-sync.test.mjs
@@ -42,3 +42,26 @@ test("core gateway disables the full-trace billing webhook without disabling raw
     }
   }
 });
+
+test("Codex OAuth providers remove unsupported Responses request fields", async () => {
+  const config = createDefaultAppConfig({ generatedConfigFile: "/tmp/ccr-generated-config.json" });
+  config.providerPlugins = [{
+    codexOauth: {},
+    enabled: true,
+    key: "ccr-local-agent-codex-oauth-test",
+    providerName: "Codex API::openai_responses",
+    request: {
+      bodyRemove: ["custom-field"]
+    }
+  }];
+
+  const compiled = await compileCoreGatewayConfig(
+    config,
+    "raw-trace-token",
+    "billing-usage-token",
+    "core-auth-token"
+  );
+  const plugin = compiled.providerPlugins.find((item) => item.key === "ccr-local-agent-codex-oauth-test");
+
+  assert.deepEqual(plugin.request.bodyRemove, ["custom-field", "max_output_tokens", "stop"]);
+});

--- a/packages/core/test/unit/gateway/router-builtins.test.mjs
+++ b/packages/core/test/unit/gateway/router-builtins.test.mjs
@@ -1841,6 +1841,464 @@ test("disabled built-in Claude Code route does not inject Agent tool instruction
   assert.equal(tool.input_schema.properties.prompt.description, "Task prompt.");
 });
 
+function createClaudeCodeSubagentEnvPlugin(options = {}) {
+  const subagentModel = Object.hasOwn(options, "subagentModel")
+    ? options.subagentModel
+    : "DeepSeek,deepseek-v4-flash";
+  return createRouterPlugin({
+    customRouterPath: options.customRouterPath,
+    profiles: [
+      {
+        agent: "claude-code",
+        enabled: true,
+        env: subagentModel === undefined ? {} : { CLAUDE_CODE_SUBAGENT_MODEL: subagentModel },
+        id: "claude-code-profile",
+        model: options.profileModel ?? "Codex API/gpt-5.6-sol",
+        name: "Claude Code",
+        scope: "global"
+      }
+    ],
+    providers: options.providers ?? [
+      {
+        models: ["gpt-5.6-sol"],
+        name: "Codex API",
+        type: "openai_responses"
+      },
+      {
+        models: ["deepseek-v4-flash", "deepseek-v4-pro"],
+        name: "DeepSeek",
+        type: "openai_chat_completions"
+      }
+    ],
+    routerRules: options.routerRules
+  });
+}
+
+function claudeCodeBillingSystem(isSubagent = true) {
+  return [
+    {
+      text: `x-anthropic-billing-header: cc_version=2.1.207; cc_entrypoint=cli; cc_is_subagent=${isSubagent};`,
+      type: "text"
+    }
+  ];
+}
+
+test("built-in Claude Code subagent route honors the authenticated profile subagent model", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const traceRecorder = new RequestRouteTraceRecorder(Date.now());
+  traceRecorder.captureIngress();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek,deepseek-v4-flash",
+      system: claudeCodeBillingSystem()
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    trace: traceRecorder,
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "DeepSeek/deepseek-v4-flash");
+  assert.equal("system" in result.body, false);
+  assert.equal(result.decision.model, "DeepSeek/deepseek-v4-flash");
+  assert.equal(result.decision.reason, "builtin:claude-code-subagent-env");
+  assert.equal(result.decision.source, "subagent");
+  const routeDecision = traceRecorder.finish().hops.find((hop) =>
+    hop.name === "builtins.builtin-agent-claude-code-subagent-env"
+  );
+  assert.equal(routeDecision?.decision?.policyId, "builtin-agent-claude-code-subagent-env");
+  assert.deepEqual(routeDecision?.changes, [{
+    after: "DeepSeek/deepseek-v4-flash",
+    before: "DeepSeek,deepseek-v4-flash",
+    operation: "replace",
+    path: "/body/model",
+    scope: "body"
+  }]);
+});
+
+test("built-in Claude Code main route does not trust the configured subagent body model", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash"
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal(result.decision.reason, "builtin:claude-code");
+});
+
+test("built-in Claude Code subagent env route requires a true billing marker", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: claudeCodeBillingSystem(false)
+    },
+    headers: {
+      "user-agent": "Claude Code",
+      "x-claude-code-agent-id": "agent-123"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal("system" in result.body, false);
+  assert.equal(result.decision.reason, "builtin:claude-code");
+});
+
+test("built-in Claude Code subagent env route does not trust agent-id without billing metadata", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash"
+    },
+    headers: {
+      "user-agent": "Claude Code",
+      "x-claude-code-agent-id": "agent-123"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal(result.decision.reason, "builtin:claude-code");
+});
+
+test("built-in Claude Code subagent env route requires the request and profile models to agree", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-pro",
+      system: claudeCodeBillingSystem()
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal(result.decision.reason, "builtin:claude-code");
+});
+
+test("built-in Claude Code subagent env route ignores an unconfigured profile model", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin({ subagentModel: "Missing/missing-model" });
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "Missing/missing-model",
+      system: claudeCodeBillingSystem()
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal(result.decision.reason, "builtin:claude-code");
+});
+
+test("built-in Claude Code subagent model tag stays ahead of the profile subagent env", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: [
+        ...claudeCodeBillingSystem(),
+        {
+          text: "<CCR-SUBAGENT-MODEL>DeepSeek/deepseek-v4-pro</CCR-SUBAGENT-MODEL>",
+          type: "text"
+        }
+      ]
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "DeepSeek/deepseek-v4-pro");
+  assert.equal(result.decision.reason, "builtin:claude-code-subagent");
+});
+
+test("router rules stay ahead of the Claude Code profile subagent env", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin({
+    routerRules: [
+      {
+        condition: {
+          left: "request.url",
+          operator: "contains",
+          right: "/v1"
+        },
+        enabled: true,
+        id: "subagent-override",
+        name: "Subagent override",
+        rewrites: [
+          { key: "request.body.model", operation: "set", value: "DeepSeek/deepseek-v4-pro" }
+        ],
+        type: "condition"
+      }
+    ]
+  });
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: claudeCodeBillingSystem()
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "DeepSeek/deepseek-v4-pro");
+  assert.equal(result.decision.reason, "rule:subagent-override");
+});
+
+test("non-model router rules preserve the Claude Code profile subagent env model", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin({
+    routerRules: [
+      {
+        condition: {
+          left: "request.url",
+          operator: "contains",
+          right: "/v1"
+        },
+        enabled: true,
+        id: "subagent-header",
+        name: "Subagent header",
+        rewrites: [
+          { key: "request.header.x-subagent-route", operation: "set", value: "matched" }
+        ],
+        type: "condition"
+      }
+    ]
+  });
+  const headers = {
+    "user-agent": "Claude Code"
+  };
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: claudeCodeBillingSystem()
+    },
+    headers,
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(headers["x-subagent-route"], "matched");
+  assert.equal(result.body.model, "DeepSeek/deepseek-v4-flash");
+  assert.equal(result.decision.reason, "rule:subagent-header");
+});
+
+test("built-in Claude Code subagent env route uses the authenticated profile only", async () => {
+  const profiles = [
+    {
+      agent: "claude-code",
+      enabled: true,
+      env: { CLAUDE_CODE_SUBAGENT_MODEL: "DeepSeek/deepseek-v4-pro" },
+      id: "profile-a",
+      model: "Codex API/gpt-5.6-sol",
+      name: "Claude Code A",
+      scope: "global"
+    },
+    {
+      agent: "claude-code",
+      enabled: true,
+      env: { CLAUDE_CODE_SUBAGENT_MODEL: "DeepSeek/deepseek-v4-flash" },
+      id: "profile-b",
+      model: "Codex API/gpt-5.6-sol",
+      name: "Claude Code B",
+      scope: "global"
+    }
+  ];
+  const plugin = createRouterPlugin({
+    authenticatedProfileId: "profile-b",
+    profiles,
+    providers: [
+      {
+        models: ["gpt-5.6-sol"],
+        name: "Codex API",
+        type: "openai_responses"
+      },
+      {
+        models: ["deepseek-v4-flash", "deepseek-v4-pro"],
+        name: "DeepSeek",
+        type: "openai_chat_completions"
+      }
+    ]
+  });
+  const selected = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: claudeCodeBillingSystem()
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+  const rejected = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-pro",
+      system: claudeCodeBillingSystem()
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(selected.body.model, "DeepSeek/deepseek-v4-flash");
+  assert.equal(selected.decision.reason, "builtin:claude-code-subagent-env");
+  assert.equal(rejected.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal(rejected.decision.reason, "builtin:claude-code");
+});
+
+test("built-in Claude Code subagent env route accepts legacy JSON billing metadata", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: [
+        {
+          text: "x-anthropic-billing-header: {\"cc_is_subagent\":true}",
+          type: "text"
+        }
+      ]
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "DeepSeek/deepseek-v4-flash");
+  assert.equal(result.decision.reason, "builtin:claude-code-subagent-env");
+});
+
+test("built-in Claude Code subagent env route accepts client-visible discovery model IDs", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const encodedModel = Buffer.from("DeepSeek/deepseek-v4-flash", "utf8").toString("hex");
+  const clientModel = `anthropic/claude-ccr-h${encodedModel}`;
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: clientModel,
+      system: claudeCodeBillingSystem()
+    },
+    headers: {
+      "user-agent": "claude-cli/2.1.207 (external, cli)"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "DeepSeek/deepseek-v4-flash");
+  assert.equal(result.decision.reason, "builtin:claude-code-subagent-env");
+});
+
+test("built-in Claude Code subagent env route rejects ambiguous billing metadata", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: [
+        {
+          text: "x-anthropic-billing-header: cc_is_subagent=true; cc_is_subagent=false;",
+          type: "text"
+        }
+      ]
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal(result.decision.reason, "builtin:claude-code");
+});
+
+test("built-in Claude Code subagent env route ignores billing metadata outside the first system block", async () => {
+  const plugin = createClaudeCodeSubagentEnvPlugin();
+  const result = await plugin.routeRequest({
+    body: {
+      messages: [],
+      model: "DeepSeek/deepseek-v4-flash",
+      system: [
+        { text: "Normal system instruction.", type: "text" },
+        ...claudeCodeBillingSystem()
+      ]
+    },
+    headers: {
+      "user-agent": "Claude Code"
+    },
+    method: "POST",
+    url: "/v1/messages"
+  });
+
+  assert.equal(result.body.model, "Codex API/gpt-5.6-sol");
+  assert.equal(result.decision.reason, "builtin:claude-code");
+});
+
+test("custom router stays ahead of the Claude Code profile subagent env", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "ccr-subagent-env-custom-router-"));
+  try {
+    const customRouterPath = path.join(dir, "router.cjs");
+    writeFileSync(customRouterPath, 'module.exports = () => "DeepSeek/deepseek-v4-pro";\n');
+    const plugin = createClaudeCodeSubagentEnvPlugin({ customRouterPath });
+    const result = await plugin.routeRequest({
+      body: {
+        messages: [],
+        model: "DeepSeek/deepseek-v4-flash",
+        system: claudeCodeBillingSystem()
+      },
+      headers: {
+        "user-agent": "Claude Code"
+      },
+      method: "POST",
+      url: "/v1/messages"
+    });
+
+    assert.equal(result.body.model, "DeepSeek/deepseek-v4-pro");
+    assert.equal(result.decision.reason, "custom-router");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("built-in Claude Code subagent route uses model tag from system", async () => {
   const plugin = createRouterPlugin({ profileModel: "Provider/claude-sonnet" });
   const result = await plugin.routeRequest({


### PR DESCRIPTION
## 解决的问题

此 PR 主要解决两个问题。

### 1. 子代理模型配置没有生效

Claude Code 在启动子代理时，会通过 `CLAUDE_CODE_SUBAGENT_MODEL` 指定子代理使用的模型。

CCR 原本能够收到这个模型信息，但后续的 Profile 路由又把它覆盖成了主模型，导致主代理和子代理最终仍然使用同一个模型。

<p align="center"><strong>子代理模型配置已正确生效</strong></p>
<p align="center">
  <img
    src="https://github.com/user-attachments/assets/eb1e381e-ea92-4ade-a873-dfeb2f2364dc"
    alt="image"
    width="500"
  />
</p>

修复后：

* 普通请求继续使用 Profile 主模型；
* 确认是 Claude Code 子代理请求时，优先使用 `CLAUDE_CODE_SUBAGENT_MODEL`；
* 配置的模型不存在或无法识别时，自动回退到原来的 Profile 主模型。

<p align="center"><strong>子代理实际调用的模型</strong></p>
<p align="center">
  <img
    src="https://github.com/user-attachments/assets/3fdb4bdf-ffe2-4c2d-883f-63064a787537"
    alt="image"
    width="500"
  />
</p>


### 2. 新版 Claude Code 请求可能导致 400，需要将 `@the-next-ai/ai-gateway` 升级到 `1.0.10`

Claude Code 2.1.207 开始在请求中加入 `output_config` 和 `effort` 等字段。

旧版 `ai-gateway` 会把部分字段直接传给上游，但有些 Responses Provider 并不支持这些参数，因此可能返回 HTTP 400。

这个 PR 将 `@the-next-ai/ai-gateway` 升级到 `1.0.10`，并在 Codex OAuth Responses 请求中去掉上游不支持的：

* `stop`
* `max_output_tokens`

## 子代理识别方式

为了避免普通请求通过伪造 `model` 或 `agent-id` 随意切换模型，只有同时满足以下条件时，CCR 才会使用子代理模型：

* 请求来自已经配置好的 Claude Code Profile；
* Claude Code 的 system 信息中明确标记这是子代理请求；
* `CLAUDE_CODE_SUBAGENT_MODEL` 配置的模型能够在 CCR 中正常找到。

不满足这些条件时，仍然沿用原有的 Profile 路由，不改变现有行为。

## 验证

已完成以下检查：

* 66 项网关和路由相关测试通过；
* `npm run typecheck` 通过；
* `npm run build:assets` 通过；
* 在 Electron 中使用真实 Claude Code Agent 请求测试，子代理能够正确路由到指定模型；
* Git 差异格式检查和敏感信息扫描通过。
