### PR TITLE
fix(ui): 修复更新入口自动触发下载

### DIFF
--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -36,7 +36,7 @@ import {
 } from "./shared/index";
 import { startVisiblePolling } from "./shared/polling";
 import {
-  AppDialogStack, LightToast, MainLayout, OnboardingLayout
+  AppDialogStack, LightToast, MainLayout, OnboardingLayout, shouldCheckForUpdateOnOpen
 } from "./components/index";
 
 type ProfileOpenDialogState = {
@@ -893,20 +893,9 @@ function App() {
   function openSidebarUpdateDialog() {
     setUpdateDialogOpen(true);
     setUpdateActionError("");
-    if (updateDialogStatus.canDownload || updateDialogStatus.state === "available") {
-      void downloadAppUpdate();
-      return;
+    if (shouldCheckForUpdateOnOpen(updateDialogStatus)) {
+      void checkForAppUpdate();
     }
-    if (
-      updateDialogStatus.canInstall ||
-      updateDialogStatus.state === "checking" ||
-      updateDialogStatus.state === "downloading" ||
-      updateDialogStatus.state === "downloaded" ||
-      updateDialogStatus.state === "installing"
-    ) {
-      return;
-    }
-    void checkForAppUpdate();
   }
 
   async function checkForAppUpdate() {

--- a/packages/ui/src/pages/home/components/index.ts
+++ b/packages/ui/src/pages/home/components/index.ts
@@ -1,9 +1,9 @@
 export { OnboardingView } from "./onboarding";
 export { LightToast } from "./feedback";
 export { AppDialogStack } from "./dialog-stack";
-export { MainLayout, OnboardingLayout } from "./layout";
+export { MainLayout, OnboardingLayout, UpdateEntryButton } from "./layout";
 export { AppSettingsDialog } from "./settings";
-export { UpdateDialog } from "./update";
+export { shouldCheckForUpdateOnOpen, UpdateDialog } from "./update";
 export { OverviewView, AgentAnalysisView } from "./dashboard";
 export { ApiKeysView, AddApiKeyDialog, EditApiKeyDialog } from "./api-keys";
 export { ProfileView, AddProfileForm, AddProfileDialog, DeleteProfileDialog } from "./profiles";

--- a/packages/ui/src/pages/home/components/layout.tsx
+++ b/packages/ui/src/pages/home/components/layout.tsx
@@ -3,7 +3,7 @@ import { MorphIcon } from "@musistudio/lucide-morph-react";
 import { collapseSidebarToExpandInspectorMorph } from "@/lib/morph-icon";
 import {
   AnimatePresence, AppConfig, AppCopy, Button, Check, CircleAlert, cn, EndpointTitleBar,
-  AppUpdateStatus, Download, GatewayStatus, listSpringTransition, LucideIcon, motion, motionEase,
+  AppUpdateStatus, GatewayStatus, listSpringTransition, LucideIcon, motion, motionEase,
   LoaderCircle, NavigationId, RefreshCw,
   reducedMotionTransition, ServiceControlButton, Settings, ViewId,
   useAppText, ViewMotionShell, viewUsesInternalScroll
@@ -116,21 +116,6 @@ export function MainLayout({
   const windowControlSafeAreaWidth = showUpdateButton
     ? (isMac ? 188 : 124)
     : (isMac ? 152 : 88);
-  const updateBusy =
-    updateActionBusy ||
-    updateStatus.state === "checking" ||
-    updateStatus.state === "downloading" ||
-    updateStatus.state === "installing";
-  const updateLabel = updateStatus.state === "downloaded"
-    ? copy.text["Update ready to install"] ?? "Update ready to install"
-    : updateStatus.state === "downloading"
-      ? copy.text["Downloading update"] ?? "Downloading update"
-      : updateStatus.state === "checking"
-        ? copy.text["Checking for updates"] ?? "Checking for updates"
-        : updateStatus.state === "available"
-          ? copy.text["Download update"] ?? "Download update"
-          : copy.text["Check for updates"] ?? "Check for updates";
-
   return (
     <>
       <div className={cn(
@@ -164,25 +149,12 @@ export function MainLayout({
           targetActive={gatewayTargetActive}
         />
         {showUpdateButton ? (
-          <Button
-            aria-label={updateLabel}
-            className="app-no-drag inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent bg-transparent p-0 text-primary outline-none transition-colors hover:bg-primary/10 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/25"
-            onMouseDown={(event) => event.stopPropagation()}
-            onClick={onOpenUpdate}
-            title={updateLabel}
-            type="button"
-            unstyled
-          >
-            {updateBusy ? (
-              <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-            ) : updateStatus.state === "downloaded" ? (
-              <Check className="h-3.5 w-3.5" />
-            ) : updateStatus.state === "available" ? (
-              <Download className="h-3.5 w-3.5" />
-            ) : (
-              <RefreshCw className="h-3.5 w-3.5" />
-            )}
-          </Button>
+          <UpdateEntryButton
+            actionBusy={updateActionBusy}
+            copy={copy}
+            onOpen={onOpenUpdate}
+            status={updateStatus}
+          />
         ) : null}
       </div>
 
@@ -301,6 +273,56 @@ export function MainLayout({
         </div>
       </main>
     </>
+  );
+}
+
+export function UpdateEntryButton({
+  actionBusy,
+  copy,
+  onOpen,
+  status
+}: {
+  actionBusy: boolean;
+  copy: AppCopy;
+  onOpen: () => void;
+  status: AppUpdateStatus;
+}) {
+  const busy = actionBusy || status.state === "checking" || status.state === "downloading" || status.state === "installing";
+  const label = status.state === "downloaded"
+    ? copy.text["Update ready to install"] ?? "Update ready to install"
+    : status.state === "downloading"
+      ? copy.text["Downloading update"] ?? "Downloading update"
+      : status.state === "checking"
+        ? copy.text["Checking for updates"] ?? "Checking for updates"
+        : status.state === "available"
+          ? copy.text["Update available"] ?? "Update available"
+          : copy.text["Online updates"] ?? "Online updates";
+
+  return (
+    <Button
+      aria-label={label}
+      className="app-no-drag relative inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent bg-transparent p-0 text-primary outline-none transition-colors hover:bg-primary/10 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/25"
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={onOpen}
+      title={label}
+      type="button"
+      unstyled
+    >
+      {busy ? (
+        <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+      ) : status.state === "downloaded" ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <RefreshCw className="h-3.5 w-3.5" />
+      )}
+      {status.state === "available" ? (
+        <span
+          aria-hidden="true"
+          className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-amber-500 ring-2 ring-background"
+          data-update-available-indicator
+        />
+      ) : null}
+    </Button>
   );
 }
 

--- a/packages/ui/src/pages/home/components/update.tsx
+++ b/packages/ui/src/pages/home/components/update.tsx
@@ -5,6 +5,10 @@ import {
 
 export type UpdateActionBusy = "" | "check" | "download" | "install";
 
+export function shouldCheckForUpdateOnOpen(status: AppUpdateStatus): boolean {
+  return status.state === "idle" || status.state === "not-available" || status.state === "error";
+}
+
 export function UpdateDialog({
   actionBusy,
   actionError,

--- a/packages/ui/test/component/layout.test.tsx
+++ b/packages/ui/test/component/layout.test.tsx
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { GatewayStartupErrorBanner } from "@ccr/ui/pages/home/components/layout.tsx";
+import { GatewayStartupErrorBanner, UpdateEntryButton } from "@ccr/ui/pages/home/components/layout.tsx";
 import { AppI18nContext, appCopy } from "@ccr/ui/pages/home/shared/i18n.tsx";
+import { fallbackUpdateStatus } from "@ccr/ui/pages/home/shared/fallbacks.ts";
+import { shouldCheckForUpdateOnOpen } from "@ccr/ui/pages/home/components/update.tsx";
 
 test("GatewayStartupErrorBanner renders startup failure details", () => {
   const html = renderToStaticMarkup(
@@ -23,4 +25,35 @@ test("GatewayStartupErrorBanner stays hidden without a failure message", () => {
   const html = renderToStaticMarkup(<GatewayStartupErrorBanner message="" />);
 
   assert.equal(html, "");
+});
+
+test("UpdateEntryButton keeps update-center semantics when an update is available", () => {
+  const html = renderToStaticMarkup(
+    <UpdateEntryButton
+      actionBusy={false}
+      copy={appCopy.en}
+      onOpen={() => undefined}
+      status={{
+        ...fallbackUpdateStatus,
+        availableVersion: "3.0.15",
+        canDownload: true,
+        state: "available",
+        supported: true
+      }}
+    />
+  );
+
+  assert.match(html, /aria-label="Update available"/);
+  assert.match(html, /lucide-refresh-cw/);
+  assert.match(html, /data-update-available-indicator/);
+  assert.doesNotMatch(html, /lucide-download/);
+});
+
+test("opening the update entry only checks when the status is not already actionable", () => {
+  for (const state of ["idle", "not-available", "error"] as const) {
+    assert.equal(shouldCheckForUpdateOnOpen({ ...fallbackUpdateStatus, state }), true, state);
+  }
+  for (const state of ["checking", "available", "downloading", "downloaded", "installing"] as const) {
+    assert.equal(shouldCheckForUpdateOnOpen({ ...fallbackUpdateStatus, state }), false, state);
+  }
 });


### PR DESCRIPTION
## 修改说明

- 左上角更新按钮始终作为“更新检查”入口，不再在发现新版本后变成直接下载入口
- 修复点击更新入口时自动开始下载的问题，下载与安装操作继续由用户在更新弹窗中明确确认
- 检测到新版本时保留更新图标，并增加琥珀色状态提示圆点
- 增加更新入口视觉状态及不同更新状态下检查行为的回归测试

## 界面效果

### 修复前：更新入口变为下载按钮

<p align="center">
  <img src="https://github.com/user-attachments/assets/8fd673f1-5e2c-4f3f-904f-1e472a23b6c8" alt="修复前：检测到更新后入口显示为下载按钮" width="760" />
</p>

### 修复后：保留更新入口并提示有新版本

<p align="center">
  <img src="https://github.com/user-attachments/assets/b1728c1d-9232-4251-9e0b-d1308afe4840" alt="修复后：更新入口保留并显示新版本提示" width="760" />
</p>

### 更新弹窗：由用户明确确认下载

<p align="center">
  <img src="https://github.com/user-attachments/assets/9c6670e4-56b1-405a-90da-bacdf1524a9f" alt="更新弹窗：下载操作保留在弹窗内" width="411" />
</p>

## 测试情况

- [x] TypeScript 类型检查：`npm run typecheck`
- [x] 更新入口回归测试：4 项全部通过
- [x] 验证发现新版本后仍显示更新入口和状态提示圆点
- [x] 验证点击更新入口只打开弹窗，不自动请求更新安装包
- [x] 验证下载操作仍需在更新弹窗中明确触发

