### PR TITLE
fix(opencode): stop forcing Bearer public on public local-agent imports

### DIFF
--- a/packages/core/src/agents/local-providers/opencode.ts
+++ b/packages/core/src/agents/local-providers/opencode.ts
@@ -141,13 +141,26 @@ export function importOpenCodeProvider(
   if (publicOnly && !candidate.models.every((model) => catalog.models[protocol].includes(model))) {
     throw new Error("OpenCode CLI public models were not found.");
   }
-  const apiKey = credential?.apiKey || "public";
-  const authSuffix = `opencode-${candidate.protocol.replaceAll("_", "-")}-api-key`;
   const provider = providerPayload(
     candidate,
     uniqueProviderName(providerNames, candidate.name),
     catalog.baseUrl
   );
+  if (publicOnly) {
+    return {
+      candidate,
+      provider: {
+        ...provider,
+        apiKey: "public"
+      },
+      providerPlugins: []
+    };
+  }
+  const apiKey = credential?.apiKey;
+  if (!apiKey) {
+    throw new Error("OpenCode CLI API key was not found.");
+  }
+  const authSuffix = `opencode-${candidate.protocol.replaceAll("_", "-")}-api-key`;
   return {
     candidate,
     provider,

--- a/packages/core/test/unit/agents/local-agent-provider-opencode.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-opencode.test.mjs
@@ -172,12 +172,14 @@ test("OpenCode local provider imports public free models without a login", async
     assert.ok(available.every((candidate) => candidate.detail.includes("No login is required")));
 
     const chatResult = importOpenCodeProvider(candidateForProtocol(candidates, "openai_chat_completions"), []);
-    assert.equal(chatResult.providerPlugins[0].auth.headers.authorization, "Bearer public");
+    assert.deepEqual(chatResult.providerPlugins, []);
+    assert.equal(chatResult.provider.apiKey, "public");
     assert.deepEqual(chatResult.provider.models, ["chat-free"]);
     assert.equal(chatResult.provider.account, undefined);
 
     const anthropicResult = importOpenCodeProvider(candidateForProtocol(candidates, "anthropic_messages"), []);
-    assert.equal(anthropicResult.providerPlugins[0].auth.headers["x-api-key"], "public");
+    assert.deepEqual(anthropicResult.providerPlugins, []);
+    assert.equal(anthropicResult.provider.apiKey, "public");
   });
 });
 


### PR DESCRIPTION
## Summary
- Public OpenCode "Import Local Agent Provider" no longer writes `providerPlugins` auth with `authorization: "Bearer public"` / `strict: true`.
- The public token is stored on `Providers[].api_key` instead, so auth uses the normal credential path.
- Editing the provider to a real API key no longer gets overridden by a leftover placeholder plugin (which caused upstream 401s).
- Logged-in OpenCode imports still use real-credential `providerPlugins` as before.

## Test plan
- [x] `local-agent-provider-opencode` unit tests (7/7 pass)
- [ ] Import OpenCode Public (Chat Completions) with no login → provider `api_key` is `public`, no strict `providerPlugins` auth override
- [ ] Edit that provider's API key to a real key → upstream requests use the real key (no 401 from `Bearer public`)
- [ ] Import OpenCode with a real CLI login → still gets `providerPlugins` with the real key

Fixes #1562