### PR TITLE
fix(profiles): tolerate transient gateway resets

### DIFF
--- a/packages/core/src/profiles/launch-service.ts
+++ b/packages/core/src/profiles/launch-service.ts
@@ -397,7 +397,8 @@ async function ensureGatewayConfigRunning(
     }
     if (existingGateway.state === "unavailable") {
       if (!startIfMissing) {
-        throw new ProfileGatewayUnavailableError(`CCR gateway is not running at ${profileGatewayEndpoint(config)}. Start CCR Desktop or run ccr start before opening ${appName}.`);
+        const reason = existingGateway.reason ? `: ${existingGateway.reason}` : "";
+        throw new ProfileGatewayUnavailableError(`CCR gateway is not running at ${profileGatewayEndpoint(config)}${reason}. Start CCR Desktop or run ccr start before opening ${appName}.`);
       }
     } else {
       throw new Error(existingGatewayConflictMessage(existingGateway, appName));
@@ -437,24 +438,26 @@ type ExistingGatewayHttpProbe = {
   status?: number;
 };
 
+const existingGatewayFetchAttempts = 3;
+
 async function probeExistingProfileGateway(
   config: AppConfig,
   profile: ReturnType<typeof findProfileForOpen>,
   candidateConfig: AppConfig = config
 ): Promise<ExistingProfileGatewayProbe> {
   const endpoint = profileGatewayEndpoint(config);
-  const root = await fetchExistingGateway(endpoint, "/");
-  if (root.status === undefined) {
-    return { endpoint, reason: root.reason, state: "unavailable" };
-  }
-
-  let ccrGateway = isCcrGatewayRoot(root.payload);
+  const health = await fetchExistingGateway(endpoint, "/health");
+  let ccrGateway = isCcrGatewayHealth(health.payload);
+  let root: ExistingGatewayHttpProbe | undefined;
   if (!ccrGateway) {
-    const health = await fetchExistingGateway(endpoint, "/health");
-    ccrGateway = isCcrGatewayHealth(health.payload);
+    root = await fetchExistingGateway(endpoint, "/");
+    ccrGateway = isCcrGatewayRoot(root.payload);
   }
   if (!ccrGateway) {
-    return { endpoint, status: root.status, state: "not-ccr" };
+    if (health.status === undefined && root?.status === undefined) {
+      return { endpoint, reason: health.reason || root?.reason, state: "unavailable" };
+    }
+    return { endpoint, status: health.status ?? root?.status, state: "not-ccr" };
   }
 
   let lastUnauthorized: ExistingGatewayHttpProbe | undefined;
@@ -492,22 +495,26 @@ async function fetchExistingGateway(
   pathname: string,
   init: RequestInit = {}
 ): Promise<ExistingGatewayHttpProbe> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 1200);
-  try {
-    const response = await fetch(new URL(pathname, endpoint).toString(), {
-      ...init,
-      signal: controller.signal
-    });
-    return {
-      payload: await readResponseJson(response),
-      status: response.status
-    };
-  } catch (error) {
-    return { reason: formatError(error) };
-  } finally {
-    clearTimeout(timeout);
+  let reason: string | undefined;
+  for (let attempt = 0; attempt < existingGatewayFetchAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 1200);
+    try {
+      const response = await fetch(new URL(pathname, endpoint).toString(), {
+        ...init,
+        signal: controller.signal
+      });
+      return {
+        payload: await readResponseJson(response),
+        status: response.status
+      };
+    } catch (error) {
+      reason = formatError(error);
+    } finally {
+      clearTimeout(timeout);
+    }
   }
+  return { reason };
 }
 
 async function readResponseJson(response: Response): Promise<unknown> {

--- a/packages/core/test/unit/profiles/profile-gateway-probe.test.mjs
+++ b/packages/core/test/unit/profiles/profile-gateway-probe.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDefaultAppConfig } from "@ccr/core/config/default-config.ts";
+import { ensureProfileGateway } from "@ccr/core/profiles/launch-service.ts";
+
+function claudeProfileConfig() {
+  const profile = {
+    agent: "claude-code",
+    enabled: true,
+    env: {},
+    id: "claude-main",
+    model: "Provider/model",
+    name: "Claude Main",
+    scope: "ccr",
+    surface: "cli"
+  };
+  const config = createDefaultAppConfig({ generatedConfigFile: "/tmp/ccr-gateway.config.json" });
+  config.APIKEY = "profile-token";
+  config.APIKEYS = [
+    {
+      createdAt: "2026-01-01T00:00:00.000Z",
+      id: "profile:claude-main",
+      key: "profile-token",
+      name: "Profile: Claude Main"
+    }
+  ];
+  config.gateway.host = "127.0.0.1";
+  config.gateway.port = 3466;
+  config.profile.profiles = [profile];
+  return { config, profile };
+}
+
+test("existing profile gateway uses health before the optional root probe", async () => {
+  const previousFetch = globalThis.fetch;
+  const paths = [];
+  globalThis.fetch = async (input, init = {}) => {
+    const url = new URL(String(input));
+    paths.push(url.pathname);
+    if (url.pathname === "/health") {
+      return Response.json({
+        core: "http://127.0.0.1:3467",
+        status: "running",
+        timestamp: "2026-01-01T00:00:00.000Z"
+      });
+    }
+    if (url.pathname === "/v1/models") {
+      assert.equal(new Headers(init.headers).get("authorization"), "Bearer profile-token");
+      return Response.json({ data: [], object: "list" });
+    }
+    if (url.pathname === "/") {
+      throw new TypeError("root probe connection reset");
+    }
+    throw new Error(`Unexpected gateway probe: ${url.pathname}`);
+  };
+
+  try {
+    const { config, profile } = claudeProfileConfig();
+    const result = await ensureProfileGateway(config, profile, "Local subscription router", {
+      reuseExisting: true,
+      startIfMissing: false
+    });
+
+    assert.equal(result.APIKEY, "profile-token");
+    assert.deepEqual(paths, ["/health", "/v1/models"]);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("existing profile gateway falls back to the root identity response", async () => {
+  const previousFetch = globalThis.fetch;
+  const paths = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    paths.push(url.pathname);
+    if (url.pathname === "/health") {
+      return Response.json({ status: "unknown" }, { status: 404 });
+    }
+    if (url.pathname === "/") {
+      return Response.json({ name: "claude-code-router" });
+    }
+    if (url.pathname === "/v1/models") {
+      return Response.json({ data: [], object: "list" });
+    }
+    throw new Error(`Unexpected gateway probe: ${url.pathname}`);
+  };
+
+  try {
+    const { config, profile } = claudeProfileConfig();
+    const result = await ensureProfileGateway(config, profile, "Local subscription router", {
+      reuseExisting: true,
+      startIfMissing: false
+    });
+
+    assert.equal(result.APIKEY, "profile-token");
+    assert.deepEqual(paths, ["/health", "/", "/v1/models"]);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("existing profile gateway retries a transient transport failure", async () => {
+  const previousFetch = globalThis.fetch;
+  const paths = [];
+  let modelAttempts = 0;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    paths.push(url.pathname);
+    if (url.pathname === "/health") {
+      return Response.json({
+        core: "http://127.0.0.1:3467",
+        status: "running",
+        timestamp: "2026-01-01T00:00:00.000Z"
+      });
+    }
+    if (url.pathname === "/v1/models") {
+      modelAttempts += 1;
+      if (modelAttempts === 1) {
+        throw new TypeError("fetch failed", { cause: { code: "ECONNRESET" } });
+      }
+      return Response.json({ data: [], object: "list" });
+    }
+    throw new Error(`Unexpected gateway probe: ${url.pathname}`);
+  };
+
+  try {
+    const { config, profile } = claudeProfileConfig();
+    const result = await ensureProfileGateway(config, profile, "Local subscription router", {
+      reuseExisting: true,
+      startIfMissing: false
+    });
+
+    assert.equal(result.APIKEY, "profile-token");
+    assert.equal(modelAttempts, 2);
+    assert.deepEqual(paths, ["/health", "/v1/models", "/v1/models"]);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("unavailable profile gateway reports the probe failure reason", async () => {
+  const previousFetch = globalThis.fetch;
+  const paths = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    paths.push(url.pathname);
+    if (url.pathname === "/health") {
+      throw new TypeError("health probe timed out");
+    }
+    if (url.pathname === "/") {
+      throw new TypeError("root probe connection reset");
+    }
+    throw new Error(`Unexpected gateway probe: ${url.pathname}`);
+  };
+
+  try {
+    const { config, profile } = claudeProfileConfig();
+    await assert.rejects(
+      ensureProfileGateway(config, profile, "Local subscription router", {
+        reuseExisting: true,
+        startIfMissing: false
+      }),
+      (error) => {
+        assert.equal(error?.name, "ProfileGatewayUnavailableError");
+        assert.match(error.message, /health probe timed out/);
+        return true;
+      }
+    );
+    assert.deepEqual(paths, ["/health", "/health", "/health", "/", "/", "/"]);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- identify an existing CCR gateway through its health endpoint before using the optional root fallback
- retry only transport-level probe failures, while preserving immediate handling for HTTP responses
- include the underlying connection reason when a profile gateway is unavailable

## Why

A healthy loopback listener can occasionally reset one request. The profile launcher treated that single reset as an unusable gateway with `HTTP 0`, which blocked an otherwise valid profile launch.

## Test plan

- [x] focused profile gateway probe tests: 4 passed
- [x] `npm run typecheck`
- [x] `npm run build:assets`
- [ ] `npm test -w @claude-code-router/core` remains blocked by media-listener and bounded-heap failures reproduced on unchanged `main`