### PR TITLE
Add Kenari provider preset

### DIFF
--- a/packages/core/src/providers/presets/index.ts
+++ b/packages/core/src/providers/presets/index.ts
@@ -6,6 +6,7 @@ import { deepSeekProviderPreset } from "@ccr/core/providers/presets/deepseek/ind
 import { fennoProviderPreset } from "@ccr/core/providers/presets/fenno/index";
 import { geminiProviderPreset } from "@ccr/core/providers/presets/gemini/index";
 import { infistarAiProviderPreset } from "@ccr/core/providers/presets/infistar-ai/index";
+import { kenariProviderPreset } from "@ccr/core/providers/presets/kenari/index";
 import { kimiCodingProviderPreset } from "@ccr/core/providers/presets/kimi-coding/index";
 import { minimaxChinaProviderPreset, minimaxGlobalProviderPreset } from "@ccr/core/providers/presets/minimax/index";
 import { mistralProviderPreset } from "@ccr/core/providers/presets/mistral/index";
@@ -57,6 +58,7 @@ export const providerPresets: ProviderPreset[] = [
   infistarAiProviderPreset,
   runApiProviderPreset,
   teamoRouterProviderPreset,
+  kenariProviderPreset,
   unity2ProviderPreset,
   code0ProviderPreset,
   claudeApiProviderPreset

--- a/packages/core/src/providers/presets/kenari/index.ts
+++ b/packages/core/src/providers/presets/kenari/index.ts
@@ -1,0 +1,19 @@
+import type { ProviderPreset } from "@ccr/core/providers/presets/types";
+import { standardProviderAccountConfig } from "@ccr/core/providers/presets/types";
+
+export const kenariProviderPreset: ProviderPreset = {
+  account: standardProviderAccountConfig,
+  aliases: ["kenari", "kenari.id", "kenari cloud"],
+  defaultModels: ["claude-sonnet-5", "kimi-k2-7-code", "deepseek-v4-flash"],
+  endpoints: [
+    {
+      baseUrl: "https://kenari.id/v1",
+      protocols: ["anthropic_messages", "openai_chat_completions", "openai_responses"],
+      websiteUrl: "https://kenari.id/docs"
+    }
+  ],
+  id: "kenari",
+  name: "Kenari",
+  officialApiKeyPatterns: [{ source: "^kn-[0-9a-f]{48}$" }],
+  websiteUrl: "https://kenari.id/"
+};


### PR DESCRIPTION
## What

Adds a provider preset for [Kenari](https://kenari.id/), an Indonesian LLM gateway (OpenAI-compatible API with local-currency billing).

- `packages/core/src/providers/presets/kenari/index.ts`: preset with `https://kenari.id/v1` serving `anthropic_messages`, `openai_chat_completions`, and `openai_responses` on the same base URL
- Registered in `presets/index.ts`

## Notes

- Kenari's models are already present in `packages/core/models.json` via the models.dev sync (provider id `kenari`, aliases like `kenari/claude-sonnet-5`); this preset adds the matching provider entry
- API key format is `kn-` + 48 hex chars, covered by `officialApiKeyPatterns`
- Live model list with pricing and context length: `GET https://kenari.id/v1/models` (no auth required)
- Docs: https://kenari.id/docs

## Testing

- `npm run test:core`: 547 tests, 542 pass, 0 fail (5 skipped, pre-existing)
- `npm run test:architecture`: 4 pass, 0 fail

Follows the shape of the MiniMax preset PR (#1504).