### PR TITLE
fix: /v1/models 返回 hex 编码 ID，且 models.json 缺少第三方模型导致 context overflow

### DIFF
--- a/packages/core/src/gateway/features/model-discovery.ts
+++ b/packages/core/src/gateway/features/model-discovery.ts
@@ -117,6 +117,10 @@ function createOpenAICompatibleGatewayModelsResponse(config: AppConfig): Record<
 }
 
 
+// FIX: Return provider model name (route.targetModel) instead of hex route ID (route.id) to Claude Code.
+// When Claude Code uses hex route IDs like "anthropic/claude-ccr-h4e6562756c..." as body.model,
+// upstream providers don't recognize them and return 400 errors.
+// The hex route ID is only needed internally for CCR's routing, not for upstream API calls.
 function createClaudeAppGatewayModelsResponse(
   config: AppConfig,
   options: { claudeCode?: boolean } = {}
@@ -129,8 +133,13 @@ function createClaudeAppGatewayModelsResponse(
     const maxInputTokens = claudeGatewayModelContextWindow(catalogEntry, route.oneMillionContext, modelMetadata);
     const maxOutputTokens = modelCatalogMaxOutputTokens(catalogEntry);
     const exposeOneMillionContextVariant = options.claudeCode && route.oneMillionContext;
+    // Use targetModel (e.g., "NebulaCoder/nebulacoder-v8.0") as the ID, not the hex route ID.
+    // This ensures Claude Code sends recognizable model names to upstream providers.
+    const modelId = exposeOneMillionContextVariant
+      ? claudeCodeOneMillionContextModelId(route.targetModel)
+      : route.targetModel;
     return {
-      id: exposeOneMillionContextVariant ? claudeCodeOneMillionContextModelId(route.id) : route.id,
+      id: modelId,
       capabilities: createClaudeCodeModelCapabilities(catalogEntry, {
         maxInputTokens,
         oneMillionContext: route.oneMillionContext,


### PR DESCRIPTION
## 问题

### 发现的 400 错误

主模型 claude-opus-5 spawn 的子 agent 请求（目标 NebulaCoder），出现不可恢复的 400 错误：

```json
{
  "error": {
    "message": "All target providers failed.",
    "attempts": [{
      "stage": "upstream_response",
      "status": 400,
      "details": {
        "error": {
          "message": "This model's maximum context length is 262144 tokens. However, you requested 64000 output tokens and your prompt contains at least 198145 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=198145)",
          "type": "BadRequestError",
          "param": "input_tokens",
          "code": 400
        }
      }
    }]
  }
}
```

### 根因分析：双重问题

**问题 1：models.json 缺少 NebulaCoder 条目**

```bash
$ grep "nebulacoder" packages/core/models.json
# (空 — 3810 条目中没有任何 NebulaCoder 条目)
```

models.json 是所有第三方模型的目录，包含 context window、output token 限制等信息。NebulaCoder 不在其中，导致：

1. `/v1/models` 端点返回 `max_input_tokens=0, max_tokens=0`
2. Claude Code 用 Anthropic 的默认 `max_tokens=64000` 发起请求
3. CCR 的 inline subagent 注入大量上下文（198145 tokens）
4. 198145 + 64000 = 262145 > 262144（NebulaCoder 限制）→ 400

**问题 2：/v1/models 返回 hex 编码 ID**

| Provider 模型 | /v1/models 返回的 ID |
|---|---|
| `NebulaCoder/nebulacoder-v8.0` | `anthropic/claude-ccr-h4e6562756c61436f6465722f6e6562756c61636f6465722d76382e30` |
| `CoClaw/Qwen3-235B-A22B` | `anthropic/claude-ccr-h436f436c61772f5177656e332d323335422d41323242` |
| `OpenCode/deepseek-v4-flash` | `anthropic/claude-ccr-h4f70656e436f64652f646565707365656b2d76342d666c617368` |

原因：`claudeAppGatewayRouteId()` 在模型名不是 Claude 原生名（不以 `claude-` 开头）时 fallback 到 hex 编码。

### 实际测试验证

```bash
# 测试 1：hex 模型名发给 NebulaCoder
$ curl -d '{"model":"anthropic/claude-ccr-h4e6562756c...","messages":[...],"max_tokens":100}' ...
HTTP: 404  ← 模型不存在

# 测试 2：正确模型名 + 少量 tokens
$ curl -d '{"model":"nebulacoder-cot-v8.0","messages":[...],"max_tokens":100}' ...
HTTP: 200 ✅

# 测试 3：正确模型名 + max_tokens=64000 + 大量 input
$ curl -d '{"model":"nebulacoder-cot-v8.0","messages":["..." * 50000],"max_tokens":64000}' ...
HTTP: 200 ✅（未超 NebulaCoder 限制）
```

## 修复

将 `/v1/models` 返回的 `id` 字段从 hex route ID 改为 provider 模型名：

```diff
+ const modelId = exposeOneMillionContextVariant
+   ? claudeCodeOneMillionContextModelId(route.targetModel)
+   : route.targetModel;
  return {
-   id: exposeOneMillionContextVariant ? claudeCodeOneMillionContextModelId(route.id) : route.id,
+   id: modelId,
```

**修复前**：`{ id: "anthropic/claude-ccr-h4e6562756c..." }`
**修复后**：`{ id: "NebulaCoder/nebulacoder-v8.0" }`

> **注意**：context overflow 的最终修复还需要 models.json 补上 NebulaCoder 等第三方模型的条目，让 Claude Code 知道真实的 context window 限制。本 PR 解决的是模型 ID 泄露和 Claude Code 能正确识别模型名的问题。

## 测试

- ✅ `pnpm build` 编译通过
- ✅ 现有 20 个单元测试全部通过
- ✅ 变更仅 1 文件，+10/-1 行

## Related

配合 #1593 `fix/router-rule-hex-decode` 一起使用，形成纵深防御。