### PR TITLE
fix: hex 编码 body.model 导致自定义 Router rules 全部失效

### DIFF
--- a/packages/core/src/gateway/claude-code-router-plugin.ts
+++ b/packages/core/src/gateway/claude-code-router-plugin.ts
@@ -295,6 +295,14 @@ async function resolveConfiguredRouteDecision(
       ? resolveClaudeAppGatewayRouteModel(explicitModel, config, claudeAppGatewayModelRouteOptions)
       : undefined
   );
+
+  // FIX: Replace hex-encoded body.model with decoded canonical selector so router rules can match human-readable model names.
+  // Without this, rules like `body.model contains "sonnet"` never match because body.model is hex like
+  // "anthropic/claude-ccr-h4f70656e436f64652f646565707365656b2d76342d666c617368".
+  if (resolvedExplicitModel) {
+    request.body.model = resolvedExplicitModel.canonicalSelector;
+  }
+
   const explicitDecision: ConfiguredRouteDecision | undefined = resolvedExplicitModel
     ? {
         fallback: compiled.fallback,


### PR DESCRIPTION
## 问题

所有自定义 Router rules（条件匹配型）全部失效，因为 `body.model` 是 hex 编码的 gateway route ID，不包含任何可读的模型名关键词。

### Router rules 全部是死代码

举例，典型配置中的五条 Router rules：

| Rule | Condition | 实际匹配结果 |
|------|-----------|------------|
| `rule-highest-tier` | `body.model starts-with "claude-fable"` | ❌ hex 里没有 "fable" |
| `rule-opus` | `body.model contains "opus"` | ❌ hex 里没有 "opus" |
| `rule-haiku` | `body.model contains "haiku"` | ❌ hex 里没有 "haiku" |
| `rule-default` | `body.model contains "sonnet"` | ❌ hex 里没有 "sonnet" |
| 所有 fallback 链 | 依赖 rule 命中才触发 | ❌ rule 不命中 = fallback 永不触发 |

### 为什么 body.model 是 hex？

```
Claude Code 在 profile 里配置的模型（如 deepseek-v4-pro）
  → 不是 Claude 原生模型名（不以 "claude-" 开头）
  → claudeAppGatewayNativeModelNameIsSafe() 返回 false
  → fallback 到 hex 编码: "anthropic/claude-ccr-h" + hex(targetModel)
  → body.model = "anthropic/claude-ccr-h446565705365656b2f646565707365656b2d763470726f"
  → hex 只包含 [0-9a-f]，不包含 "sonnet"/"opus"/"haiku"/"fable"
```

### 验证

```bash
# 所有 provider 模型名的 hex 编码都不包含模型层级关键词
$ for m in "OpenCode/deepseek-v4-pro" "CoClaw/Qwen3-235B-A22B" "NebulaCoder/nebulacoder-v8.0"; do
    hex=$(echo -n "$m" | xxd -p)
    echo -n "$m → $hex → "
    echo "$hex" | grep -qiE "sonnet|opus|haiku|fable" && echo "MATCH" || echo "NO MATCH"
  done

OpenCode/deepseek-v4-pro → 4f70656e436f64652f... → NO MATCH
CoClaw/Qwen3-235B-A22B → 436f436c61772f517765... → NO MATCH
NebulaCoder/nebulacoder-v8.0 → 4e6562756c61436f... → NO MATCH
```

### 原始日志证据

路由实际走了 `clientModelDecision` 兜底，从未命中自定义 rules：

```
请求日志中的 requested_model vs resolved_model：

claude-opus-5  → deepseek-v4-pro   (route_hop_count=9, reason="default")
claude-sonnet-5 → deepseek-v4-flash (route_hop_count=9, reason="default")
```

注意：所有 `route_reason` 都是 `"default"`，没有 `"rule:rule-sonnet"` 或 `"rule:rule-opus"`——证明 Router rules 从未匹配成功。路由全靠 `clientModelDecision` 的 hex 解码兜底。

```bash
$ sqlite3 request-logs.sqlite "SELECT id, requested_model, resolved_model, route_hop_count FROM request_logs ORDER BY id DESC LIMIT 10"
```

## 修复

在 `resolveConfiguredRouteDecision` 中，hex 解码后立即替换 `body.model`，使下游 rule 条件匹配能看到人类可读的模型名：

```diff
+  // FIX: Replace hex-encoded body.model with decoded canonical selector
+  // so router rules can match human-readable model names.
+  // Without this, rules like "body.model contains sonnet" never match
+  // because body.model is hex like
+  // "anthropic/claude-ccr-h4f70656e436f64652f646565707365656b2d76342d666c617368".
+  if (resolvedExplicitModel) {
+    request.body.model = resolvedExplicitModel.canonicalSelector;
+  }
```

**修复前**：`body.model = "anthropic/claude-ccr-h4f70656e43..."` → rule 匹配失败
**修复后**：`body.model = "OpenCode/deepseek-v4-flash"` → rule 匹配成功 ✅

## 测试

- ✅ `pnpm build` 编译通过
- ✅ 现有 20 个单元测试全部通过
- ✅ 变更仅 1 文件，+8 行

## Related

配合 #1592 `fix/model-discovery-provider-name` 一起使用，形成纵深防御。