### PR TITLE
fix(gateway): 修复 HTTPS 自定义供应商请求 502

### DIFF
--- a/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
+++ b/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
@@ -32,6 +32,12 @@ const clientAuthHeaderNames = new Set([
   "x-api-key"
 ]);
 
+const proxyMetadataHeaderNames = new Set([
+  "forwarded",
+  "via",
+  "x-real-ip"
+]);
+
 const transportHeaderNames = new Set([
   "connection",
   "content-encoding",
@@ -65,7 +71,8 @@ export function sanitizeUpstreamProviderHeaders(headers: Record<string, string>)
 /**
  * Restores client headers after the core protocol adapter has rebuilt the
  * provider request. Provider-generated auth and content headers win on name
- * collisions, while transport and CCR-owned headers never cross the boundary.
+ * collisions, while transport, proxy metadata and CCR-owned headers never
+ * cross the boundary.
  */
 export function mergeUpstreamProviderHeaders(
   requestHeaders: Record<string, string | string[] | undefined> | undefined,
@@ -89,6 +96,8 @@ export function mergeUpstreamProviderHeaders(
       ccrAuthHeaderNames.has(normalized) ||
       ccrRoutingHeaderNames.has(normalized) ||
       clientAuthHeaderNames.has(normalized) ||
+      proxyMetadataHeaderNames.has(normalized) ||
+      normalized.startsWith("x-forwarded-") ||
       connectionHeaders.has(normalized)
     ) {
       continue;

--- a/packages/core/test/unit/gateway/upstream-header-sanitizer.test.mjs
+++ b/packages/core/test/unit/gateway/upstream-header-sanitizer.test.mjs
@@ -94,3 +94,38 @@ test("gateway sanitizer hook forwards client headers without overriding provider
     "x-title": "Claude Code Router"
   });
 });
+
+test("gateway sanitizer hook does not forward reverse proxy metadata to providers", async () => {
+  const [hook] = createGatewayPlugin().providerHooks;
+  const upstreamRequest = {
+    body: { model: "provider-model" },
+    headers: {
+      "content-type": "application/json"
+    },
+    method: "POST",
+    url: "https://provider.example/v1/messages"
+  };
+
+  const result = await hook.transformRequest({
+    request: {
+      headers: {
+        forwarded: "for=192.0.2.10;proto=http;host=ccr.example",
+        via: "1.1 ccr",
+        "x-forwarded-client-cert": "proxy-certificate",
+        "x-forwarded-for": "192.0.2.10",
+        "x-forwarded-host": "ccr.example",
+        "x-forwarded-port": "80",
+        "x-forwarded-proto": "http",
+        "x-real-ip": "192.0.2.10",
+        "x-custom-provider-header": "custom-value"
+      }
+    },
+    upstreamRequest
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value.headers, {
+    "content-type": "application/json",
+    "x-custom-provider-header": "custom-value"
+  });
+});


### PR DESCRIPTION
## 问题

Docker 环境中的入口反向代理会写入 `x-forwarded-proto: http`。该请求头被继续转发给 HTTPS 自定义供应商后，部分 nginx 或 LiteLLM 网关会据此返回 308，重定向循环最终表现为 `502 upstream_connect`。

供应商连通性检测没有经过完整的请求转发流程，因此会出现“检测正常，但实际请求失败”的现象。

## 修改

- 在最终发送给供应商前，过滤客户端请求中的 `Forwarded`、`X-Forwarded-*`、`Via` 和 `X-Real-IP`。
- 保留普通客户端自定义请求头，以及协议适配器和供应商配置生成的请求头。
- 增加回归测试，覆盖 `x-forwarded-proto: http` 被错误转发给 HTTPS 供应商的场景。

## 验证

- `npm run typecheck`
- `node --test .test-dist/core/test/gateway/upstream-header-sanitizer.test.js`（4/4 通过）

Fixes #1590
