### PR TITLE
fix: fall back to reasoning_content when content is empty

### DIFF
--- a/packages/core/src/transformer/anthropic.transformer.ts
+++ b/packages/core/src/transformer/anthropic.transformer.ts
@@ -988,10 +988,17 @@ export class AnthropicTransformer implements Transformer {
           }),
         });
       }
-      if (choice.message.content) {
+      // Reasoning models (GLM, DeepSeek, Qwen) may put all output in
+      // reasoning_content with content="" (especially when max_tokens is
+      // consumed by thinking). Fall back so the Anthropic response always
+      // has at least one text block.
+      const msgText = choice.message.content
+        || (choice.message as any)?.reasoning_content
+        || "";
+      if (msgText) {
         content.push({
           type: "text",
-          text: choice.message.content,
+          text: msgText,
         });
       }
       if (choice.message.tool_calls && choice.message.tool_calls.length > 0) {


### PR DESCRIPTION
## Problem

Reasoning models (GLM-5.2, DeepSeek-R1, Qwen) may return `content: ""` with all actual output in `reasoning_content`. This happens when `max_tokens` is consumed entirely by the thinking process.

The `AnthropicTransformer` non-streaming response path only checks `choice.message.content`. When it is empty, the resulting Anthropic-format response has `content: []` — Claude Code receives no text blocks and fails silently.

## Fix

Added a fallback chain in `anthropic.transformer.ts`:

```typescript
const msgText = choice.message.content
  || (choice.message as any)?.reasoning_content
  || "";
```

This ensures the Anthropic response always has at least one `text` content block when the model produced any output.

## Affected models

- **GLM-5.2 / GLM-4.6** (ZhipuAI) — uses `reasoning_content` for chain-of-thought
- **DeepSeek-R1** — same pattern when thinking tokens exhaust `max_tokens`
- **Qwen reasoning models** — same pattern

## Test plan

- [ ] Configure a GLM-5.2 provider with low `max_tokens` (e.g. 50) to force reasoning-only output
- [ ] Send a non-streaming `/v1/messages` request through CCR
- [ ] Verify the response contains a `text` content block with reasoning_content as fallback
- [ ] Verify normal models (content populated) are unaffected