### PR TITLE
feat: add apiToken.sale provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Use CCR to:
 - **Add capabilities to existing models** with Fusion vision, web search, MCP tools, and ToolHub.
 - **See what actually happened** through request logs, resolved routes, latency, token usage, cost estimates, and account status.
 
-CCR supports OpenAI Chat / Responses, Anthropic Messages, Gemini Generate Content / Interactions, OpenRouter, DeepSeek, SiliconFlow, Moonshot, Kimi Code, Mistral, Z.AI, Bailian, and custom compatible providers.
+CCR supports OpenAI Chat / Responses, Anthropic Messages, Gemini Generate Content / Interactions, OpenRouter, apiToken.sale, DeepSeek, SiliconFlow, Moonshot, Kimi Code, Mistral, Z.AI, Bailian, and custom compatible providers.
 
 <details open>
 <summary><strong>Supported Agents</strong></summary>

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,7 +69,7 @@ Claude Code Router（CCR）是面向编程 Agent 的本地模型网关与控制�
 - **通过 Fusion 视觉、联网搜索、MCP 工具和 ToolHub 扩展现有模型**。
 - **通过请求日志、最终路由、耗时、Token、成本估算和账号状态了解真实运行情况**。
 
-CCR 支持 OpenAI Chat / Responses、Anthropic Messages、Gemini Generate Content / Interactions、OpenRouter、DeepSeek、SiliconFlow、Moonshot、Kimi Code、Mistral、Z.AI、百炼以及自定义兼容供应商。
+CCR 支持 OpenAI Chat / Responses、Anthropic Messages、Gemini Generate Content / Interactions、OpenRouter、apiToken.sale、DeepSeek、SiliconFlow、Moonshot、Kimi Code、Mistral、Z.AI、百炼以及自定义兼容供应商。
 
 <details open>
 <summary><strong>支持的 Agent</strong></summary>

--- a/docs/public/provider-icons/apitoken.svg
+++ b/docs/public/provider-icons/apitoken.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="apiToken.sale">
+  <defs>
+    <linearGradient id="a" x1="10" y1="54" x2="54" y2="10" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0746ff"/>
+      <stop offset="1" stop-color="#09b8ff"/>
+    </linearGradient>
+  </defs>
+  <path fill="#071c52" d="M29 2h6l2 8 7-5 4 4-4 7 8 2v6l-7 2 7 5v5l-8 2 4 7-4 4-7-4-2 8h-6l-2-8-7 4-4-4 4-7-8-2v-5l7-5-7-2v-6l8-2-4-7 4-4 7 5z"/>
+  <path fill="url(#a)" d="M29 8h6l2 9 8-3 4 5-6 7 9 3v6l-9 3 6 7-4 5-8-3-2 9h-6l-2-9-8 3-4-5 6-7-9-3v-6l9-3-6-7 4-5 8 3z"/>
+  <path fill="#fff" d="m32 19 4 5 7 1-2 7 2 7-7 1-4 5-4-5-7-1 2-7-2-7 7-1z"/>
+  <path fill="#2d74ff" d="M7 7h3v4h4v3h-4v4H7v-4H3v-3h4zm47 39h3v4h4v3h-4v4h-3v-4h-4v-3h4z"/>
+</svg>

--- a/docs/src/content/docs/en/configuration/provider-deeplink.md
+++ b/docs/src/content/docs/en/configuration/provider-deeplink.md
@@ -18,6 +18,10 @@ Choose a provider below to get started. CCR shows what will be added before savi
     <span class="provider-import-icon-shell"><img src="../../../provider-icons/anthropic.png" alt="" loading="lazy" /></span>
     <span class="provider-import-copy"><span class="provider-import-name">Anthropic</span><span class="provider-import-meta">Anthropic Messages</span></span>
   </a>
+  <a class="provider-import-button provider-apitoken" href="ccr://provider?name=apiToken.sale&amp;base_url=https%3A%2F%2Fapi.apitoken.sale&amp;protocol=anthropic_messages&amp;models=claude-opus-4-8%2Cclaude-opus-4-7%2Cclaude-sonnet-5%2Cclaude-sonnet-4-6%2Cclaude-haiku-4-5&amp;source=https%3A%2F%2Fapitoken.sale" aria-label="Import apiToken.sale provider">
+    <span class="provider-import-icon-shell"><img src="../../../provider-icons/apitoken.svg" alt="" loading="lazy" /></span>
+    <span class="provider-import-copy"><span class="provider-import-name">apiToken.sale</span><span class="provider-import-meta">Anthropic-compatible API</span></span>
+  </a>
   <a class="provider-import-button provider-gemini" href="ccr://provider?name=Google+Gemini&amp;base_url=https%3A%2F%2Fgenerativelanguage.googleapis.com&amp;protocol=gemini_generate_content&amp;models=gemini-3.5-flash%2Cgemini-3.1-pro-preview%2Cgemini-3-flash-preview" aria-label="Import Google Gemini provider">
     <span class="provider-import-icon-shell"><img src="../../../provider-icons/gemini.svg" alt="" loading="lazy" /></span>
     <span class="provider-import-copy"><span class="provider-import-name">Google Gemini</span><span class="provider-import-meta">Gemini Generate Content</span></span>

--- a/docs/src/content/docs/zh/configuration/provider-deeplink.md
+++ b/docs/src/content/docs/zh/configuration/provider-deeplink.md
@@ -18,6 +18,10 @@ lead: 快速添加常见模型供应商，确认无误后即可保存，减少�
     <span class="provider-import-icon-shell"><img src="../../provider-icons/anthropic.png" alt="" loading="lazy" /></span>
     <span class="provider-import-copy"><span class="provider-import-name">Anthropic 官方</span><span class="provider-import-meta">Anthropic Messages</span></span>
   </a>
+  <a class="provider-import-button provider-apitoken" href="ccr://provider?name=apiToken.sale&amp;base_url=https%3A%2F%2Fapi.apitoken.sale&amp;protocol=anthropic_messages&amp;models=claude-opus-4-8%2Cclaude-opus-4-7%2Cclaude-sonnet-5%2Cclaude-sonnet-4-6%2Cclaude-haiku-4-5&amp;source=https%3A%2F%2Fapitoken.sale" aria-label="导入 apiToken.sale 供应商">
+    <span class="provider-import-icon-shell"><img src="../../provider-icons/apitoken.svg" alt="" loading="lazy" /></span>
+    <span class="provider-import-copy"><span class="provider-import-name">apiToken.sale</span><span class="provider-import-meta">Anthropic 兼容 API</span></span>
+  </a>
   <a class="provider-import-button provider-gemini" href="ccr://provider?name=Google+Gemini&amp;base_url=https%3A%2F%2Fgenerativelanguage.googleapis.com&amp;protocol=gemini_generate_content&amp;models=gemini-3.5-flash%2Cgemini-3.1-pro-preview%2Cgemini-3-flash-preview" aria-label="导入谷歌 Gemini 供应商">
     <span class="provider-import-icon-shell"><img src="../../provider-icons/gemini.svg" alt="" loading="lazy" /></span>
     <span class="provider-import-copy"><span class="provider-import-name">谷歌 Gemini</span><span class="provider-import-meta">Gemini Generate Content</span></span>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1294,6 +1294,12 @@ h1 {
   --provider-brand-3: #ffd1bf;
 }
 
+.doc-markdown a.provider-import-button.provider-apitoken {
+  --provider-brand: #071c52;
+  --provider-brand-2: #0958ff;
+  --provider-brand-3: #8de7ff;
+}
+
 .doc-markdown a.provider-import-button.provider-gemini {
   --provider-brand: #1a73e8;
   --provider-brand-2: #a142f4;

--- a/packages/core/src/providers/presets/apitoken/index.ts
+++ b/packages/core/src/providers/presets/apitoken/index.ts
@@ -1,0 +1,25 @@
+import { defaultProviderAccountConfig, type ProviderPreset } from "@ccr/core/providers/presets/types";
+
+export const apiTokenProviderPreset: ProviderPreset = {
+  account: defaultProviderAccountConfig,
+  aliases: ["apitoken", "apitoken.sale", "api token sale"],
+  defaultModels: [
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5"
+  ],
+  endpoints: [
+    {
+      baseUrl: "https://api.apitoken.sale",
+      protocols: ["anthropic_messages"]
+    }
+  ],
+  id: "apitoken",
+  name: "apiToken.sale",
+  officialApiKeyPatterns: [
+    { source: "^sk-pool-[A-Za-z0-9._-]+$" }
+  ],
+  websiteUrl: "https://apitoken.sale"
+};

--- a/packages/core/src/providers/presets/index.ts
+++ b/packages/core/src/providers/presets/index.ts
@@ -1,4 +1,5 @@
 import { anthropicProviderPreset } from "@ccr/core/providers/presets/anthropic/index";
+import { apiTokenProviderPreset } from "@ccr/core/providers/presets/apitoken/index";
 import { bailianProviderPreset } from "@ccr/core/providers/presets/bailian/index";
 import { claudeApiProviderPreset } from "@ccr/core/providers/presets/claudeapi/index";
 import { code0ProviderPreset } from "@ccr/core/providers/presets/code0/index";
@@ -36,6 +37,7 @@ import type { ProviderIdentitySafetyIssue, ProviderPreset } from "@ccr/core/prov
 export const providerPresets: ProviderPreset[] = [
   openaiProviderPreset,
   anthropicProviderPreset,
+  apiTokenProviderPreset,
   geminiProviderPreset,
   openRouterProviderPreset,
   nvidiaProviderPreset,

--- a/packages/core/test/unit/providers/provider-preset-utils.test.mjs
+++ b/packages/core/test/unit/providers/provider-preset-utils.test.mjs
@@ -4,6 +4,9 @@ import {
   normalizeProviderPresetCapabilitiesForTest
 } from "@ccr/core/config/config.ts";
 import {
+  apiTokenProviderPreset
+} from "@ccr/core/providers/presets/apitoken/index.ts";
+import {
   findProviderPresetByBaseUrlInList,
   findProviderPresetByIdentityInList,
   providerApiKeySafetyIssueInList,
@@ -70,6 +73,21 @@ test("provider preset matching accepts endpoint subpaths but rejects different h
   assert.equal(providerPresetMatchesBaseUrl(openRouterPreset, "https://openrouter.ai/api"), true);
   assert.equal(providerPresetMatchesBaseUrl(openAiPreset, "https://proxy.example.com/v1"), false);
   assert.equal(findProviderPresetByBaseUrlInList(presets, "api.anthropic.com/v1/messages")?.id, "anthropic");
+});
+
+test("apiToken.sale preset is reachable by identity and normalized Anthropic endpoint", () => {
+  assert.equal(providerPresets.find((preset) => preset.id === "apitoken"), apiTokenProviderPreset);
+  assert.equal(findProviderPresetByBaseUrlInList(providerPresets, "https://api.apitoken.sale"), apiTokenProviderPreset);
+  assert.equal(findProviderPresetByBaseUrlInList(providerPresets, "https://api.apitoken.sale/"), apiTokenProviderPreset);
+  assert.equal(findProviderPresetByBaseUrlInList(providerPresets, "https://api.apitoken.sale/v1"), apiTokenProviderPreset);
+  assert.deepEqual(apiTokenProviderPreset.endpoints[0]?.protocols, ["anthropic_messages"]);
+  assert.deepEqual(apiTokenProviderPreset.defaultModels, [
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5"
+  ]);
 });
 
 test("provider identity lookup normalizes aliases and punctuation", () => {

--- a/packages/ui/src/assets/provider-icons/apitoken.svg
+++ b/packages/ui/src/assets/provider-icons/apitoken.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="apiToken.sale">
+  <defs>
+    <linearGradient id="a" x1="10" y1="54" x2="54" y2="10" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0746ff"/>
+      <stop offset="1" stop-color="#09b8ff"/>
+    </linearGradient>
+  </defs>
+  <path fill="#071c52" d="M29 2h6l2 8 7-5 4 4-4 7 8 2v6l-7 2 7 5v5l-8 2 4 7-4 4-7-4-2 8h-6l-2-8-7 4-4-4 4-7-8-2v-5l7-5-7-2v-6l8-2-4-7 4-4 7 5z"/>
+  <path fill="url(#a)" d="M29 8h6l2 9 8-3 4 5-6 7 9 3v6l-9 3 6 7-4 5-8-3-2 9h-6l-2-9-8 3-4-5 6-7-9-3v-6l9-3-6-7 4-5 8 3z"/>
+  <path fill="#fff" d="m32 19 4 5 7 1-2 7 2 7-7 1-4 5-4-5-7-1 2-7-2-7 7-1z"/>
+  <path fill="#2d74ff" d="M7 7h3v4h4v3h-4v4H7v-4H3v-3h4zm47 39h3v4h4v3h-4v4h-3v-4h-4v-3h4z"/>
+</svg>

--- a/packages/ui/src/pages/home/shared/options.ts
+++ b/packages/ui/src/pages/home/shared/options.ts
@@ -43,6 +43,7 @@ import type {
   VirtualModelToolVisibility
 } from "@ccr/core/contracts/app";
 import anthropicProviderIconUrl from "@/assets/provider-icons/anthropic.png";
+import apiTokenProviderIconUrl from "@/assets/provider-icons/apitoken.svg";
 import bailianProviderIconUrl from "@/assets/provider-icons/bailian.ico";
 import claudeapiProviderIconUrl from "@/assets/provider-icons/claudeapi.png";
 import code0ProviderIconUrl from "@/assets/provider-icons/code0.png";
@@ -355,6 +356,7 @@ export const mcpStdioMessageModeOptions: Array<{ label: string; value: GatewayMc
 
 export const providerPresetIconUrls: Record<string, string> = {
   anthropic: anthropicProviderIconUrl,
+  apitoken: apiTokenProviderIconUrl,
   bailian: bailianProviderIconUrl,
   claudeapi: claudeapiProviderIconUrl,
   code0: code0ProviderIconUrl,

--- a/packages/ui/test/integration/providers.test.ts
+++ b/packages/ui/test/integration/providers.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { newApiKeyUsageAccountConfig } from "@ccr/core/providers/new-api.ts";
+import { apiTokenProviderPreset } from "@ccr/core/providers/presets/apitoken/index.ts";
 import { geminiProviderPreset } from "@ccr/core/providers/presets/gemini/index.ts";
 import { minimaxChinaProviderPreset } from "@ccr/core/providers/presets/minimax/index.ts";
 import { moonshotGlobalProviderPreset } from "@ccr/core/providers/presets/moonshot/index.ts";
@@ -982,8 +983,17 @@ test("provider deep link config saves anthropic probe prefix as capability URL",
 });
 
 test("provider display icon prefers custom icons and falls back to preset icons", () => {
-  setProviderPresets([geminiProviderPreset, minimaxChinaProviderPreset]);
+  setProviderPresets([apiTokenProviderPreset, geminiProviderPreset, minimaxChinaProviderPreset]);
 
+  assert.equal(
+    providerDisplayIcon({
+      api_base_url: "https://api.apitoken.sale/v1",
+      models: [],
+      name: "apiToken.sale",
+      type: "anthropic_messages"
+    }),
+    providerPresetIconUrls.apitoken
+  );
   assert.equal(
     providerDisplayIcon({
       api_base_url: "https://custom.example/v1",


### PR DESCRIPTION
## Summary

Add apiToken.sale as a built-in Anthropic-compatible API provider so users can select it directly in CCR instead of entering a custom endpoint.

## Changes

- add the `apiToken.sale` preset with its Anthropic Messages endpoint and supported Claude models
- add the provider icon to the app and one-click import documentation
- add English and Chinese documentation entries linking to the provider website
- cover preset registration, normalized endpoint matching, model defaults, and UI icon resolution

## Tests

- `npm run typecheck`
- `npm run test:ui` — 134 passed
- `npm run build:assets`
- `npm run build` in `docs/` — 72 pages built
- `npm run test:core` — 646 passed, 5 skipped, 4 failed; the same four unrelated failures reproduce on pristine upstream `3b99fa2` (645 passed, 5 skipped, 4 failed)

The upstream baseline failures are the bounded-heap request-log regression and three bundled Claude Design path/permission tests.

## Proof of working

Verified through a locally built CCR gateway against `https://api.apitoken.sale` using `claude-sonnet-4-6`:

- basic Messages request: HTTP 200, expected text returned
- streaming Messages request: HTTP 200, complete Anthropic SSE event sequence and expected text returned
- forced tool-use request: HTTP 200, `integration_check` called with `{ "status": "ok" }`

The API key was provided only through a temporary environment variable and is not included in this change or the test output.
