### PR TITLE
fix(claude-code): look up the macOS keychain item by account

### DIFF
--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -21,7 +22,23 @@ import {
 } from "@ccr/core/agents/local-providers/shared";
 
 const claudeDefaultModels = ["claude-sonnet-5"];
-const claudeCodeKeychainService = "Claude Code-credentials";
+const claudeCodeKeychainServiceBase = "Claude Code-credentials";
+const claudeCodeKeychainAccountPattern = /^[a-zA-Z0-9._-]+$/;
+const claudeCodeKeychainServicePattern = /^Claude Code(?:-[a-z]+-oauth)?-credentials(?:-[0-9a-f]{8})?$/;
+// `security` exit code for errSecItemNotFound.
+const keychainItemNotFoundStatus = 44;
+
+type ClaudeCodeKeychainCandidate = { account?: string; service: string };
+
+export type ClaudeCodeLoginScan = {
+  /** Reads that failed, with the `security` stderr that explains why. */
+  errors: string[];
+  /** Locations that parsed successfully. */
+  inspected: string[];
+  oauth?: OAuthTokenSet;
+  /** Locations that parsed but carry no OAuth token. */
+  tokenless: string[];
+};
 
 const percentLimitMapping = (id: string, label: string, path: string, window: string) => ({
   id,
@@ -65,7 +82,8 @@ const claudeCodeAccountMapping: ProviderAccountMappingConfig = {
 };
 
 export function claudeCodeCandidate(): LocalAgentProviderCandidate {
-  const oauth = readClaudeCodeOauth();
+  const scan = scanClaudeCodeLogin();
+  const oauth = scan.oauth;
   if (oauth?.accessToken) {
     return {
       detail: "Claude Code login detected. Click Import to add it as a gateway provider.",
@@ -92,7 +110,34 @@ export function claudeCodeCandidate(): LocalAgentProviderCandidate {
       status: "locked"
     };
   }
+  const detail = claudeCodeScanDiagnostic(scan);
+  if (detail) {
+    return {
+      detail,
+      id: "claude-code-api",
+      importable: false,
+      kind: "claude-code",
+      models: claudeDefaultModels,
+      name: "Claude Code API",
+      protocol: "anthropic_messages",
+      sourceFile: scan.inspected[0],
+      status: "locked"
+    };
+  }
   return missingCandidate("claude-code", "claude-code-api", "Claude Code API", "anthropic_messages", claudeDefaultModels);
+}
+
+// Distinguishes "found login state but no token" and "could not read the store"
+// from "no login at all", so the Add Provider list can say why an import is
+// unavailable instead of silently omitting the candidate.
+function claudeCodeScanDiagnostic(scan: ClaudeCodeLoginScan): string | undefined {
+  if (scan.tokenless.length > 0) {
+    return `Claude Code login state was found but contains no OAuth token (${scan.tokenless.join("; ")}). Run \`claude /login\`, then retry.`;
+  }
+  if (scan.errors.length > 0) {
+    return `Claude Code login state could not be read: ${scan.errors.join("; ")}`;
+  }
+  return undefined;
 }
 
 export function importClaudeCodeProvider(candidate: LocalAgentProviderCandidate, providerNames: string[]): LocalAgentProviderImportResult {
@@ -139,9 +184,15 @@ function claudeCodeProviderAccountConfig(): ProviderAccountConfig {
 }
 
 export function readClaudeCodeOauth(): OAuthTokenSet | undefined {
-  const keychainOauth = readClaudeCodeKeychainOauth();
+  return scanClaudeCodeLogin().oauth;
+}
+
+export function scanClaudeCodeLogin(): ClaudeCodeLoginScan {
+  const scan: ClaudeCodeLoginScan = { errors: [], inspected: [], tokenless: [] };
+  const keychainOauth = scanClaudeCodeKeychain(scan);
   if (keychainOauth) {
-    return keychainOauth;
+    scan.oauth = keychainOauth;
+    return scan;
   }
 
   for (const sourceFile of claudeCredentialFiles()) {
@@ -149,58 +200,232 @@ export function readClaudeCodeOauth(): OAuthTokenSet | undefined {
     if (!record) {
       continue;
     }
-    const credential = findOauthTokenSet(record);
-    return {
-      accessToken: credential?.accessToken,
-      refreshToken: credential?.refreshToken,
+    scan.inspected.push(sourceFile);
+    const credential = findOauthTokenSet(record.claudeAiOauth) ?? findOauthTokenSet(record);
+    if (!credential?.accessToken && !credential?.refreshToken) {
+      scan.tokenless.push(`${sourceFile} (keys: ${Object.keys(record).join(", ")})`);
+      continue;
+    }
+    scan.oauth = {
+      accessToken: credential.accessToken,
+      refreshToken: credential.refreshToken,
       sourceFile
     };
+    return scan;
   }
 
-  return undefined;
+  return scan;
 }
 
 function claudeCredentialFiles(): string[] {
   return uniqueStrings([
+    path.join(claudeCodeStorageDir(), ".credentials.json"),
     path.join(os.homedir(), ".claude", ".credentials.json"),
     path.join(os.homedir(), ".claude", "credentials.json"),
     path.join(os.homedir(), ".config", "claude", "credentials.json")
   ]);
 }
 
-// Newer macOS builds of the Claude Code CLI store credentials in the
-// Keychain instead of ~/.claude/.credentials.json. Reading it triggers the
-// standard macOS keychain access prompt (Allow / Always Allow); the user
-// declining or the item not existing both surface as a non-zero exit here.
-function readClaudeCodeKeychainOauth(): OAuthTokenSet | undefined {
-  const keychainRecord = readClaudeCodeKeychainRecord();
-  if (!keychainRecord) {
-    return undefined;
-  }
-  const credential = findOauthTokenSet(keychainRecord);
-  if (!credential) {
-    return undefined;
-  }
-  return {
-    accessToken: credential.accessToken,
-    refreshToken: credential.refreshToken,
-    sourceFile: `keychain:${claudeCodeKeychainService}`
-  };
+// Claude Code's plaintext fallback lives in its secure-storage config dir,
+// which CLAUDE_SECURESTORAGE_CONFIG_DIR / CLAUDE_CONFIG_DIR can relocate.
+function claudeCodeStorageDir(): string {
+  const secureStorageDir = process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+  const dir = secureStorageDir !== undefined
+    ? secureStorageDir || path.join(os.homedir(), ".claude")
+    : process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+  return dir.normalize("NFC");
 }
 
-function readClaudeCodeKeychainRecord(): Record<string, unknown> | undefined {
+// Claude Code >= 2.1 derives the keychain service name from its config dir:
+//   `Claude Code${oauthSuffix}-credentials${configSuffix}`
+// `configSuffix` is empty for a default config dir and
+// `-${sha256(NFC(configDir)).slice(0, 8)}` once CLAUDE_CONFIG_DIR or
+// CLAUDE_SECURESTORAGE_CONFIG_DIR is set. Verified against 2.1.220.
+function claudeCodeExpectedKeychainServices(): string[] {
+  const secureStorageDir = process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+  const usesDefaultDir = secureStorageDir !== undefined ? !secureStorageDir : !process.env.CLAUDE_CONFIG_DIR;
+  const configSuffix = usesDefaultDir
+    ? ""
+    : `-${createHash("sha256").update(claudeCodeStorageDir()).digest("hex").slice(0, 8)}`;
+  const oauthSuffix = process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL ? "-custom-oauth" : "";
+  return uniqueStrings([`Claude Code${oauthSuffix}-credentials${configSuffix}`, claudeCodeKeychainServiceBase]);
+}
+
+// Claude Code writes the item under the current `$USER`; a login from an older
+// build (or one that could not resolve a username) sits under a different
+// account on the *same* service name, so the account has to be explicit.
+function claudeCodeKeychainAccount(): string {
+  let user: string | undefined;
+  try {
+    user = process.env.USER || os.userInfo().username;
+  } catch {
+    user = undefined;
+  }
+  return user && claudeCodeKeychainAccountPattern.test(user) ? user : "claude-code-user";
+}
+
+// Newer macOS builds of the Claude Code CLI store credentials in the Keychain
+// instead of ~/.claude/.credentials.json. Reading one triggers the standard
+// macOS keychain access prompt (Allow / Always Allow); the user declining or
+// the item not existing both surface as a non-zero exit here.
+function scanClaudeCodeKeychain(scan: ClaudeCodeLoginScan): OAuthTokenSet | undefined {
   if (process.platform !== "darwin") {
     return undefined;
   }
+  const expectedServices = claudeCodeExpectedKeychainServices();
+  const account = claudeCodeKeychainAccount();
+  // Ordered by cost: the enumeration tier shells out to `security dump-keychain`,
+  // so it is only built once the expected item fails to produce a token.
+  const tiers: Array<() => ClaudeCodeKeychainCandidate[]> = [
+    () => expectedServices.map(service => ({ account, service })),
+    // An item written under a different account, or under a config dir this
+    // process cannot reconstruct, only turns up by enumeration.
+    discoverClaudeCodeKeychainItems,
+    // Pre-2.1 lookup: no `-a`, so the Keychain picks an arbitrary account when
+    // several items share the service name.
+    () => expectedServices.map(service => ({ service }))
+  ];
+
+  const attempted = new Set<string>();
+  const servicesRead = new Set<string>();
+  let nestedMatch: OAuthTokenSet | undefined;
+  for (const buildTier of tiers) {
+    for (const candidate of buildTier()) {
+      const key = `${candidate.service}\u0000${candidate.account ?? ""}`;
+      // An accountless read of a service already read by account returns one of
+      // those same items, so it would only duplicate the diagnostics.
+      if (attempted.has(key) || (candidate.account === undefined && servicesRead.has(candidate.service))) {
+        continue;
+      }
+      attempted.add(key);
+      const label = candidate.account === undefined ? candidate.service : `${candidate.service} (${candidate.account})`;
+      const record = readClaudeCodeKeychainRecord(candidate, scan, label);
+      if (!record) {
+        continue;
+      }
+      servicesRead.add(candidate.service);
+      scan.inspected.push(`keychain:${label}`);
+      // Only `claudeAiOauth` is an Anthropic API credential. A recursive search
+      // over the whole record also matches the per-plugin tokens under
+      // `mcpOAuth`, which import cleanly and then 401 on every request.
+      const claudeAiOauth = findOauthTokenSet(record.claudeAiOauth);
+      if (claudeAiOauth?.accessToken || claudeAiOauth?.refreshToken) {
+        return {
+          accessToken: claudeAiOauth.accessToken,
+          refreshToken: claudeAiOauth.refreshToken,
+          sourceFile: `keychain:${label}`
+        };
+      }
+      const nested = findOauthTokenSet(record);
+      if (nested?.accessToken || nested?.refreshToken) {
+        nestedMatch ??= {
+          accessToken: nested.accessToken,
+          refreshToken: nested.refreshToken,
+          sourceFile: `keychain:${label}`
+        };
+        continue;
+      }
+      scan.tokenless.push(`keychain:${label} (keys: ${Object.keys(record).join(", ")})`);
+    }
+  }
+  // Every tier is exhausted before falling back to a nested match, so an
+  // explicit `claudeAiOauth` on any item always wins.
+  return nestedMatch;
+}
+
+// `security dump-keychain` without `-d` prints item *metadata* only: it never
+// decrypts a password and never prompts. Finds login items this environment
+// cannot name, newest-modified first.
+function discoverClaudeCodeKeychainItems(): ClaudeCodeKeychainCandidate[] {
+  let dump: string;
   try {
-    const output = execFileSync(
-      "security",
-      ["find-generic-password", "-s", claudeCodeKeychainService, "-w"],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
-    );
-    const parsed = JSON.parse(output.trim()) as unknown;
-    return isRecord(parsed) ? parsed : undefined;
+    dump = execFileSync("security", ["dump-keychain"], {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"]
+    });
   } catch {
+    return [];
+  }
+  const found: Array<ClaudeCodeKeychainCandidate & { modified: string }> = [];
+  let account: string | undefined;
+  let modified = "";
+  let service: string | undefined;
+  const flush = () => {
+    if (service && claudeCodeKeychainServicePattern.test(service)) {
+      found.push({ account, modified, service });
+    }
+    account = undefined;
+    modified = "";
+    service = undefined;
+  };
+  for (const line of dump.split("\n")) {
+    if (line.startsWith("keychain:")) {
+      flush();
+      continue;
+    }
+    const serviceMatch = /^\s*"svce"<blob>="(.*)"$/.exec(line);
+    if (serviceMatch) {
+      service = serviceMatch[1];
+      continue;
+    }
+    const accountMatch = /^\s*"acct"<blob>="(.*)"$/.exec(line);
+    if (accountMatch) {
+      account = accountMatch[1];
+      continue;
+    }
+    const modifiedMatch = /^\s*"mdat"<timedate>=.*"(\d{14})Z/.exec(line);
+    if (modifiedMatch) {
+      modified = modifiedMatch[1];
+    }
+  }
+  flush();
+  return found
+    .sort((left, right) => right.modified.localeCompare(left.modified))
+    .map(({ account: itemAccount, service: itemService }) => ({ account: itemAccount, service: itemService }));
+}
+
+function readClaudeCodeKeychainRecord(
+  candidate: ClaudeCodeKeychainCandidate,
+  scan: ClaudeCodeLoginScan,
+  label: string
+): Record<string, unknown> | undefined {
+  const args = ["find-generic-password", "-s", candidate.service, "-w"];
+  if (candidate.account !== undefined) {
+    args.splice(1, 0, "-a", candidate.account);
+  }
+  try {
+    const output = execFileSync("security", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    const parsed = JSON.parse(output.trim()) as unknown;
+    if (isRecord(parsed)) {
+      return parsed;
+    }
+    scan.errors.push(`keychain:${label}: item is not a JSON object`);
+    return undefined;
+  } catch (error) {
+    const message = keychainErrorMessage(error);
+    // errSecItemNotFound is the ordinary "no such login" answer, not a fault:
+    // recording it would turn a logged-out machine into a `locked` candidate.
+    if (message !== undefined) {
+      scan.errors.push(`keychain:${label}: ${message}`);
+    }
     return undefined;
   }
+}
+
+// Returns undefined when the item simply does not exist.
+function keychainErrorMessage(error: unknown): string | undefined {
+  if (error instanceof SyntaxError) {
+    return `item is not valid JSON (${error.message})`;
+  }
+  const failure = error as { status?: number; stderr?: Buffer | string } | undefined;
+  if (failure?.status === keychainItemNotFoundStatus) {
+    return undefined;
+  }
+  const stderr = typeof failure?.stderr === "string" ? failure.stderr : failure?.stderr?.toString("utf8");
+  const message = stderr?.trim().replace(/\s*\n\s*/g, "; ");
+  if (message) {
+    return /could not be found/i.test(message) ? undefined : message;
+  }
+  return failure?.status === undefined ? String(error) : `security exited ${failure.status}`;
 }

--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -10,12 +10,12 @@ import type {
 } from "@ccr/core/contracts/app";
 import {
   bearerAuthPlugin,
-  findOauthTokenSet,
   isRecord,
   missingCandidate,
   providerInternalNamePlaceholder,
   providerPayload,
   readJsonRecord,
+  readOauthTokenSetFields,
   uniqueProviderName,
   uniqueStrings,
   type OAuthTokenSet
@@ -201,7 +201,9 @@ export function scanClaudeCodeLogin(): ClaudeCodeLoginScan {
       continue;
     }
     scan.inspected.push(sourceFile);
-    const credential = findOauthTokenSet(record.claudeAiOauth) ?? findOauthTokenSet(record);
+    // Root-level fields only, same reasoning as the keychain path below: Claude
+    // Code writes this file with the identical record shape, mcpOAuth included.
+    const credential = readOauthTokenSetFields(record.claudeAiOauth) ?? readOauthTokenSetFields(record);
     if (!credential?.accessToken && !credential?.refreshToken) {
       scan.tokenless.push(`${sourceFile} (keys: ${Object.keys(record).join(", ")})`);
       continue;
@@ -288,7 +290,7 @@ function scanClaudeCodeKeychain(scan: ClaudeCodeLoginScan): OAuthTokenSet | unde
 
   const attempted = new Set<string>();
   const servicesRead = new Set<string>();
-  let nestedMatch: OAuthTokenSet | undefined;
+  let legacyRootMatch: OAuthTokenSet | undefined;
   for (const buildTier of tiers) {
     for (const candidate of buildTier()) {
       const key = `${candidate.service}\u0000${candidate.account ?? ""}`;
@@ -305,22 +307,26 @@ function scanClaudeCodeKeychain(scan: ClaudeCodeLoginScan): OAuthTokenSet | unde
       }
       servicesRead.add(candidate.service);
       scan.inspected.push(`keychain:${label}`);
-      // Only `claudeAiOauth` is an Anthropic API credential. A recursive search
-      // over the whole record also matches the per-plugin tokens under
-      // `mcpOAuth`, which import cleanly and then 401 on every request.
-      const claudeAiOauth = findOauthTokenSet(record.claudeAiOauth);
-      if (claudeAiOauth?.accessToken || claudeAiOauth?.refreshToken) {
+      // Only `claudeAiOauth` is an Anthropic API credential. Both reads are
+      // root-level: a recursive search would descend into `mcpOAuth`, whose
+      // per-plugin records also carry `accessToken`, and that token imports
+      // cleanly as a provider and then 401s on every request. Restricting to
+      // root-level fields excludes *any* nested container, so a future sibling
+      // key cannot reintroduce the hole.
+      const claudeAiOauth = readOauthTokenSetFields(record.claudeAiOauth);
+      if (claudeAiOauth) {
         return {
           accessToken: claudeAiOauth.accessToken,
           refreshToken: claudeAiOauth.refreshToken,
           sourceFile: `keychain:${label}`
         };
       }
-      const nested = findOauthTokenSet(record);
-      if (nested?.accessToken || nested?.refreshToken) {
-        nestedMatch ??= {
-          accessToken: nested.accessToken,
-          refreshToken: nested.refreshToken,
+      // Pre-`claudeAiOauth` layout, where the tokens sat at the record root.
+      const legacyRoot = readOauthTokenSetFields(record);
+      if (legacyRoot) {
+        legacyRootMatch ??= {
+          accessToken: legacyRoot.accessToken,
+          refreshToken: legacyRoot.refreshToken,
           sourceFile: `keychain:${label}`
         };
         continue;
@@ -328,9 +334,9 @@ function scanClaudeCodeKeychain(scan: ClaudeCodeLoginScan): OAuthTokenSet | unde
       scan.tokenless.push(`keychain:${label} (keys: ${Object.keys(record).join(", ")})`);
     }
   }
-  // Every tier is exhausted before falling back to a nested match, so an
+  // Every tier is exhausted before falling back to a root-level match, so an
   // explicit `claudeAiOauth` on any item always wins.
-  return nestedMatch;
+  return legacyRootMatch;
 }
 
 // `security dump-keychain` without `-d` prints item *metadata* only: it never

--- a/packages/core/src/agents/local-providers/shared.ts
+++ b/packages/core/src/agents/local-providers/shared.ts
@@ -130,8 +130,11 @@ export function cloneProviderAccountConfig(account: ProviderAccountConfig | unde
   return account ? JSON.parse(JSON.stringify(account)) as ProviderAccountConfig : undefined;
 }
 
-export function findOauthTokenSet(value: unknown, depth = 0): { accessToken?: string; refreshToken?: string } | undefined {
-  if (!isRecord(value) || depth > 5) {
+// Reads the token fields on `value` itself, never descending into children.
+// Callers that know their record shape use this to avoid matching an unrelated
+// nested credential -- see the mcpOAuth note in claude-code.ts.
+export function readOauthTokenSetFields(value: unknown): { accessToken?: string; refreshToken?: string } | undefined {
+  if (!isRecord(value)) {
     return undefined;
   }
   const accessToken =
@@ -142,8 +145,16 @@ export function findOauthTokenSet(value: unknown, depth = 0): { accessToken?: st
     readString(value.refreshToken) ||
     readString(value.refresh_token) ||
     readString(value.anthropicRefreshToken);
-  if (accessToken || refreshToken) {
-    return { accessToken, refreshToken };
+  return accessToken || refreshToken ? { accessToken, refreshToken } : undefined;
+}
+
+export function findOauthTokenSet(value: unknown, depth = 0): { accessToken?: string; refreshToken?: string } | undefined {
+  if (!isRecord(value) || depth > 5) {
+    return undefined;
+  }
+  const direct = readOauthTokenSetFields(value);
+  if (direct) {
+    return direct;
   }
   for (const child of Object.values(value)) {
     const found = findOauthTokenSet(child, depth + 1);

--- a/packages/core/test/unit/agents/local-agent-provider-claude-code.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-claude-code.test.mjs
@@ -184,6 +184,78 @@ test("Claude Code local provider ignores mcpOAuth plugin tokens in favour of cla
   });
 });
 
+// Regression for the review on #1604: an mcpOAuth-only record must yield no
+// token at all, not a plugin token demoted to a fallback.
+test("Claude Code local provider does not import an mcpOAuth-only keychain token", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async () => {
+    await withPlatform("darwin", async () => {
+      await withFakeSecurityKeychain([
+        {
+          account: keychainAccount,
+          modified: "20260729042837",
+          record: {
+            mcpOAuth: {
+              "plugin:github|1": {
+                accessToken: "mcp-plugin-token",
+                refreshToken: "mcp-plugin-refresh"
+              }
+            }
+          },
+          service: "Claude Code-credentials"
+        }
+      ], async () => {
+        const candidate = claudeCodeCandidate();
+
+        assert.equal(candidate.status, "locked");
+        assert.equal(candidate.importable, false);
+        assert.match(candidate.detail, /no OAuth token/);
+        assert.match(candidate.detail, /mcpOAuth/);
+        assert.throws(
+          () => importClaudeCodeProvider(candidate, []),
+          /Claude Code access token was not found/
+        );
+      });
+    });
+  });
+});
+
+// An mcpOAuth-only keychain record must not short-circuit the file fallback.
+test("Claude Code local provider prefers file credentials over an mcpOAuth-only keychain token", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async (home) => {
+    await withPlatform("darwin", async () => {
+      await withFakeSecurityKeychain([
+        {
+          account: keychainAccount,
+          modified: "20260729042837",
+          record: {
+            mcpOAuth: {
+              "plugin:github|1": {
+                accessToken: "mcp-plugin-token",
+                refreshToken: "mcp-plugin-refresh"
+              }
+            }
+          },
+          service: "Claude Code-credentials"
+        }
+      ], async () => {
+        const credentialFile = writeClaudeCredentials(home, {
+          accessToken: "file-access-token",
+          refreshToken: "file-refresh-token"
+        });
+
+        const candidate = claudeCodeCandidate();
+
+        assert.equal(candidate.status, "available");
+        assert.equal(candidate.importable, true);
+        assert.equal(candidate.sourceFile, credentialFile);
+
+        const result = importClaudeCodeProvider(candidate, []);
+        assert.equal(result.providerPlugins[0].auth.headers.authorization, "Bearer file-access-token");
+      });
+    });
+  });
+});
+
 // With CLAUDE_CONFIG_DIR set, Claude Code appends the first 8 hex of
 // sha256(NFC(configDir)) to the service name.
 test("Claude Code local provider reads the config-dir-suffixed keychain service", { skip: process.platform === "win32" }, async () => {

--- a/packages/core/test/unit/agents/local-agent-provider-claude-code.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-claude-code.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -24,7 +25,7 @@ test("Claude Code local provider prefers macOS Keychain credentials over stale f
         const candidate = claudeCodeCandidate();
         assert.equal(candidate.status, "available");
         assert.equal(candidate.importable, true);
-        assert.equal(candidate.sourceFile, "keychain:Claude Code-credentials");
+        assert.equal(candidate.sourceFile, `keychain:Claude Code-credentials (${keychainAccount})`);
 
         const result = importClaudeCodeProvider(candidate, []);
         assert.equal(result.providerPlugins[0].auth.headers.authorization, "Bearer keychain-access-token");
@@ -100,6 +101,151 @@ test("Core gateway config replaces imported Claude Code OAuth token with live ma
   });
 });
 
+// Claude Code >= 2.1 writes the credential item under the current $USER and
+// leaves any pre-2.1 item (account "unknown") in place on the same service
+// name. A lookup without `-a` matches the stale one, which only carries MCP
+// plugin OAuth. See musistudio/claude-code-router#1601.
+test("Claude Code local provider reads the credential item stored under the current account", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async () => {
+    await withPlatform("darwin", async () => {
+      await withFakeSecurityKeychain([
+        {
+          account: "unknown",
+          modified: "20260604091803",
+          record: { mcpOAuth: { "plugin:github|1": { expiresAt: 1 } } },
+          service: "Claude Code-credentials"
+        },
+        {
+          account: keychainAccount,
+          modified: "20260729042837",
+          record: { claudeAiOauth: { accessToken: "live-access-token", refreshToken: "live-refresh-token" } },
+          service: "Claude Code-credentials"
+        }
+      ], async () => {
+        const candidate = claudeCodeCandidate();
+        assert.equal(candidate.status, "available");
+        assert.equal(candidate.importable, true);
+        assert.equal(candidate.sourceFile, `keychain:Claude Code-credentials (${keychainAccount})`);
+
+        const result = importClaudeCodeProvider(candidate, []);
+        assert.equal(result.providerPlugins[0].auth.headers.authorization, "Bearer live-access-token");
+      });
+    });
+  });
+});
+
+// The only path to an item written under a different account (a login made as
+// another user, or a $USER that has since changed) is `security dump-keychain`
+// enumeration; the expected-name lookup cannot reach it.
+test("Claude Code local provider enumerates the keychain to find an item under another account", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async () => {
+    await withPlatform("darwin", async () => {
+      await withFakeSecurityKeychain([
+        {
+          account: "other-user",
+          modified: "20260729042837",
+          record: { claudeAiOauth: { accessToken: "enumerated-access-token" } },
+          service: "Claude Code-credentials",
+          accountlessLookup: false
+        }
+      ], async () => {
+        const candidate = claudeCodeCandidate();
+        assert.equal(candidate.status, "available");
+        assert.equal(candidate.importable, true);
+        assert.equal(candidate.sourceFile, "keychain:Claude Code-credentials (other-user)");
+
+        const result = importClaudeCodeProvider(candidate, []);
+        assert.equal(result.providerPlugins[0].auth.headers.authorization, "Bearer enumerated-access-token");
+      });
+    });
+  });
+});
+
+// mcpOAuth holds per-plugin tokens that are not Anthropic API credentials;
+// importing one yields a provider that 401s on every request.
+test("Claude Code local provider ignores mcpOAuth plugin tokens in favour of claudeAiOauth", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async () => {
+    await withPlatform("darwin", async () => {
+      await withFakeSecurityKeychain([
+        {
+          account: keychainAccount,
+          modified: "20260729042837",
+          record: {
+            mcpOAuth: { "plugin:github|1": { accessToken: "mcp-plugin-token", refreshToken: "mcp-plugin-refresh" } },
+            claudeAiOauth: { accessToken: "live-access-token", refreshToken: "live-refresh-token" }
+          },
+          service: "Claude Code-credentials"
+        }
+      ], async () => {
+        const result = importClaudeCodeProvider(claudeCodeCandidate(), []);
+        assert.equal(result.providerPlugins[0].auth.headers.authorization, "Bearer live-access-token");
+      });
+    });
+  });
+});
+
+// With CLAUDE_CONFIG_DIR set, Claude Code appends the first 8 hex of
+// sha256(NFC(configDir)) to the service name.
+test("Claude Code local provider reads the config-dir-suffixed keychain service", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async (home) => {
+    await withPlatform("darwin", async () => {
+      const configDir = path.join(home, "alt-claude");
+      const suffix = createHash("sha256").update(configDir.normalize("NFC")).digest("hex").slice(0, 8);
+      const service = `Claude Code-credentials-${suffix}`;
+      await withEnv("CLAUDE_CONFIG_DIR", configDir, async () => {
+        await withFakeSecurityKeychain([
+          {
+            account: keychainAccount,
+            modified: "20260729042837",
+            record: { claudeAiOauth: { accessToken: "suffixed-access-token" } },
+            service
+          }
+        ], async () => {
+          const candidate = claudeCodeCandidate();
+          assert.equal(candidate.status, "available");
+          assert.equal(candidate.sourceFile, `keychain:${service} (${keychainAccount})`);
+        });
+      });
+    });
+  });
+});
+
+test("Claude Code local provider explains login state that carries no OAuth token", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async () => {
+    await withPlatform("darwin", async () => {
+      await withFakeSecurityKeychain([
+        {
+          account: keychainAccount,
+          modified: "20260729042837",
+          record: { mcpOAuth: { "plugin:github|1": { expiresAt: 1 } } },
+          service: "Claude Code-credentials"
+        }
+      ], async () => {
+        const candidate = claudeCodeCandidate();
+        assert.equal(candidate.status, "locked");
+        assert.equal(candidate.importable, false);
+        assert.match(candidate.detail, /no OAuth token/);
+        assert.match(candidate.detail, /mcpOAuth/);
+      });
+    });
+  });
+});
+
+// errSecItemNotFound is the ordinary logged-out answer: it must not be reported
+// as an unreadable store.
+test("Claude Code local provider reports a missing candidate when no keychain item exists", { skip: process.platform === "win32" }, async () => {
+  await withClaudeCodeHome(async () => {
+    await withPlatform("darwin", async () => {
+      await withFakeSecurityKeychain([], async () => {
+        const candidate = claudeCodeCandidate();
+        assert.equal(candidate.status, "missing");
+        assert.equal(candidate.importable, false);
+        assert.equal(candidate.detail, "No local login state was found for this agent.");
+      });
+    });
+  });
+});
+
 async function withClaudeCodeHome(run) {
   const home = mkdtempSync(path.join(os.tmpdir(), "ccr-claude-code-provider-"));
   const previousHome = process.env.HOME;
@@ -133,18 +279,106 @@ async function withFakeSecurityFailure(run) {
   await withFakeSecurityScript("exit 44\n", run);
 }
 
+// Pins $USER as well as PATH: the provider looks the keychain item up under the
+// current account, so the expected item name has to be deterministic.
 async function withFakeSecurityScript(body, run) {
   const binDir = mkdtempSync(path.join(os.tmpdir(), "ccr-security-bin-"));
   const securityPath = path.join(binDir, "security");
   const previousPath = process.env.PATH;
+  const previousUser = process.env.USER;
   writeFileSync(securityPath, `#!/bin/sh\n${body}`);
   chmodSync(securityPath, 0o755);
   process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+  process.env.USER = keychainAccount;
   try {
     await run();
   } finally {
     restoreEnv("PATH", previousPath);
+    restoreEnv("USER", previousUser);
     rmSync(binDir, { force: true, recursive: true });
+  }
+}
+
+const keychainAccount = "ccr-test-user";
+
+// Stands in for the macOS keychain: `find-generic-password` matches on
+// service+account, an omitted `-a` matches the first item registered for the
+// service (as the real Keychain picks an arbitrary one), and `dump-keychain`
+// prints the metadata-only listing the provider parses.
+async function withFakeSecurityKeychain(items, run) {
+  await withFakeSecurityScript(fakeSecurityBody(items), run);
+}
+
+function fakeSecurityBody(items) {
+  const dump = [
+    ...items.map(item => [
+      `keychain: "/tmp/login.keychain-db"`,
+      "version: 512",
+      "class: \"genp\"",
+      "attributes:",
+      `    "acct"<blob>="${item.account}"`,
+      `    "mdat"<timedate>=0x00  "${item.modified}Z\\000"`,
+      `    "svce"<blob>="${item.service}"`
+    ].join("\n")),
+    [
+      `keychain: "/tmp/login.keychain-db"`,
+      "attributes:",
+      `    "acct"<blob>="unrelated"`,
+      `    "svce"<blob>="Bitwarden Safe Storage"`
+    ].join("\n")
+  ].join("\n");
+
+  // `accountlessLookup: false` models an item the Keychain will not return for
+  // a `-s`-only query, so only enumeration can reach it.
+  const firstForService = new Map();
+  for (const item of items) {
+    if (item.accountlessLookup !== false && !firstForService.has(item.service)) {
+      firstForService.set(item.service, item);
+    }
+  }
+  const branches = [
+    ...items.map((item, index) => ({ key: `${item.service}|${item.account}`, record: item.record, tag: `CCR_J${index}` })),
+    ...[...firstForService.values()].map((item, index) => ({ key: `${item.service}|`, record: item.record, tag: `CCR_A${index}` }))
+  ];
+
+  return [
+    `if [ "$1" = "dump-keychain" ]; then`,
+    `cat <<'CCR_DUMP'`,
+    dump,
+    "CCR_DUMP",
+    "exit 0",
+    "fi",
+    "shift",
+    "acct=''",
+    "svc=''",
+    "while [ $# -gt 0 ]; do",
+    `  case "$1" in`,
+    `    -a) acct="$2"; shift 2 ;;`,
+    `    -s) svc="$2"; shift 2 ;;`,
+    "    *) shift ;;",
+    "  esac",
+    "done",
+    `case "$svc|$acct" in`,
+    ...branches.map(branch => [
+      `"${branch.key}")`,
+      `cat <<'${branch.tag}'`,
+      JSON.stringify(branch.record),
+      branch.tag,
+      "exit 0 ;;"
+    ].join("\n")),
+    "esac",
+    `echo 'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.' >&2`,
+    "exit 44"
+  ].join("\n");
+}
+
+async function withEnv(name, value, run) {
+  const previous = process.env[name];
+  process.env[name] = value;
+  try {
+    await run();
+  } finally {
+    restoreEnv(name, previous);
   }
 }
 


### PR DESCRIPTION
Fixes #1601. Likely also fixes #1567 — see the `mcpOAuth` note below.

## Problem

On macOS with Claude Code >= 2.1, "Import Local Agent Login → Claude Code" finds no credentials and fails silently.

Claude Code writes its credential item under the current `$USER`, and leaves any pre-2.1 item (account `unknown`) in place on the **same** service name, `Claude Code-credentials`. `readClaudeCodeKeychainRecord()` runs:

```
security find-generic-password -s "Claude Code-credentials" -w      # no -a
```

With no `-a`, the Keychain returns an arbitrary item among those sharing the service — in practice the stale legacy one, which carries only `mcpOAuth`. The read exits 0, the JSON parses, `findOauthTokenSet()` correctly returns `undefined`, and `service.ts` then drops the candidate entirely via `.filter(c => c.status !== "missing")`. Hence: no token, no error, no entry in Add Provider.

`security dump-keychain | grep svce` de-duplicates the two same-named items, which makes this easy to misdiagnose as a service-name-suffix problem. It isn't — on a default install the service name is exactly the legacy one CCR already uses. **The account is the only thing missing in the common case.**

Full analysis, including the naming algorithm decompiled out of the 2.1.220 binary: https://github.com/musistudio/claude-code-router/issues/1601#issuecomment-5116055653

## Change

`packages/core/src/agents/local-providers/claude-code.ts` only (plus tests).

**Tiered candidate resolution**, lazily evaluated so the normal case stays at one `security` call:

1. the expected service name, derived the way Claude Code derives it — `` `Claude Code${oauthSuffix}-credentials${configSuffix}` ``, where `configSuffix` is `-${sha256(NFC(configDir)).slice(0, 8)}` once `CLAUDE_CONFIG_DIR` / `CLAUDE_SECURESTORAGE_CONFIG_DIR` is set — read under the current account;
2. `security dump-keychain` enumeration, newest-modified first, for items under another account or a config dir this process cannot reconstruct. Without `-d` that prints item **metadata only**: it never decrypts a password and never prompts;
3. the previous accountless read, as a last resort.

**`claudeAiOauth` wins over the recursive search.** `mcpOAuth` holds per-plugin OAuth records that also carry `accessToken`, and key order puts it first — so a recursive match can import an MCP plugin token as an Anthropic provider that then 401s on every request. Recursive search is now a fallback used only when no candidate has an explicit `claudeAiOauth`. This is why I think it also covers #1567.

**Diagnostics instead of silence.** `security` stderr is captured rather than discarded via `stdio: ["ignore","pipe","ignore"]`, and a `locked` candidate naming the reason is returned when login state exists but yields no token, so it survives the `status !== "missing"` filter. `errSecItemNotFound` (exit 44) is treated as absence, not an error, so a machine with no Claude Code login still correctly reports `missing` rather than a confusing `locked`.

**File fallback fixed.** `continue` past a credentials file that holds no token instead of returning it, and check the secure-storage config dir, which the env vars above can relocate away from `~/.claude`.

No public API changed. `readClaudeCodeOauth()` keeps its signature; `scanClaudeCodeLogin()` is added for the diagnostic path.

## Verification

- **9/9** in `local-agent-provider-claude-code.test.mjs`. 6 are new: per-account lookup (this bug), `dump-keychain` enumeration for an item under another account, `mcpOAuth` rejection in favour of `claudeAiOauth`, config-dir-suffixed service name, the tokenless diagnostic, and logged-out-stays-`missing`. The 3 pre-existing tests still pass; one assertion changed because `sourceFile` now names the account (`keychain:Claude Code-credentials (<user>)`), which is display-only — it feeds a tooltip in `providers.tsx`.
- `npm run test:core`: **651/660**. The 4 failures (`RequestLogStore bounded heap regression`, 3 Claude Design plugin config) are identical on an unmodified tree at `v3.0.17` (645/654), so they are pre-existing and unrelated.
- `tsc --noEmit` clean.
- End-to-end on a real machine with Claude Code 2.1.220 and a subscription login: `getLocalAgentProviderCandidates` over the live web RPC returns `status=available importable=true`; import produces a provider whose bearer gets **HTTP 200** from `GET /api/oauth/usage` with real quota data, and a real inference request through the gateway on `/v1/messages` returns **200**. So it resolves the correct live token, not an MCP one.

Tested only on macOS/arm64 — the changed code paths are all `process.platform === "darwin"`-gated.
