### PR TITLE
fix: validator thinking blocks + SSE streaming termination (npm 2.1.1 dist)

### DIFF
--- a/.pr-description.md
+++ b/.pr-description.md
@@ -1,0 +1,33 @@
+# Fix: Anthropic content block validator rejects thinking/redacted_thinking blocks
+
+## Problem
+
+Claude Code CLI 2.1.x introduced **interleaved-thinking** and **redact-thinking** features. When CCR receives these requests, the Anthropic content block validator throws `Unknown content block type "thinking"` / `"redacted_thinking"`, causing all requests with thinking blocks to fail.
+
+This affects:
+- `claude --model claude-sonnet-4-20250514` with extended thinking enabled
+- Any client sending `thinking` or `redacted_thinking` content blocks per the [Anthropic Messages API](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
+
+## Root Cause
+
+The content block `switch` statement in `validateContentBlocks()` had no cases for `thinking`, `redacted_thinking`, `server_tool_use`, `web_search_tool_result`, or `container_upload`. The `default` branch threw a `ValidationError` for any unrecognized type.
+
+## Solution
+
+1. **Added `packages/core/src/input/anthropic/validator.ts`** — a proper TypeScript validator source with full content block support including thinking blocks. This source was missing from the repo (it only existed in the npm-published `dist/`).
+2. **Added cases** for `thinking`, `redacted_thinking`, `server_tool_use`, `web_search_tool_result`, `container_upload`.
+3. **Changed `default` to `break`** instead of throwing — forward-compatible with future block types.
+4. **Added unit tests** covering all block types and edge cases.
+5. **Added `scripts/patch-npm-dist.sh`** — maintenance script for users of the npm-installed version (v2.1.x) who can't upgrade immediately. Patches the bundled `dist/` validator in-place after `npm update`.
+
+## Testing
+
+```bash
+cd packages/core
+pnpm test -- validator
+```
+
+All 20 test cases pass:
+- ✅ Valid: minimal request, text blocks, thinking blocks, redacted_thinking blocks, tool_use/tool_result, image blocks, system array, tools
+- ✅ Invalid: non-object, missing model, missing messages, empty messages, invalid role, thinking without field, redacted_thinking without data, tool_use without id, tool_result without tool_use_id, invalid max_tokens, invalid temperature
+- ✅ Forward compatibility: unknown block types allowed

--- a/packages/core/src/input/anthropic/validator.test.ts
+++ b/packages/core/src/input/anthropic/validator.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateAnthropicRequest,
+  ValidationError,
+} from "./validator";
+
+describe("validateAnthropicRequest", () => {
+  // --- Valid requests ---
+
+  it("accepts a minimal valid request", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [{ role: "user", content: "Hello" }],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts content as array of text blocks", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Hello" }],
+          },
+        ],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts thinking blocks (Claude Code 2.1.x interleaved-thinking)", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "Let me analyze this..." },
+              { type: "text", text: "Here is my response." },
+            ],
+          },
+          { role: "user", content: "Follow up" },
+        ],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts redacted_thinking blocks (redact-thinking)", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "redacted_thinking", data: "encrypted-data-here" },
+              { type: "text", text: "Response after redacted thinking." },
+            ],
+          },
+        ],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts tool_use and tool_result blocks", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_01abc",
+                name: "get_weather",
+                input: { city: "SF" },
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_01abc",
+                content: "Sunny, 72F",
+              },
+            ],
+          },
+        ],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts image blocks", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "iVBORw0KGgo=",
+                },
+              },
+            ],
+          },
+        ],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts system as array", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        system: [{ type: "text", text: "You are a helpful assistant." }],
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts tools", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        tools: [
+          {
+            name: "get_weather",
+            description: "Get weather",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        messages: [{ role: "user", content: "Weather?" }],
+        max_tokens: 1024,
+      })
+    ).toBe(true);
+  });
+
+  // --- Invalid requests ---
+
+  it("rejects non-object request", () => {
+    expect(() => validateAnthropicRequest(null)).toThrow(ValidationError);
+    expect(() => validateAnthropicRequest("string")).toThrow(ValidationError);
+  });
+
+  it("rejects missing model", () => {
+    expect(() =>
+      validateAnthropicRequest({ messages: [] })
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects missing messages", () => {
+    expect(() =>
+      validateAnthropicRequest({ model: "claude" })
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects empty messages", () => {
+    expect(() =>
+      validateAnthropicRequest({ model: "claude", messages: [] })
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects invalid role", () => {
+    expect(() =>
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [{ role: "system_admin", content: "hi" }],
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects thinking block without thinking field", () => {
+    expect(() =>
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "thinking" }],
+          },
+        ],
+      })
+    ).toThrow(/Thinking block.*must have thinking field/);
+  });
+
+  it("rejects redacted_thinking block without data field", () => {
+    expect(() =>
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "redacted_thinking" }],
+          },
+        ],
+      })
+    ).toThrow(/Redacted thinking block.*must have data field/);
+  });
+
+  it("rejects tool_use without id", () => {
+    expect(() =>
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "tool_use", name: "test", input: {} }],
+          },
+        ],
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects tool_result without tool_use_id", () => {
+    expect(() =>
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "tool_result", content: "result" }],
+          },
+        ],
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects invalid max_tokens", () => {
+    expect(() =>
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: -1,
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects invalid temperature", () => {
+    expect(() =>
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 2,
+      })
+    ).toThrow(ValidationError);
+  });
+
+  // --- Forward compatibility ---
+
+  it("allows unknown block types (forward-compatible)", () => {
+    expect(
+      validateAnthropicRequest({
+        model: "claude",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "future_block_type", data: "whatever" }],
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/input/anthropic/validator.ts
+++ b/packages/core/src/input/anthropic/validator.ts
@@ -1,0 +1,288 @@
+/**
+ * Anthropic Request Validator
+ *
+ * Validates incoming Anthropic-format requests against the Anthropic Messages API
+ * specification. Supports all content block types including thinking and
+ * redacted_thinking blocks introduced by Claude Code CLI 2.1.x
+ * (interleaved-thinking + redact-thinking).
+ *
+ * @see https://docs.anthropic.com/en/api/messages
+ */
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  thinking?: string;
+  data?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  source?: unknown;
+  [key: string]: unknown;
+}
+
+interface AnthropicMessage {
+  role: string;
+  content: string | ContentBlock[];
+  [key: string]: unknown;
+}
+
+interface SystemMessage {
+  type: string;
+  text: string;
+  [key: string]: unknown;
+}
+
+interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface AnthropicRequest {
+  model: string;
+  messages: AnthropicMessage[];
+  system?: SystemMessage[];
+  tools?: AnthropicTool[];
+  max_tokens?: number;
+  temperature?: number;
+  stream?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Validates an Anthropic-format request.
+ *
+ * @throws {ValidationError} if the request is invalid
+ * @returns `true` if validation passes
+ */
+export function validateAnthropicRequest(request: unknown): true {
+  if (!request || typeof request !== "object") {
+    throw new ValidationError("Request must be an object");
+  }
+
+  const req = request as AnthropicRequest;
+
+  // Required fields
+  if (!req.model || typeof req.model !== "string") {
+    throw new ValidationError("Model is required and must be a string");
+  }
+
+  if (!req.messages || !Array.isArray(req.messages)) {
+    throw new ValidationError("Messages are required and must be an array");
+  }
+
+  if (req.messages.length === 0) {
+    throw new ValidationError("At least one message is required");
+  }
+
+  // Validate messages
+  for (let i = 0; i < req.messages.length; i++) {
+    const message = req.messages[i];
+    if (!message || typeof message !== "object") {
+      throw new ValidationError(`Message at index ${i} must be an object`);
+    }
+    if (!message.role || typeof message.role !== "string") {
+      throw new ValidationError(`Message at index ${i} must have a role`);
+    }
+    if (!["user", "assistant", "system"].includes(message.role)) {
+      throw new ValidationError(
+        `Invalid role "${message.role}" at message index ${i}`
+      );
+    }
+    if (message.content === undefined || message.content === null) {
+      throw new ValidationError(`Message at index ${i} must have content`);
+    }
+    if (
+      typeof message.content !== "string" &&
+      !Array.isArray(message.content)
+    ) {
+      throw new ValidationError(
+        `Message content at index ${i} must be string or array`
+      );
+    }
+    if (Array.isArray(message.content)) {
+      validateContentBlocks(message.content, i);
+    }
+  }
+
+  // Optional system validation
+  if (req.system !== undefined) {
+    if (!Array.isArray(req.system)) {
+      throw new ValidationError("System must be an array");
+    }
+    for (let i = 0; i < req.system.length; i++) {
+      const systemMsg = req.system[i];
+      if (!systemMsg || typeof systemMsg !== "object") {
+        throw new ValidationError(
+          `System message at index ${i} must be an object`
+        );
+      }
+      if (systemMsg.type !== "text") {
+        throw new ValidationError(
+          `System message at index ${i} must have type "text"`
+        );
+      }
+      if (!systemMsg.text || typeof systemMsg.text !== "string") {
+        throw new ValidationError(
+          `System message at index ${i} must have text field`
+        );
+      }
+    }
+  }
+
+  // Optional tools validation
+  if (req.tools !== undefined) {
+    if (!Array.isArray(req.tools)) {
+      throw new ValidationError("Tools must be an array");
+    }
+    for (let i = 0; i < req.tools.length; i++) {
+      const tool = req.tools[i];
+      if (!tool || typeof tool !== "object") {
+        throw new ValidationError(`Tool at index ${i} must be an object`);
+      }
+      if (!tool.name || typeof tool.name !== "string") {
+        throw new ValidationError(`Tool at index ${i} must have a name`);
+      }
+      if (!tool.description || typeof tool.description !== "string") {
+        throw new ValidationError(
+          `Tool at index ${i} must have a description`
+        );
+      }
+      if (!tool.input_schema || typeof tool.input_schema !== "object") {
+        throw new ValidationError(`Tool at index ${i} must have input_schema`);
+      }
+    }
+  }
+
+  // Optional numeric fields
+  if (req.max_tokens !== undefined) {
+    if (typeof req.max_tokens !== "number" || req.max_tokens <= 0) {
+      throw new ValidationError("max_tokens must be a positive number");
+    }
+  }
+  if (req.temperature !== undefined) {
+    if (
+      typeof req.temperature !== "number" ||
+      req.temperature < 0 ||
+      req.temperature > 1
+    ) {
+      throw new ValidationError(
+        "temperature must be a number between 0 and 1"
+      );
+    }
+  }
+  if (req.stream !== undefined && typeof req.stream !== "boolean") {
+    throw new ValidationError("stream must be a boolean");
+  }
+
+  return true;
+}
+
+/**
+ * Validates content blocks within a message.
+ * Supports all Anthropic content block types including thinking blocks.
+ */
+function validateContentBlocks(
+  content: ContentBlock[],
+  messageIndex: number
+): void {
+  for (let i = 0; i < content.length; i++) {
+    const block = content[i];
+    if (!block || typeof block !== "object") {
+      throw new ValidationError(
+        `Content block at index ${i} in message ${messageIndex} must be an object`
+      );
+    }
+    if (!block.type || typeof block.type !== "string") {
+      throw new ValidationError(
+        `Content block at index ${i} in message ${messageIndex} must have a type`
+      );
+    }
+
+    switch (block.type) {
+      case "text":
+        if (!block.text || typeof block.text !== "string") {
+          throw new ValidationError(
+            `Text block at index ${i} in message ${messageIndex} must have text field`
+          );
+        }
+        break;
+
+      case "tool_use":
+        if (!block.id || typeof block.id !== "string") {
+          throw new ValidationError(
+            `Tool use block at index ${i} in message ${messageIndex} must have id`
+          );
+        }
+        if (!block.name || typeof block.name !== "string") {
+          throw new ValidationError(
+            `Tool use block at index ${i} in message ${messageIndex} must have name`
+          );
+        }
+        if (block.input === undefined) {
+          throw new ValidationError(
+            `Tool use block at index ${i} in message ${messageIndex} must have input`
+          );
+        }
+        break;
+
+      case "tool_result":
+        if (!block.tool_use_id || typeof block.tool_use_id !== "string") {
+          throw new ValidationError(
+            `Tool result block at index ${i} in message ${messageIndex} must have tool_use_id`
+          );
+        }
+        if (block.content === undefined) {
+          throw new ValidationError(
+            `Tool result block at index ${i} in message ${messageIndex} must have content`
+          );
+        }
+        break;
+
+      case "image":
+        if (!block.source || typeof block.source !== "object") {
+          throw new ValidationError(
+            `Image block at index ${i} in message ${messageIndex} must have source`
+          );
+        }
+        break;
+
+      case "thinking":
+        if (!block.thinking || typeof block.thinking !== "string") {
+          throw new ValidationError(
+            `Thinking block at index ${i} in message ${messageIndex} must have thinking field`
+          );
+        }
+        break;
+
+      case "redacted_thinking":
+        if (!block.data || typeof block.data !== "string") {
+          throw new ValidationError(
+            `Redacted thinking block at index ${i} in message ${messageIndex} must have data field`
+          );
+        }
+        break;
+
+      // Pass-through for newer block types we don't need to validate deeply
+      case "server_tool_use":
+      case "web_search_tool_result":
+      case "container_upload":
+        break;
+
+      default:
+        // Unknown block types are allowed (forward-compatible)
+        break;
+    }
+  }
+}

--- a/packages/core/src/input/index.ts
+++ b/packages/core/src/input/index.ts
@@ -1,0 +1,4 @@
+export {
+  validateAnthropicRequest,
+  ValidationError,
+} from "./anthropic/validator";

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -274,3 +274,4 @@ export { TransformerService } from "./services/transformer";
 export { TokenizerService } from "./services/tokenizer";
 export { pluginManager, tokenSpeedPlugin, getTokenSpeedStats, getGlobalTokenSpeedStats, CCRPlugin, CCRPluginOptions, PluginMetadata } from "./plugins";
 export { SSEParserTransform, SSESerializerTransform, rewriteStream } from "./utils/sse";
+export { validateAnthropicRequest, ValidationError } from "./input";

--- a/scripts/patch-npm-dist.sh
+++ b/scripts/patch-npm-dist.sh
@@ -2,8 +2,14 @@
 #
 # CCR (claude-code-router) npm 2.1.1 patch script
 #
-# Fixes: Anthropic content block validator rejects thinking/redacted_thinking blocks
-# from Claude Code CLI 2.1.x (interleaved-thinking + redact-thinking).
+# Fixes two bugs in the npm-published dist that affect Claude Code CLI 2.1.x:
+#
+#   1. Validator rejects thinking/redacted_thinking blocks
+#      (interleaved-thinking + redact-thinking beta headers)
+#
+#   2. SSE streaming response never terminates properly
+#      (stop_reason deleted, message_stop filtered → Claude Code retries
+#       indefinitely, causing duplicate/repeated output)
 #
 # Usage:
 #   bash patch-npm-dist.sh          # auto-detect install path
@@ -122,6 +128,87 @@ else
   skipped=$((skipped + 1))
 fi
 
+# --- Patch 3: SSE streaming — filter provider framing events + restore stop_reason/message_stop ---
+echo ""
+echo "--- Patch: SSE streaming termination (stop_reason + message_stop) ---"
+
+if grep -q 'Filtered out message_stop event to allow conversation continuation' "$CLI" 2>/dev/null; then
+  node -e "
+    const fs = require('fs');
+    const f = process.argv[1];
+    let c = fs.readFileSync(f, 'utf8');
+
+    // Patch 3a: Filter provider's framing events instead of stripping stop_reason
+    const old3a = \`        if (chunk.event === \\\"message_delta\\\" && chunk.data?.delta?.stop_reason) {
+          const filteredData = { ...chunk.data };
+          if (filteredData.delta) {
+            filteredData.delta = { ...filteredData.delta };
+            delete filteredData.delta.stop_reason;
+            delete filteredData.delta.stop_sequence;
+          }
+          this.sendSSEEvent(reply, chunk.event, filteredData);
+        } else if (chunk.event === \\\"message_stop\\\") {
+          logger.debug(\\\"Filtered out message_stop event to allow conversation continuation\\\", {}, requestId, \\\"server\\\");
+        } else {
+          this.sendSSEEvent(reply, chunk.event, chunk.data);
+        }\`;
+    const new3a = \`        if (chunk.event === \\\"message_start\\\" || chunk.event === \\\"ping\\\" || chunk.event === \\\"message_delta\\\" || chunk.event === \\\"message_stop\\\") {
+          logger.debug(\\\"Filtered framing event from provider\\\", { event: chunk.event }, requestId, \\\"server\\\");
+        } else if ((chunk.event === \\\"content_block_start\\\" || chunk.event === \\\"content_block_stop\\\") && chunk.data?.index === 0) {
+          logger.debug(\\\"Filtered duplicate text block framing from provider\\\", { event: chunk.event }, requestId, \\\"server\\\");
+        } else {
+          this.sendSSEEvent(reply, chunk.event, chunk.data);
+        }\`;
+
+    if (c.includes(old3a)) {
+      c = c.replace(old3a, new3a);
+      console.log('  OK: Patch 3a applied (filter framing events)');
+    } else {
+      console.log('  SKIP: Patch 3a pattern not found (already patched or version changed)');
+    }
+
+    // Patch 3b: Restore stop_reason and message_stop at end of stream
+    const old3b = \`      this.sendSSEEvent(reply, \\\"message_delta\\\", {
+        type: \\\"message_delta\\\",
+        delta: {
+          // stop_reason: stopReason, // 移除停止原因，但保持HTTP连接正常结束
+          // stop_sequence: null      // 移除停止序列  
+        },
+        usage: {
+          output_tokens: outputTokens
+        }
+      });
+      reply.raw.end();\`;
+    const new3b = \`      this.sendSSEEvent(reply, \\\"message_delta\\\", {
+        type: \\\"message_delta\\\",
+        delta: {
+          stop_reason: \\\"end_turn\\\",
+          stop_sequence: null
+        },
+        usage: {
+          output_tokens: outputTokens
+        }
+      });
+      this.sendSSEEvent(reply, \\\"message_stop\\\", {
+        type: \\\"message_stop\\\"
+      });
+      reply.raw.end();\`;
+
+    if (c.includes(old3b)) {
+      c = c.replace(old3b, new3b);
+      console.log('  OK: Patch 3b applied (restore stop_reason + message_stop)');
+    } else {
+      console.log('  SKIP: Patch 3b pattern not found (already patched or version changed)');
+    }
+
+    fs.writeFileSync(f, c);
+  " "$CLI" 2>/dev/null
+  patched=$((patched + 1))
+else
+  echo "  SKIP (already patched or pattern changed): SSE streaming"
+  skipped=$((skipped + 1))
+fi
+
 # --- Summary ---
 echo ""
 echo "Done. Patched: $patched, Skipped: $skipped"
@@ -143,4 +230,8 @@ if [[ -f "$VALIDATOR" ]] && grep -q 'Unknown content block type' "$VALIDATOR" 2>
   echo "FAIL: validator.js still has 'Unknown content block type'"
   exit 1
 fi
-echo "PASS: No 'Unknown content block type' found — thinking blocks will be accepted"
+if grep -q 'Filtered out message_stop event to allow conversation continuation' "$CLI" 2>/dev/null; then
+  echo "FAIL: cli.js still strips message_stop (SSE streaming patch not applied)"
+  exit 1
+fi
+echo "PASS: All patches verified — thinking blocks accepted, SSE streams terminate correctly"

--- a/scripts/patch-npm-dist.sh
+++ b/scripts/patch-npm-dist.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# CCR (claude-code-router) npm 2.1.1 patch script
+#
+# Fixes: Anthropic content block validator rejects thinking/redacted_thinking blocks
+# from Claude Code CLI 2.1.x (interleaved-thinking + redact-thinking).
+#
+# Usage:
+#   bash patch-npm-dist.sh          # auto-detect install path
+#   bash patch-npm-dist.sh /path/to/claude-code-router
+#
+# Re-run after every `npm update` — npm overwrites dist/.
+#
+set -uo pipefail
+
+# --- locate install ---
+CCR_DIR="${1:-}"
+if [[ -z "$CCR_DIR" ]]; then
+  CCR_DIR="$(npm root -g 2>/dev/null)/claude-code-router"
+fi
+CLI="$CCR_DIR/dist/cli.js"
+VALIDATOR="$CCR_DIR/dist/input/anthropic/validator.js"
+
+if [[ ! -f "$CLI" ]]; then
+  echo "ERROR: $CLI not found. Pass the install path as argument."
+  exit 1
+fi
+
+echo "Patching CCR at: $CCR_DIR"
+echo "Version: $(node -e "console.log(require('$CCR_DIR/package.json').version)")"
+
+patched=0
+skipped=0
+
+# --- Patch 1: cli.js inline validator ---
+echo ""
+echo "--- Patch: content block validator (thinking blocks) ---"
+
+if grep -q 'Unknown content block type' "$CLI" 2>/dev/null; then
+  # Use node for reliable multiline patch (avoids perl escaping issues)
+  node -e "
+    const fs = require('fs');
+    const f = process.argv[1];
+    let c = fs.readFileSync(f, 'utf8');
+    const old = \`      default:\\n        throw new ValidationError(\\n          \\\`Unknown content block type \\\"\${'\\\${block.type}'}\\\" at index \${'\\\${i}'} in message \${'\\\${messageIndex}'}\\\`\\n        );\`;
+    // Simple: replace the throw-in-default with pass-through, insert thinking cases before default
+    c = c.replace(
+      /case \"image\":([\\s\\S]*?break;)\\n      default:\\n        throw new ValidationError\\([\\s\\S]*?Unknown content block type[\\s\\S]*?\\);/,
+      \`case \"image\":\$1
+      case \"thinking\":
+        if (!block.thinking || typeof block.thinking !== \"string\") {
+          throw new ValidationError(
+            \\\`Thinking block at index \${'\\\${i}'} in message \${'\\\${messageIndex}'} must have thinking field\\\`
+          );
+        }
+        break;
+      case \"redacted_thinking\":
+        if (!block.data || typeof block.data !== \"string\") {
+          throw new ValidationError(
+            \\\`Redacted thinking block at index \${'\\\${i}'} in message \${'\\\${messageIndex}'} must have data field\\\`
+          );
+        }
+        break;
+      case \"server_tool_use\":
+      case \"web_search_tool_result\":
+      case \"container_upload\":
+        break;
+      default:
+        break;\`
+    );
+    fs.writeFileSync(f, c);
+  " "$CLI" 2>/dev/null
+
+  if grep -q 'Unknown content block type' "$CLI" 2>/dev/null; then
+    echo "  WARN: regex replacement failed, trying line-based approach"
+  else
+    echo "  OK: cli.js patched"
+    patched=$((patched + 1))
+  fi
+else
+  echo "  SKIP (already patched or pattern changed): cli.js"
+  skipped=$((skipped + 1))
+fi
+
+# --- Patch 2: validator.js standalone module (if exists) ---
+if [[ -f "$VALIDATOR" ]] && grep -q 'Unknown content block type' "$VALIDATOR" 2>/dev/null; then
+  node -e "
+    const fs = require('fs');
+    const f = process.argv[1];
+    let c = fs.readFileSync(f, 'utf8');
+    c = c.replace(
+      /case 'image':([\\s\\S]*?break;)\\n            default:\\n                throw new types_1\\.ValidationError\\(\`Unknown content block type[\\s\\S]*?\\);/,
+      \`case 'image':\$1
+            case 'thinking':
+                if (!block.thinking || typeof block.thinking !== 'string') {
+                    throw new types_1.ValidationError(\\\`Thinking block at index \${'\\\${i}'} in message \${'\\\${messageIndex}'} must have thinking field\\\`);
+                }
+                break;
+            case 'redacted_thinking':
+                if (!block.data || typeof block.data !== 'string') {
+                    throw new types_1.ValidationError(\\\`Redacted thinking block at index \${'\\\${i}'} in message \${'\\\${messageIndex}'} must have data field\\\`);
+                }
+                break;
+            case 'server_tool_use':
+            case 'web_search_tool_result':
+            case 'container_upload':
+                break;
+            default:
+                break;\`
+    );
+    fs.writeFileSync(f, c);
+  " "$VALIDATOR" 2>/dev/null
+
+  if grep -q 'Unknown content block type' "$VALIDATOR" 2>/dev/null; then
+    echo "  WARN: regex replacement failed for validator.js"
+  else
+    echo "  OK: validator.js patched"
+    patched=$((patched + 1))
+  fi
+else
+  echo "  SKIP (already patched or file not found): validator.js"
+  skipped=$((skipped + 1))
+fi
+
+# --- Summary ---
+echo ""
+echo "Done. Patched: $patched, Skipped: $skipped"
+echo ""
+if [[ $patched -gt 0 ]]; then
+  echo "Next: restart CCR"
+  echo "  launchctl kickstart -k gui/\$(id -u)/com.claude-code-router.proxy"
+  echo "  # or: ccr restart"
+fi
+
+# --- Verify ---
+echo ""
+echo "--- Verification ---"
+if grep -q 'Unknown content block type' "$CLI" 2>/dev/null; then
+  echo "FAIL: cli.js still has 'Unknown content block type'"
+  exit 1
+fi
+if [[ -f "$VALIDATOR" ]] && grep -q 'Unknown content block type' "$VALIDATOR" 2>/dev/null; then
+  echo "FAIL: validator.js still has 'Unknown content block type'"
+  exit 1
+fi
+echo "PASS: No 'Unknown content block type' found — thinking blocks will be accepted"


### PR DESCRIPTION
# Fix: Anthropic validator + SSE streaming termination (npm 2.1.1 dist)

## Problem 1: Validator rejects thinking/redacted_thinking blocks

Claude Code CLI 2.1.x introduced **interleaved-thinking** and **redact-thinking** features. When CCR receives these requests, the Anthropic content block validator throws `Unknown content block type "thinking"` / `"redacted_thinking"`, causing all requests with thinking blocks to fail.

## Problem 2: SSE streaming never terminates — Claude Code repeats output

The npm 2.1.1 dist's `handleStreamingRequest` has three compounding bugs:

1. **Duplicate framing events**: Provider's `message_start`, `ping`, `message_delta`, `message_stop` are transparently forwarded alongside the handler's own copies. Claude Code sees double events per turn.

2. **`stop_reason` deleted**: `message_delta`'s `stop_reason` is explicitly stripped (code comment: "allow conversation continuation"). Claude Code never receives the `end_turn` signal.

3. **`message_stop` filtered**: The `message_stop` event is explicitly suppressed. Claude Code cannot determine that a response turn has completed.

**Combined effect**: Claude Code retries indefinitely, producing repeated output when using GLM or other non-Anthropic providers via CCR.

## Root Cause

Both bugs exist only in the npm-published `dist/`. The TypeScript source in `feature/2.0` already handles both correctly:
- `anthropic.transformer.ts`: thinking blocks supported (lines 163-171)
- `anthropic.transformer.ts` `convertOpenAIStreamToAnthropic()`: stop_reason and message_stop correctly emitted

The npm `dist/` is published from a different commit (orphan code).

## Solution

### Source (Problem 1 only)
1. Added `packages/core/src/input/anthropic/validator.ts` with full content block support including thinking blocks.
2. Added cases for `thinking`, `redacted_thinking`, `server_tool_use`, `web_search_tool_result`, `container_upload`.
3. Changed `default` to `break` instead of throwing (forward-compatible).
4. Added 20 unit tests.

### Bridge script (Problems 1 + 2)
Added `scripts/patch-npm-dist.sh` — patches the bundled dist in-place after `npm update`:
- Validator block-type fix (cli.js + validator.js)
- SSE streaming: filter provider framing events + restore stop_reason/message_stop

## Testing

```bash
cd packages/core
pnpm test -- validator   # 20/20 pass
```

SSE verification (after patching dist):
```
message_start -> ping -> content_block_start -> content_block_delta(s) -> content_block_stop -> message_delta -> message_stop
```
