### PR TITLE
fix: trigger model probe during Get Started onboarding

### DIFF
--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -1263,7 +1263,8 @@ function App() {
   }
 
   useEffect(() => {
-    if (!window.ccr || !providerAddOpen) {
+    const providerFormVisible = providerAddOpen || (activeView === "onboarding" && onboardingStep === "provider");
+    if (!window.ccr || !providerFormVisible) {
       return;
     }
     if (providerDraft.protocolDetectionMode === "manual") {


### PR DESCRIPTION
The model-probe useEffect in App.tsx guarded on `providerAddOpen` only, which is set true solely when opening the manual Add/Edit Provider dialog. It is never set during the onboarding wizard, so after entering an endpoint + API key on the Get Started flow and reaching the "Pick models" step, probeProviderCandidates() never fired and the model list stayed empty with no loading state.

Regressed in 9f704fc ("Guide onboarding through granular provider setup steps"), which narrowed the guard from
`providerAddOpen || (activeView === "onboarding" && onboardingStep === "provider")` down to `providerAddOpen`. Restore the broader guard so the probe runs both when the dialog is open and when onboarding is on the provider step.