### PR TITLE
fix(config): Codex provider requests 404 — top-level protocol never became a capability

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -527,6 +527,10 @@ export function normalizeProviderPresetCapabilitiesForTest(
   return normalizeProviderPresetCapabilities(provider);
 }
 
+export function parseProvidersForTest(value: unknown): GatewayProviderConfig[] | undefined {
+  return parseProviders(value);
+}
+
 function hasUnsupportedNvidiaCapabilities(value: unknown): boolean {
   if (!Array.isArray(value)) {
     return false;
@@ -1378,7 +1382,8 @@ function parseProviders(value: unknown): GatewayProviderConfig[] | undefined {
         baseUrl: readString(item.baseUrl),
         baseurl: readString(item.baseurl),
         billing: item.billing,
-        capabilities: parseProviderCapabilities(item.capabilities),
+        capabilities: parseProviderCapabilities(item.capabilities)
+          ?? parseProviderProtocolCapability(item),
         credentials: parseProviderCredentials(item.credentials ?? item.keys ?? item.apiKeys),
         extraBody: item.extraBody,
         extraHeaders: item.extraHeaders,
@@ -1685,6 +1690,21 @@ function parseProviderCapabilities(value: unknown): GatewayProviderCapability[] 
     .filter((item): item is GatewayProviderCapability => Boolean(item));
 
   return capabilities.length > 0 ? capabilities : undefined;
+}
+
+// Local-agent login imports (e.g. Codex API) declare their protocol at the top
+// level of the provider payload instead of inside a capabilities array. When no
+// explicit capabilities are configured, translate that protocol into a single
+// capability so the gateway picks the correct upstream adapter. Without this,
+// an openai_responses provider silently falls back to the chat-completions
+// adapter and every request 404s against Responses-only backends.
+function parseProviderProtocolCapability(item: Record<string, unknown>): GatewayProviderCapability[] | undefined {
+  const type = parseProviderCapabilityProtocol(readString(item.protocol));
+  const baseUrl = readString(item.baseUrl) || readString(item.baseurl) || readString(item.api_base_url);
+  if (!type || !baseUrl) {
+    return undefined;
+  }
+  return [{ baseUrl, type }];
 }
 
 function parseProviderCapabilityProtocol(value: string | undefined): GatewayProviderCapabilityProtocol | undefined {

--- a/packages/core/test/unit/config/provider-protocol-capability.test.mjs
+++ b/packages/core/test/unit/config/provider-protocol-capability.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("top-level provider protocol becomes a capability when none are configured", async () => {
+  const { parseProvidersForTest } = await import("@ccr/core/config/config.ts");
+  const providers = parseProvidersForTest([
+    {
+      name: "Codex API",
+      protocol: "openai_responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      models: ["gpt-5.5"]
+    }
+  ]);
+
+  assert.equal(providers?.length, 1);
+  assert.deepEqual(providers[0].capabilities, [
+    { baseUrl: "https://chatgpt.com/backend-api/codex", type: "openai_responses" }
+  ]);
+});
+
+test("explicit capabilities win over the top-level protocol", async () => {
+  const { parseProvidersForTest } = await import("@ccr/core/config/config.ts");
+  const providers = parseProvidersForTest([
+    {
+      name: "Codex API",
+      protocol: "openai_responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      capabilities: [
+        { type: "openai_chat_completions", baseUrl: "https://example.com/v1" }
+      ],
+      models: []
+    }
+  ]);
+
+  assert.deepEqual(providers[0].capabilities, [
+    { baseUrl: "https://example.com/v1", endpoint: undefined, source: undefined, type: "openai_chat_completions" }
+  ]);
+});
+
+test("protocol aliases are normalized", async () => {
+  const { parseProvidersForTest } = await import("@ccr/core/config/config.ts");
+  const providers = parseProvidersForTest([
+    {
+      name: "Claude Code API",
+      protocol: "anthropic_messages",
+      baseUrl: "https://api.anthropic.com",
+      models: []
+    }
+  ]);
+
+  assert.deepEqual(providers[0].capabilities, [
+    { baseUrl: "https://api.anthropic.com", type: "anthropic_messages" }
+  ]);
+});
+
+test("unknown or missing protocol yields no synthesized capability", async () => {
+  const { parseProvidersForTest } = await import("@ccr/core/config/config.ts");
+  const providers = parseProvidersForTest([
+    { name: "DeepInfra", api_base_url: "https://api.deepinfra.com/v1/openai", models: [] },
+    { name: "Mystery", protocol: "carrier_pigeon", baseUrl: "https://example.com", models: [] }
+  ]);
+
+  assert.equal(providers[0].capabilities, undefined);
+  assert.equal(providers[1].capabilities, undefined);
+});
+
+test("protocol without any base URL yields no synthesized capability", async () => {
+  const { parseProvidersForTest } = await import("@ccr/core/config/config.ts");
+  const providers = parseProvidersForTest([
+    { name: "Codex API", protocol: "openai_responses", models: [] }
+  ]);
+
+  assert.equal(providers[0].capabilities, undefined);
+});


### PR DESCRIPTION
## Problem

Fixes #1619.

Local-agent login imports (Codex API et al.) produce a provider payload with the protocol at the **top level** (`protocol: "openai_responses"`) and no `capabilities` array (`shared.ts providerPayload`). `parseProviders` never reads `item.protocol`, so the saved provider ends up with neither protocol nor capabilities. At runtime the gateway's adapter resolution then falls back to the default `openai_chat_completions` adapter and posts to `{base}/chat/completions` — a route that doesn't exist on the Responses-only Codex backend (`chatgpt.com/backend-api/codex`), so every request fails with upstream **404 `{"detail":"Not Found"}`**.

Verified with upstream-request logging against the live gateway: before the fix the codex request goes to `https://chatgpt.com/backend-api/codex/chat/completions` (404); after giving the provider an explicit `openai_responses` capability it goes to `https://chatgpt.com/backend-api/codex/responses` and returns 200. A direct API call with the same account/token confirms the backend works (HTTP 200), so the failure is purely this adapter-selection defect.

## Fix

In `parseProviders`, when no explicit `capabilities` are configured, synthesize a single capability from the provider's top-level `protocol` + base URL, reusing `parseProviderCapabilityProtocol` (the same normalization used for capability items, aliases included). Explicit capabilities still win; unknown/missing protocols and missing base URLs synthesize nothing.

## Tests

New `provider-protocol-capability.test.mjs` (5 tests): protocol→capability synthesis, explicit-capabilities precedence, alias normalization, unknown/missing protocol, missing base URL. Full core suite: **688 pass / 3 fail**, where the 3 failures are pre-existing on main (unrelated bundled-plugin tests) — verified against a stashed baseline, which also fails all 5 new tests as expected. `tsc --noEmit` clean.

## Notes

- The OAuth scope hard-check (`api.connectors.*`) mentioned in the issue is a separate concern and untouched here; the backend accepts the standard `codex login` token scopes.
- Users hitting this on 3.0.18 can work around it by adding an explicit `capabilities: [{type: "openai_responses", baseUrl: "https://chatgpt.com/backend-api/codex"}]` to the Codex provider.