### PR TITLE
fix(codex): 同步本地登录的最新 OAuth 凭据

### DIFF
--- a/packages/core/src/gateway/core-runtime/config-compiler.ts
+++ b/packages/core/src/gateway/core-runtime/config-compiler.ts
@@ -448,9 +448,9 @@ function withCodexOauthRuntimeDefaults(providerPlugins: unknown[]): unknown[] {
     const codexOauth = plugin.codexOauth;
     const nextCodexOauth = {
       ...codexOauth,
-      ...(!hasOwn(codexOauth, "accountId") && !hasOwn(codexOauth, "account_id") && codexAuth?.accountId
-        ? { accountId: codexAuth.accountId }
-        : {})
+      ...(codexAuth?.accessToken ? { accessToken: codexAuth.accessToken } : {}),
+      ...(codexAuth?.refreshToken ? { refreshToken: codexAuth.refreshToken } : {}),
+      ...(codexAuth?.accountId ? { accountId: codexAuth.accountId } : {})
     };
     const nextPlugin: Record<string, unknown> = {
       ...plugin,
@@ -786,9 +786,4 @@ function addProviderNameVariants(names: Set<string>, providerName: string | unde
   if (capabilitySeparatorIndex > 0) {
     names.add(providerName.slice(0, capabilitySeparatorIndex));
   }
-}
-
-
-function hasOwn(value: Record<string, unknown>, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(value, key);
 }

--- a/packages/core/test/unit/agents/provider-plugin-runtime-identity.test.mjs
+++ b/packages/core/test/unit/agents/provider-plugin-runtime-identity.test.mjs
@@ -96,6 +96,49 @@ test("Codex OAuth plugins retain the default base URL after runtime identity nor
   assert.equal(compiled.providers[0].baseurl, codexDefaultBaseUrl);
 });
 
+test("Codex OAuth plugins prefer live login credentials over imported snapshots", async (t) => {
+  const home = useTemporaryCodexHome(t, "ccr-codex-runtime-live-credentials-");
+  fs.mkdirSync(path.join(home, ".codex"), { recursive: true });
+  fs.writeFileSync(path.join(home, ".codex", "auth.json"), JSON.stringify({
+    tokens: {
+      access_token: "access-live",
+      account_id: "acct-live",
+      refresh_token: "refresh-live"
+    }
+  }));
+
+  const config = createDefaultAppConfig();
+  config.providerPlugins = [{
+    codexOauth: {
+      accessToken: "access-imported",
+      accountId: "acct-imported",
+      refreshToken: "refresh-imported"
+    },
+    key: "ccr-local-agent-codex-api-codex-oauth",
+    providerName: "Codex API"
+  }];
+  config.Providers = [{
+    api_base_url: codexDefaultBaseUrl,
+    api_key: "ccr-local-agent-login",
+    id: "codex-api",
+    models: ["gpt-5.5"],
+    name: "Codex API",
+    type: "openai_responses"
+  }];
+
+  const compiled = await compileCoreGatewayConfig(
+    config,
+    "raw-trace-token",
+    "billing-usage-token",
+    "core-auth-token"
+  );
+  const codexPlugin = compiled.providerPlugins.find((item) => item.key === "ccr-local-agent-codex-api-codex-oauth");
+
+  assert.equal(codexPlugin.codexOauth.accessToken, "access-live");
+  assert.equal(codexPlugin.codexOauth.refreshToken, "refresh-live");
+  assert.equal(codexPlugin.codexOauth.accountId, "acct-live");
+});
+
 test("Codex local providers synthesize OAuth plugins when persisted plugins are missing", async (t) => {
   const home = useTemporaryCodexHome(t, "ccr-codex-runtime-missing-plugins-");
   fs.mkdirSync(path.join(home, ".codex"), { recursive: true });


### PR DESCRIPTION
## 问题

CCR 导入 Codex 登录信息后，会在 provider plugin 中保存当时的 OAuth 凭据。Codex CLI 后续刷新 `~/.codex/auth.json` 时，CCR 编译网关运行时配置只同步了 `accountId`，仍可能继续使用旧的 `accessToken` 和 `refreshToken`，最终收到 `401 token_expired`。

## 修改

- 编译本地 Codex OAuth 插件时，优先使用当前登录文件中的 `accessToken`、`refreshToken` 和 `accountId`。
- 只在读取到有效值时覆盖已导入快照，不影响其他供应商或非本地 Codex 配置。
- 增加回归测试，覆盖“已导入旧凭据、本地登录已刷新”的情况。

## 验证
<img width="1957" height="400" alt="image" src="https://github.com/user-attachments/assets/d874e5c1-ff98-4f2e-8f14-7ca1990ad5c4" />

- Codex OAuth 定向测试：6 条通过。
- `npm run typecheck` 通过。