### PR TITLE
fix(gateway): compare API keys in constant time

### DIFF
--- a/packages/core/src/gateway/auth/api-key-authorizer.ts
+++ b/packages/core/src/gateway/auth/api-key-authorizer.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ApiKeyConfig, AppConfig } from "@ccr/core/contracts/app";
 import { loadPersistedApiKeys } from "@ccr/core/config/config-repository";
@@ -24,10 +25,10 @@ export async function authorize(
   }
 
   const token = readAuthToken(request.headers) || readRemoteControlQueryAuthToken(request);
-  let apiKey = token ? apiKeys.find((item) => item.key === token) : undefined;
+  let apiKey = token ? findApiKeyByToken(apiKeys, token) : undefined;
   if (!apiKey && token) {
     apiKeys = await configuredApiKeys(config, { refresh: true });
-    apiKey = apiKeys.find((item) => item.key === token);
+    apiKey = findApiKeyByToken(apiKeys, token);
   }
   if (apiKey) {
     if (isApiKeyExpired(apiKey)) {
@@ -119,6 +120,16 @@ async function loadPersistedApiKeysCached(options: { refresh?: boolean } = {}): 
     console.warn(`[gateway] Failed to load persisted API keys: ${formatError(error)}`);
     return [];
   }
+}
+
+function findApiKeyByToken(apiKeys: ApiKeyConfig[], token: string): ApiKeyConfig | undefined {
+  return apiKeys.find((item) => constantTimeEqual(item.key, token));
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
 }
 
 function isApiKeyExpired(apiKey: ApiKeyConfig): boolean {

--- a/packages/core/test/unit/gateway/api-key-authorizer.test.mjs
+++ b/packages/core/test/unit/gateway/api-key-authorizer.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createDefaultAppConfig } from "@ccr/core/config/default-config.ts";
+import { authorize } from "@ccr/core/gateway/auth/api-key-authorizer.ts";
+
+const authorizerSourceFile = path.join(
+  process.cwd(),
+  "packages",
+  "core",
+  "src",
+  "gateway",
+  "auth",
+  "api-key-authorizer.ts"
+);
+const gatewayApiKey = "ccr-3f8a1c7d9e2b4056a1c7d9e2b4056f8a";
+
+function configWithApiKeys(apiKeys) {
+  const config = createDefaultAppConfig();
+  config.APIKEYS = apiKeys;
+  return config;
+}
+
+function createResponse() {
+  const response = {
+    payload: undefined,
+    statusCode: undefined,
+    end(chunk) {
+      response.payload = JSON.parse(String(chunk));
+    },
+    writeHead(statusCode) {
+      response.statusCode = statusCode;
+    }
+  };
+  return response;
+}
+
+async function authorizeRequest(config, request) {
+  const response = createResponse();
+  const result = await authorize({ headers: {}, url: "/v1/messages", ...request }, response, config);
+  return { response, result };
+}
+
+test("gateway authorization accepts the configured API key on every supported carrier", async () => {
+  const config = configWithApiKeys([
+    { createdAt: new Date(0).toISOString(), id: "primary", key: gatewayApiKey }
+  ]);
+
+  for (const request of [
+    { headers: { authorization: `Bearer ${gatewayApiKey}` } },
+    { headers: { "x-api-key": gatewayApiKey } },
+    { url: `/__ccr/remote/status?api_key=${gatewayApiKey}` }
+  ]) {
+    const { response, result } = await authorizeRequest(config, request);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.apiKey.id, "primary");
+    assert.equal(response.statusCode, undefined);
+  }
+});
+
+test("gateway authorization rejects near-miss tokens of any length without throwing", async () => {
+  const config = configWithApiKeys([
+    { createdAt: new Date(0).toISOString(), id: "primary", key: gatewayApiKey }
+  ]);
+
+  for (const token of [
+    `X${gatewayApiKey.slice(1)}`,
+    `${gatewayApiKey.slice(0, -1)}b`,
+    gatewayApiKey.toUpperCase(),
+    gatewayApiKey.slice(0, -1),
+    `${gatewayApiKey}-extra`
+  ]) {
+    const { response, result } = await authorizeRequest(config, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(response.statusCode, 401);
+    assert.equal(response.payload.error.message, "Invalid API key.");
+  }
+});
+
+test("gateway authorization separates a missing token from an expired key", async () => {
+  const config = configWithApiKeys([
+    {
+      createdAt: new Date(0).toISOString(),
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      id: "expired",
+      key: gatewayApiKey
+    }
+  ]);
+
+  const missing = await authorizeRequest(config, {});
+  assert.equal(missing.result.ok, false);
+  assert.equal(missing.response.statusCode, 401);
+  assert.equal(missing.response.payload.error.message, "API key is missing.");
+
+  const expired = await authorizeRequest(config, {
+    headers: { authorization: `Bearer ${gatewayApiKey}` }
+  });
+  assert.equal(expired.result.ok, false);
+  assert.equal(expired.response.statusCode, 401);
+  assert.equal(expired.response.payload.error.message, "API key is expired.");
+});
+
+// A constant-time comparison is behaviour-preserving by construction, so the
+// tests above pass on both sides of the change and only prove there is no
+// regression. The invariant itself is asserted on the module source, the same
+// way test/architecture/gateway-service-architecture.test.mjs asserts that the
+// config compiler never reaches for node:fs.
+test("gateway API key matching never uses a short-circuiting equality check", () => {
+  const source = readFileSync(authorizerSourceFile, "utf8");
+
+  assert.match(source, /from "node:crypto"/);
+  assert.match(source, /timingSafeEqual\(/);
+  assert.doesNotMatch(source, /\.key\s*===/);
+});


### PR DESCRIPTION
## Summary

The gateway API key authorizer matched the presented token against every configured key with `item.key === token`, a variable-time string comparison that returns on the first differing byte. The repository already avoids that shape for its other secrets — `context-archive.ts`, `management-server.ts` and `media/service.ts` each compare tokens through a local `timingSafeEqual` helper with a length guard — so this brings the gateway authorizer in line with them.

## Change

`packages/core/src/gateway/auth/api-key-authorizer.ts` routes both lookup paths (initial and refresh-on-miss) through a small `findApiKeyByToken` → `constantTimeEqual` helper (`timingSafeEqual` from `node:crypto`, with the same length guard as `context-archive.ts:771`). Behavior is unchanged: valid keys authorize, unknown keys still get 401 `Invalid API key.`, expired keys still get 401 `API key is expired.`, and the refresh-on-miss reload path is preserved. No new dependencies.

## Tests

New `packages/core/test/unit/gateway/api-key-authorizer.test.mjs` (4 tests):

- valid key authorizes on every supported carrier (header / remote-control query token);
- near-miss tokens of **any length** are rejected without throwing (exercises the length guard and the constant-time path);
- a missing token is still distinguished from an expired key;
- invariant: the authorizer source contains no short-circuiting equality on keys and imports `node:crypto`.

Verification (Windows, Node v24.14.1):

- The invariant test **fails without the fix** (`AssertionError: The input did not match the regular expression /from "node:crypto"/`) and passes with it; the revert/re-apply cycle was re-confirmed. 4/4 pass on the compiled harness output.
- `npm run typecheck` (`tsc --noEmit`): clean.
- `npm run test:core`: the 4 new tests pass. The only delta vs the clean-`main` baseline is one Windows EPERM/fsync flake in a raw-trace test whose compiled binary is byte-identical with and without the change; the 47 other failures are pre-existing on this host (RequestLogStore, UsageStore, raw trace, profile service).

AI-assisted: drafted with AI assistance and verified locally as above; I understand and own the change.