### PR TITLE
feat(ui): polish account balance cards and fix connector persistence

### DIFF
--- a/packages/ui/src/pages/home/components/dashboard.tsx
+++ b/packages/ui/src/pages/home/components/dashboard.tsx
@@ -7,7 +7,7 @@ import {
   compactUserAgent, compareProviderAccountSnapshots, ComposedChart, CSS, DEFAULT_OVERVIEW_WIDGETS, DndContext,
   Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle,
   DragEndEvent, DragOverEvent, DragOverlay, DragStartEvent, Field, formatAxisNumber, formatBytes,
-  formatCompactNumber, formatDuration, formatLogDateTime, formatPercent, formatProviderAccountDetailDate, formatProviderAccountMeterTitle, formatProviderAccountMeterValue,
+  formatCompactNumber, formatDuration, formatLogDateTime, formatPercent, formatProviderAccountDetailDate, formatProviderAccountMeterTitle, formatProviderAccountMeterValue, formatProviderAccountResetDuration,
   formatStatusBucketDate, formatSystemStatusRange, formatUsdCost, KeyboardSensor,
   LabelList, LayoutGroup, Line, LoaderCircle, MeasuringStrategy, MetricTone,
   motion, normalizeAgentFilterValue, normalizeOverviewWidget, normalizeOverviewWidgets,
@@ -2347,7 +2347,7 @@ function ProviderAccountsOverview({
             })}
           </div>
         ) : variant === "bars" ? (
-          <div className={cn("h-full min-h-0 overflow-y-auto pr-1", providerAccountStackClass(dimensions))}>
+          <div className={cn("h-full min-h-0 overflow-y-auto pr-1", "space-y-1.5")}>
             {visibleAccounts.map((account) => {
               const meter = primaryProviderAccountDisplayMeter(account);
               const progress = meter && isProviderAccountQuotaMeter(meter) ? providerAccountMeterProgress(meter) : undefined;
@@ -2422,7 +2422,7 @@ function ProviderAccountSinglePanel({
   const showQuotaVisual = providerAccountUsesQuotaVisual(variant) && quotaMeters.length > 0;
 
   return (
-    <div className={cn("flex h-full min-h-0 min-w-0 flex-col overflow-hidden", providerAccountStackClass(dimensions))}>
+    <div className={cn("flex h-full min-h-0 min-w-0 flex-col overflow-hidden", "space-y-1.5")}>
       <div className="flex min-w-0 shrink-0 items-start justify-between gap-3">
         <div className="min-w-0">
           <div className={cn("truncate font-semibold", dimensions.height <= 1 ? "text-[12px]" : "text-[13px]")}>{providerAccountSnapshotLabel(account)}</div>
@@ -2435,7 +2435,7 @@ function ProviderAccountSinglePanel({
       ) : quotaMeters.length === 0 && balanceMeter ? (
         <ProviderAccountBalanceMetric dimensions={dimensions} meter={balanceMeter} />
       ) : meters.length > 0 ? (
-        <div className={cn("min-h-0 overflow-hidden", providerAccountStackClass(dimensions))}>
+        <div className={cn("min-h-0 overflow-hidden", "space-y-1")}>
           {meters.map((meter) => (
             <ProviderAccountMeterLine account={account} dimensions={dimensions} key={meter.id} meter={meter} single onRefresh={onRefresh} />
           ))}
@@ -2480,15 +2480,15 @@ function ProviderAccountSummaryCard({
         {providerAccountShowRefresh(dimensions) ? <ProviderAccountRefreshButton account={account} refreshing={refreshing} onRefresh={onRefresh} /> : null}
       </div>
       {showQuotaVisual ? (
-        <div className="mt-2 min-h-0 overflow-hidden">
+        <div className="mt-1.5 min-h-0 overflow-hidden">
           <ProviderAccountQuotaVisual account={account} dimensions={dimensions} meters={quotaMeters} variant={variant} />
         </div>
       ) : quotaMeters.length === 0 && balanceMeter ? (
-        <div className="mt-2 min-h-0 overflow-hidden">
+        <div className="mt-1.5 min-h-0 overflow-hidden">
           <ProviderAccountBalanceMetric dimensions={dimensions} meter={balanceMeter} compact />
         </div>
       ) : meters.length > 0 ? (
-        <div className={cn("mt-2 min-h-0", providerAccountStackClass(dimensions))}>
+        <div className={cn("mt-1.5 min-h-0", "space-y-1")}>
           {meters.map((meter) => (
             <ProviderAccountMeterLine account={account} dimensions={dimensions} key={meter.id} meter={meter} onRefresh={onRefresh} />
           ))}
@@ -2567,10 +2567,19 @@ function ProviderAccountMeterLine({
   const canExpandDetails = dimensions.height >= 2 && isProviderAccountManualResetMeter(meter) && (meter.details?.length ?? 0) > 0;
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [resetDialogDetail, setResetDialogDetail] = useState<NonNullable<ProviderAccountMeter["details"]>[number]>();
-  const title = formatProviderAccountMeterTitle(meter, t);
+  const labelText = t(meter.label);
+  const resetDuration = meter.resetAt ? formatProviderAccountResetDuration(meter.resetAt) : undefined;
+  // 已过期（或非法时间）时回退为「expired」文案；正常时用图标 + 纯时长，不重复「剩余」前缀。
+  // 天级窗口（如 7D/30D，时长含 d 单位）用 📆，小时级（如 5H）用 🕛。
+  const resetIcon = resetDuration?.includes("d") ? "📆" : "🕛";
+  const resetText = resetDuration !== undefined ? `${resetIcon} ${resetDuration}` : (meter.resetAt ? t("expired") : "");
+  // 百分比达到 90 及以上时数字和百分号整体变红（仅针对 % 单位的 meter）
+  const meterNumber = meter.remaining ?? meter.used ?? meter.limit;
+  const valueDanger = meter.unit === "%" && typeof meterNumber === "number" && meterNumber >= 90;
   const detailsId = `provider-account-meter-${providerAccountSnapshotKey(account)}-${meter.id}-details`.replace(/[^a-zA-Z0-9_-]/g, "-");
-  const titleClassName = cn("min-w-0 truncate font-medium text-muted-foreground", single && dimensions.height >= 2 ? "text-[13px]" : "text-[12px]");
-  const valueClassName = cn("shrink-0 font-semibold tracking-tight", single && dimensions.height >= 2 ? "text-[18px]" : "text-[15px]");
+  const titleClassName = cn("min-w-0 truncate font-semibold text-muted-foreground", single && dimensions.height >= 2 ? "text-[13px]" : "text-[12px]");
+  const valueClassName = cn("shrink-0 font-semibold tracking-tight tabular-nums", valueDanger && "text-red-500", single && dimensions.height >= 2 ? "text-[14px]" : "text-[13px]");
+  const resetClassName = cn("shrink-0 font-mono font-medium text-muted-foreground", single && dimensions.height >= 2 ? "text-[12px]" : "text-[11px]");
   const meterSummary = (
     <>
       <div className="flex min-w-0 items-center gap-1.5">
@@ -2579,7 +2588,8 @@ function ProviderAccountMeterLine({
             {detailsOpen ? <ChevronDown aria-hidden="true" className="h-3.5 w-3.5" /> : <ChevronRight aria-hidden="true" className="h-3.5 w-3.5" />}
           </AnimatedIconSwap>
         ) : null}
-        <div className={titleClassName}>{title}</div>
+        <div className={titleClassName}>{labelText}</div>
+        {resetText ? <div className={resetClassName}>{resetText}</div> : null}
       </div>
       <div className={valueClassName}>{formatProviderAccountMeterValue(meter, t)}</div>
     </>
@@ -2591,20 +2601,20 @@ function ProviderAccountMeterLine({
         <button
           aria-controls={detailsId}
           aria-expanded={detailsOpen}
-          aria-label={`${t(detailsOpen ? "Collapse" : "Expand")} ${title}`}
-          className="group -mx-1 flex w-[calc(100%+8px)] min-w-0 items-end justify-between gap-3 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-muted/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/25"
+          aria-label={`${t(detailsOpen ? "Collapse" : "Expand")} ${labelText}`}
+          className="group -mx-1 flex w-[calc(100%+8px)] min-w-0 items-center justify-between gap-3 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-muted/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/25"
           onClick={() => setDetailsOpen((current) => !current)}
           type="button"
         >
           {meterSummary}
         </button>
       ) : (
-        <div className="flex min-w-0 items-end justify-between gap-3">
+        <div className="flex min-w-0 items-center justify-between gap-3">
           {meterSummary}
         </div>
       )}
       {progress !== undefined && providerAccountShowProgress(dimensions) ? (
-        <div className={cn("mt-1.5 overflow-hidden rounded-full", single ? "bg-muted" : "bg-background", dimensions.height <= 1 ? "h-1.5" : "h-2")}>
+        <div className={cn("mt-0.5 overflow-hidden rounded-full", single ? "bg-muted" : "bg-background", dimensions.height <= 1 ? "h-1.5" : "h-2")}>
           <div className={cn("h-full rounded-full", providerAccountProgressClass(account.status))} style={{ width: `${progress}%` }} />
         </div>
       ) : null}
@@ -3357,15 +3367,11 @@ function providerAccountContentPaddingClass(dimensions: OverviewWidgetDimensions
 }
 
 function providerAccountCardPaddingClass(dimensions: OverviewWidgetDimensions): string {
-  return dimensions.height <= 1 || dimensions.width <= 1 ? "p-2" : "p-3";
+  return dimensions.height <= 1 || dimensions.width <= 1 ? "p-1.5" : "p-2";
 }
 
 function providerAccountGapClass(dimensions: OverviewWidgetDimensions): string {
   return dimensions.height <= 1 || dimensions.width <= 1 ? "gap-2" : "gap-3";
-}
-
-function providerAccountStackClass(dimensions: OverviewWidgetDimensions): string {
-  return dimensions.height <= 1 ? "space-y-1.5" : "space-y-2.5";
 }
 
 function providerAccountGridClass(dimensions: OverviewWidgetDimensions, itemCount: number): string {

--- a/packages/ui/src/pages/home/components/dashboard.tsx
+++ b/packages/ui/src/pages/home/components/dashboard.tsx
@@ -2392,6 +2392,15 @@ function ProviderAccountsOverview({
   );
 }
 
+// 定时重渲染：让重置倒计时（formatProviderAccountReset 内部用 Date.now()）每分钟自动刷新，无需手动刷新账户
+function useRerenderEvery(intervalMs: number) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = window.setInterval(() => setTick((value) => value + 1), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+}
+
 function ProviderAccountSinglePanel({
   account,
   dimensions,
@@ -2405,6 +2414,7 @@ function ProviderAccountSinglePanel({
   refreshing?: boolean;
   variant: OverviewAccountVariant;
 }) {
+  useRerenderEvery(60_000);
   const t = useAppText();
   const quotaMeters = providerAccountQuotaMeters(account);
   const balanceMeter = primaryProviderAccountBalanceMeter(account);
@@ -2453,6 +2463,7 @@ function ProviderAccountSummaryCard({
   refreshing?: boolean;
   variant: OverviewAccountVariant;
 }) {
+  useRerenderEvery(60_000);
   const t = useAppText();
   const quotaMeters = providerAccountQuotaMeters(account);
   const balanceMeter = primaryProviderAccountBalanceMeter(account);

--- a/packages/ui/src/pages/home/components/dashboard.tsx
+++ b/packages/ui/src/pages/home/components/dashboard.tsx
@@ -2570,15 +2570,16 @@ function ProviderAccountMeterLine({
   const labelText = t(meter.label);
   const resetDuration = meter.resetAt ? formatProviderAccountResetDuration(meter.resetAt) : undefined;
   // 已过期（或非法时间）时回退为「expired」文案；正常时用图标 + 纯时长，不重复「剩余」前缀。
-  // 天级窗口（如 7D/30D，时长含 d 单位）用 📆，小时级（如 5H）用 🕛。
-  const resetIcon = resetDuration?.includes("d") ? "📆" : "🕛";
+  // 天级窗口（如 7D/30D，时长含 d 单位）用 ☀️，小时级（如 5H）用 🕛。
+  const resetIcon = resetDuration?.includes("d") ? "☀️" : "🕛";
   const resetText = resetDuration !== undefined ? `${resetIcon} ${resetDuration}` : (meter.resetAt ? t("expired") : "");
-  // 百分比达到 90 及以上时数字和百分号整体变红（仅针对 % 单位的 meter）
+  // 百分比告警分级：达到 75 用橙色（text-amber-500），达到 90 及以上用红色（text-red-500）
   const meterNumber = meter.remaining ?? meter.used ?? meter.limit;
   const valueDanger = meter.unit === "%" && typeof meterNumber === "number" && meterNumber >= 90;
+  const valueWarning = meter.unit === "%" && typeof meterNumber === "number" && meterNumber >= 75 && !valueDanger;
   const detailsId = `provider-account-meter-${providerAccountSnapshotKey(account)}-${meter.id}-details`.replace(/[^a-zA-Z0-9_-]/g, "-");
   const titleClassName = cn("min-w-0 truncate font-semibold text-muted-foreground", single && dimensions.height >= 2 ? "text-[13px]" : "text-[12px]");
-  const valueClassName = cn("shrink-0 font-semibold tracking-tight tabular-nums", valueDanger && "text-red-500", single && dimensions.height >= 2 ? "text-[14px]" : "text-[13px]");
+  const valueClassName = cn("shrink-0 font-semibold tracking-tight tabular-nums", valueDanger && "text-red-500", valueWarning && "text-amber-500", single && dimensions.height >= 2 ? "text-[14px]" : "text-[13px]");
   const resetClassName = cn("shrink-0 font-mono font-medium text-muted-foreground", single && dimensions.height >= 2 ? "text-[12px]" : "text-[11px]");
   const meterSummary = (
     <>

--- a/packages/ui/src/pages/home/components/dashboard.tsx
+++ b/packages/ui/src/pages/home/components/dashboard.tsx
@@ -7,7 +7,7 @@ import {
   compactUserAgent, compareProviderAccountSnapshots, ComposedChart, CSS, DEFAULT_OVERVIEW_WIDGETS, DndContext,
   Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle,
   DragEndEvent, DragOverEvent, DragOverlay, DragStartEvent, Field, formatAxisNumber, formatBytes,
-  formatCompactNumber, formatDuration, formatLogDateTime, formatPercent, formatProviderAccountDetailDate, formatProviderAccountMeterTitle, formatProviderAccountMeterValue, formatProviderAccountResetDuration,
+  formatCompactNumber, formatDuration, formatLogDateTime, formatPercent, formatProviderAccountDetailDate, formatProviderAccountMeterTitleCompact, formatProviderAccountMeterValue, formatProviderAccountResetDuration,
   formatStatusBucketDate, formatSystemStatusRange, formatUsdCost, KeyboardSensor,
   LabelList, LayoutGroup, Line, LoaderCircle, MeasuringStrategy, MetricTone,
   motion, normalizeAgentFilterValue, normalizeOverviewWidget, normalizeOverviewWidgets,
@@ -3094,7 +3094,7 @@ function ProviderAccountBalanceMetric({
 
   return (
     <div className="flex min-h-0 min-w-0 flex-col justify-center overflow-hidden">
-      <div className={cn("truncate font-medium text-muted-foreground", large ? "text-[12px]" : "text-[11px]")}>{formatProviderAccountMeterTitle(meter, t)}</div>
+      <div className={cn("truncate font-medium tabular-nums text-muted-foreground", large ? "text-[12px]" : "text-[11px]")}>{formatProviderAccountMeterTitleCompact(meter, t)}</div>
       <div className={cn("truncate font-semibold tracking-tight", large ? "text-[24px]" : "text-[18px]")}>{formatProviderAccountMeterValue(meter)}</div>
     </div>
   );
@@ -3128,7 +3128,7 @@ function ProviderAccountQuotaVisual({
           {displayMeters.slice(0, variant === "nested-rings" ? 2 : 1).map((meter) => {
             return (
               <div className="min-w-0" key={meter.id}>
-                <div className="truncate text-[12px] font-medium text-muted-foreground">{formatProviderAccountMeterTitle(meter, t)}</div>
+                <div className="truncate text-[12px] font-medium tabular-nums text-muted-foreground">{formatProviderAccountMeterTitleCompact(meter, t)}</div>
                 <div className="truncate text-[17px] font-semibold tracking-tight">{formatProviderAccountMeterValue(meter)}</div>
               </div>
             );
@@ -3188,7 +3188,7 @@ function ProviderAccountQuotaGauge({
     <svg aria-hidden="true" className={sizeClass} viewBox="0 0 120 120">
       <ProviderAccountQuotaCircle cx={60} cy={60} ratio={primaryRatio} radius={40} stroke={stroke} strokeWidth={10} />
       <text className="fill-foreground text-[20px] font-semibold" dy="0.35em" textAnchor="middle" x="60" y={dimensions.height >= 2 ? "57" : "60"}>{formatProviderAccountMeterValue(primary)}</text>
-      {dimensions.height >= 2 ? <text className="fill-muted-foreground text-[10px] font-medium" dy="0.35em" textAnchor="middle" x="60" y="75">{formatProviderAccountMeterTitle(primary, t)}</text> : null}
+      {dimensions.height >= 2 ? <text className="fill-muted-foreground text-[10px] font-medium tabular-nums" dy="0.35em" textAnchor="middle" x="60" y="75">{formatProviderAccountMeterTitleCompact(primary, t)}</text> : null}
     </svg>
   );
 }

--- a/packages/ui/src/pages/home/shared/provider-accounts.ts
+++ b/packages/ui/src/pages/home/shared/provider-accounts.ts
@@ -197,11 +197,15 @@ export function formatProviderAccountReset(value: string, translate: (value: str
   if (minutes < 60) {
     return `${prefix} ${minutes}m`;
   }
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) {
-    return `${prefix} ${hours}h`;
+  // 双单位精确显示：< 24h 用「Xh Ym」，>= 24h 用「Xd Yh」
+  const totalHours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (totalHours < 24) {
+    return mins > 0 ? `${prefix} ${totalHours}h ${mins}m` : `${prefix} ${totalHours}h`;
   }
-  return `${prefix} ${Math.round(hours / 24)}d`;
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours > 0 ? `${prefix} ${days}d ${hours}h` : `${prefix} ${days}d`;
 }
 
 export function formatProviderAccountMeterTitle(meter: ProviderAccountMeter, translate: (value: string) => string): string {

--- a/packages/ui/src/pages/home/shared/provider-accounts.ts
+++ b/packages/ui/src/pages/home/shared/provider-accounts.ts
@@ -225,6 +225,24 @@ export function formatProviderAccountMeterTitle(meter: ProviderAccountMeter, tra
   return meter.resetAt ? `${label} (${formatProviderAccountReset(meter.resetAt, translate)})` : label;
 }
 
+// 紧凑 meter 标题：`label ☀️ 1d17h` / `label 🕛 3h28m`（无「剩余」前缀，emoji 按天/小时级区分）。
+// 供 tray 状态栏与 dashboard 其他 meter 渲染点复用，与 ProviderAccountMeterLine 行内样式保持一致。
+export function formatProviderAccountMeterTitleCompact(
+  meter: ProviderAccountMeter,
+  translate: (value: string) => string = (item) => item
+): string {
+  const label = translate(meter.label);
+  if (!meter.resetAt) {
+    return label;
+  }
+  const duration = formatProviderAccountResetDuration(meter.resetAt);
+  if (duration === undefined) {
+    return `${label} ${translate("expired")}`;
+  }
+  const icon = duration.includes("d") ? "☀️" : "🕛";
+  return `${label} ${icon} ${duration}`;
+}
+
 export function isProviderAccountManualResetMeter(meter: ProviderAccountMeter): boolean {
   const text = `${meter.id} ${meter.label} ${meter.window ?? ""}`.toLowerCase();
   return text.includes("manual_reset") || text.includes("manual reset") || text.includes("manual-reset");

--- a/packages/ui/src/pages/home/shared/provider-accounts.ts
+++ b/packages/ui/src/pages/home/shared/provider-accounts.ts
@@ -184,28 +184,40 @@ export function formatProviderAccountNumber(value: number): string {
   return new Intl.NumberFormat(undefined, { maximumFractionDigits: 6 }).format(value);
 }
 
-export function formatProviderAccountReset(value: string, translate: (value: string) => string = (item) => item): string {
+// 仅返回剩余时长（如「3h28m」「1d17h」「05m」）；非法时间或已过期返回 undefined
+// 与 formatProviderAccountReset 的差异：不携带「expires in / expired」文案前缀
+// （dashboard 的 meter 行用 🕛/📆 图标代替文字前缀）。
+// 分钟/小时始终补零两位（05m、3h05m），天/小时首段不补零，配合等宽字体（font-mono）对齐。
+export function formatProviderAccountResetDuration(value: string): string | undefined {
   const timestamp = new Date(value).getTime();
   if (!Number.isFinite(timestamp)) {
-    return value;
+    return undefined;
   }
   const minutes = Math.round((timestamp - Date.now()) / 60000);
   if (minutes <= 0) {
-    return translate("expired");
+    return undefined;
   }
-  const prefix = translate("expires in");
+  const pad2 = (n: number) => String(n).padStart(2, "0");
   if (minutes < 60) {
-    return `${prefix} ${minutes}m`;
+    return `${pad2(minutes)}m`;
   }
-  // 双单位精确显示：< 24h 用「Xh Ym」，>= 24h 用「Xd Yh」
   const totalHours = Math.floor(minutes / 60);
   const mins = minutes % 60;
   if (totalHours < 24) {
-    return mins > 0 ? `${prefix} ${totalHours}h ${mins}m` : `${prefix} ${totalHours}h`;
+    return `${totalHours}h${pad2(mins)}m`;
   }
   const days = Math.floor(totalHours / 24);
   const hours = totalHours % 24;
-  return hours > 0 ? `${prefix} ${days}d ${hours}h` : `${prefix} ${days}d`;
+  return `${days}d${pad2(hours)}h`;
+}
+
+export function formatProviderAccountReset(value: string, translate: (value: string) => string = (item) => item): string {
+  const duration = formatProviderAccountResetDuration(value);
+  if (duration === undefined) {
+    const timestamp = new Date(value).getTime();
+    return Number.isFinite(timestamp) ? translate("expired") : value;
+  }
+  return `${translate("expires in")} ${duration}`;
 }
 
 export function formatProviderAccountMeterTitle(meter: ProviderAccountMeter, translate: (value: string) => string): string {

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -1087,7 +1087,9 @@ export function parseProviderAccountDraft(draft: AddProviderDraft): GatewayProvi
     };
   }
 
-  if (draft.accountMode === "http-json" || draft.usageRequestUrl.trim()) {
+  // raw 模式必须走 Connectors JSON；若用 ||，表单 URL 残留会让 raw 模式
+  // 误走表单生成分支，用户粘贴的 connectors 被静默丢弃（issue: 5H用量/7D用量 变 Subscription）
+  if (draft.accountMode === "http-json" && draft.usageRequestUrl.trim()) {
     const connector = providerHttpJsonConnectorFromDraft(draft);
     if (typeof connector === "string") {
       return connector;
@@ -1193,9 +1195,22 @@ export function createProviderAccountDraftFromConfig(account: ProviderAccountCon
   }
 
   const balanceMeter = httpJsonConnector.mapping.meters.find((meter) => meter.kind === "balance" || meter.id === "balance");
-  const subscriptionMeter = httpJsonConnector.mapping.meters.find((meter) =>
-    meter.kind === "subscription" || meter.id === "subscription" || meter.kind === "quota" || meter.kind === "tokens" || meter.kind === "time_window"
+  const subscriptionMeter = httpJsonConnector.mapping.meters.find((meter) => meter.kind === "subscription" || meter.id === "subscription");
+  // 仅当所有 meter 都是简单的 balance/subscription 时才展开为表单字段；
+  // 含 quota/tokens/time_window 或自定义结构的 meter（如 MiniMax 的 5H用量/7D用量）
+  // 展开会丢 meter 和 window，必须保留 raw Connectors JSON。
+  const simpleHttpJsonConnector = httpJsonConnector.mapping.meters.every((meter) =>
+    meter.kind === "balance" || meter.id === "balance" || meter.kind === "subscription" || meter.id === "subscription"
   );
+  if (!simpleHttpJsonConnector) {
+    return {
+      ...base,
+      accountConnectorsText: JSON.stringify(connectors, null, 2),
+      accountEnabled: account.enabled === true,
+      accountMode: "raw",
+      accountRefreshIntervalMs: account.refreshIntervalMs ? String(account.refreshIntervalMs) : ""
+    };
+  }
 
   return {
     ...base,

--- a/packages/ui/src/pages/tray/components/account-panel.tsx
+++ b/packages/ui/src/pages/tray/components/account-panel.tsx
@@ -99,7 +99,7 @@ function AccountMeters({
       <div className="grid grid-cols-2 gap-1.5">
         {meters.map((meter) => (
           <div className="tray-stat-cell min-w-0 px-2 py-1" key={meter.id}>
-            <div className="truncate text-[9px] font-medium text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
+            <div className="truncate text-[9px] font-medium font-mono text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
             <div className="truncate text-[12px] font-bold text-slate-50">{formatAccountMeterValue(meter, t)}</div>
           </div>
         ))}
@@ -125,7 +125,7 @@ function AccountMeters({
           return (
             <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_56px] items-center gap-2" key={meter.id}>
               <div className="min-w-0">
-                <div className="truncate text-[10px] font-medium text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
+                <div className="truncate text-[10px] font-medium font-mono text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
                 {progress !== undefined ? (
                   <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-white/10">
                     <div className={`h-full rounded-full ${progressClass}`} style={{ width: `${progress}%` }} />
@@ -147,7 +147,7 @@ function AccountMeters({
         return (
           <div className="min-w-0" key={meter.id}>
             <div className="flex min-w-0 items-end justify-between gap-2">
-              <div className="min-w-0 truncate text-[10px] font-medium text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
+              <div className="min-w-0 truncate text-[10px] font-medium font-mono text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
               <div className="shrink-0 text-[13px] font-bold text-slate-50">{formatAccountMeterValue(meter, t)}</div>
             </div>
             {progress !== undefined ? (
@@ -177,7 +177,7 @@ function AccountMeterGauge({
   return (
     <div className="min-w-0 text-center">
       <RadialMetric color={color} label={formatAccountMeterValue(meter, t)} value={ratio} variant={variant} />
-      <div className="mt-0.5 truncate text-[9px] font-medium text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
+      <div className="mt-0.5 truncate text-[9px] font-medium font-mono text-slate-400">{formatAccountMeterTitle(meter, t)}</div>
     </div>
   );
 }

--- a/packages/ui/src/pages/tray/components/account-panel.tsx
+++ b/packages/ui/src/pages/tray/components/account-panel.tsx
@@ -1,9 +1,19 @@
+import { useEffect, useState } from "react";
 import {
   accountMetersForDisplay, accountProgressClass, accountProgressColor, accountSnapshotLabel, compareAccountSnapshots, formatAccountMeterTitle, formatAccountMeterValue,
   LoaderCircle, meterProgress, meterRemainingRatio, meterValidityProgress, ProviderAccountMeter, ProviderAccountSnapshot, RefreshCw, TrayComponentVariants,
   useTrayText
 } from "../shared";
 import { RadialMetric } from "./widgets";
+
+// 定时重渲染：让重置倒计时每分钟自动刷新
+function useRerenderEvery(intervalMs: number) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = window.setInterval(() => setTick((value) => value + 1), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+}
 
 export function AccountSummaryPanel({
   onRefresh,
@@ -16,6 +26,7 @@ export function AccountSummaryPanel({
   snapshots: ProviderAccountSnapshot[];
   variant: TrayComponentVariants["account"];
 }) {
+  useRerenderEvery(60_000);
   const t = useTrayText();
   const snapshot = snapshots
     .filter((snapshot) => snapshot.meters.length > 0 || snapshot.status === "error")

--- a/packages/ui/src/pages/tray/shared.tsx
+++ b/packages/ui/src/pages/tray/shared.tsx
@@ -868,11 +868,15 @@ export function formatAccountReset(value: string, translate: (value: string) => 
   if (minutes < 60) {
     return `${prefix} ${minutes}m`;
   }
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) {
-    return `${prefix} ${hours}h`;
+  // 双单位精确显示：< 24h 用「Xh Ym」，>= 24h 用「Xd Yh」
+  const totalHours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (totalHours < 24) {
+    return mins > 0 ? `${prefix} ${totalHours}h ${mins}m` : `${prefix} ${totalHours}h`;
   }
-  return `${prefix} ${Math.round(hours / 24)}d`;
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours > 0 ? `${prefix} ${days}d ${hours}h` : `${prefix} ${days}d`;
 }
 
 export function formatAccountMeterTitle(meter: ProviderAccountMeter, translate: (value: string) => string): string {

--- a/packages/ui/src/pages/tray/shared.tsx
+++ b/packages/ui/src/pages/tray/shared.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_TRAY_COMPONENT_VARIANTS, DEFAULT_TRAY_WIDGETS, DEFAULT_TRAY_WIN
 import { formatLocalizedErrorMessage } from "@ccr/core/contracts/i18n";
 import { findProviderPreset, findProviderPresetByBaseUrl, providerPresets } from "@ccr/core/providers/presets";
 import { providerPresetIconUrls } from "../home/shared/options";
+import { formatProviderAccountMeterTitleCompact } from "../home/shared/provider-accounts";
 import type {
   AppConfig,
   GatewayProviderConfig,
@@ -816,10 +817,6 @@ function meterDetailTimestamp(value: string | undefined): number | undefined {
   return Number.isFinite(timestamp) ? timestamp : undefined;
 }
 
-export function translateAccountMeterLabel(label: string, translate: (value: string) => string): string {
-  return translate(label);
-}
-
 export function formatAccountMeterValue(meter: ProviderAccountMeter, translate: (value: string) => string): string {
   const value = meter.remaining ?? meter.used ?? meter.limit;
   if (value === undefined) {
@@ -855,33 +852,8 @@ export function formatMeterNumber(value: number): string {
   return new Intl.NumberFormat(undefined, { maximumFractionDigits: 6 }).format(value);
 }
 
-export function formatAccountReset(value: string, translate: (value: string) => string = (item) => item): string {
-  const timestamp = new Date(value).getTime();
-  if (!Number.isFinite(timestamp)) {
-    return value;
-  }
-  const minutes = Math.round((timestamp - Date.now()) / 60000);
-  if (minutes <= 0) {
-    return translate("expired");
-  }
-  const prefix = translate("expires in");
-  if (minutes < 60) {
-    return `${prefix} ${minutes}m`;
-  }
-  // 双单位精确显示：< 24h 用「Xh Ym」，>= 24h 用「Xd Yh」
-  const totalHours = Math.floor(minutes / 60);
-  const mins = minutes % 60;
-  if (totalHours < 24) {
-    return mins > 0 ? `${prefix} ${totalHours}h ${mins}m` : `${prefix} ${totalHours}h`;
-  }
-  const days = Math.floor(totalHours / 24);
-  const hours = totalHours % 24;
-  return hours > 0 ? `${prefix} ${days}d ${hours}h` : `${prefix} ${days}d`;
-}
-
 export function formatAccountMeterTitle(meter: ProviderAccountMeter, translate: (value: string) => string): string {
-  const label = translateAccountMeterLabel(meter.label, translate);
-  return meter.resetAt ? `${label} (${formatAccountReset(meter.resetAt, translate)})` : label;
+  return formatProviderAccountMeterTitleCompact(meter, translate);
 }
 
 export function accountStatusClass(status: ProviderAccountSnapshot["status"]): string {

--- a/packages/ui/test/component/overview-components.test.tsx
+++ b/packages/ui/test/component/overview-components.test.tsx
@@ -250,7 +250,7 @@ test("OverviewView prioritizes Codex manual resets before folded balance meters"
   assert.doesNotMatch(html, /Effective/);
   assert.doesNotMatch(html, /Expires/);
   assert.doesNotMatch(html, /Full reset/);
-  assert.match(html, /📆 \d+d\d+h/);
+  assert.match(html, /☀️ \d+d\d+h/);
   assert.match(html, /2 resets/);
   assert.doesNotMatch(html, /Credit balance/);
 });

--- a/packages/ui/test/component/overview-components.test.tsx
+++ b/packages/ui/test/component/overview-components.test.tsx
@@ -250,7 +250,7 @@ test("OverviewView prioritizes Codex manual resets before folded balance meters"
   assert.doesNotMatch(html, /Effective/);
   assert.doesNotMatch(html, /Expires/);
   assert.doesNotMatch(html, /Full reset/);
-  assert.match(html, /expires in/);
+  assert.match(html, /📆 \d+d\d+h/);
   assert.match(html, /2 resets/);
   assert.doesNotMatch(html, /Credit balance/);
 });

--- a/packages/ui/test/component/tray-components.test.tsx
+++ b/packages/ui/test/component/tray-components.test.tsx
@@ -231,7 +231,7 @@ test("AccountSummaryPanel prioritizes Codex manual reset meter with expiration",
 
   assert.match(html, /Primary quota/);
   assert.match(html, /Manual resets/);
-  assert.match(html, /expires in/);
+  assert.match(html, /☀️ \d+d\d+h/);
   assert.match(html, /2 resets/);
   assert.match(html, /width:/);
   assert.doesNotMatch(html, /Secondary quota/);

--- a/packages/ui/test/integration/providers.test.ts
+++ b/packages/ui/test/integration/providers.test.ts
@@ -33,6 +33,7 @@ import {
   removeLocalAgentProviderPluginsForProvider,
   setProviderPresets
 } from "@ccr/ui/pages/home/shared/index.tsx";
+import { createProviderAccountDraftFromConfig, parseProviderAccountDraft } from "@ccr/ui/pages/home/shared/providers.ts";
 import { installBrowserGlobals } from "../fixtures/index.ts";
 
 installBrowserGlobals();
@@ -1249,3 +1250,101 @@ function providerInstallLinkPayload(link) {
   const bytes = Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
   return JSON.parse(new TextDecoder().decode(bytes));
 }
+
+test("raw account connectors win over stale form URL on save", () => {
+  const draft = {
+    ...createProviderDraft([]),
+    accountConnectorsText: JSON.stringify([
+      {
+        type: "http-json",
+        auth: "provider-api-key",
+        endpoint: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains",
+        mapping: {
+          meters: [
+            {
+              id: "five_hour_quota",
+              kind: "quota",
+              label: "5H用量",
+              used: "100 - $.model_remains[?(@.model_name==\"general\")].current_interval_remaining_percent",
+              resetAt: "$.model_remains[?(@.model_name==\"general\")].end_time",
+              unit: "%",
+              window: "5h"
+            },
+            {
+              id: "weekly_quota",
+              kind: "quota",
+              label: "7D用量",
+              used: "100 - $.model_remains[?(@.model_name==\"general\")].current_weekly_remaining_percent",
+              resetAt: "$.model_remains[?(@.model_name==\"general\")].weekly_end_time",
+              unit: "%",
+              window: "weekly"
+            }
+          ]
+        },
+        method: "GET"
+      }
+    ], null, 2),
+    accountEnabled: true,
+    accountMode: "raw",
+    usageRequestUrl: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains"
+  };
+
+  const account = parseProviderAccountDraft(draft);
+  assert.ok(account && typeof account !== "string");
+  const connectors = account.connectors ?? [];
+  assert.equal(connectors.length, 1);
+  assert.equal(connectors[0].type, "http-json");
+  const meters = connectors[0].mapping.meters;
+  assert.equal(meters.length, 2);
+  assert.equal(meters[0].id, "five_hour_quota");
+  assert.equal(meters[0].kind, "quota");
+  assert.equal(meters[0].label, "5H用量");
+  assert.equal(meters[0].window, "5h");
+  assert.equal(meters[1].id, "weekly_quota");
+  assert.equal(meters[1].window, "weekly");
+});
+
+test("quota meter connectors reopen in raw mode without dropping meters", () => {
+  const account = {
+    connectors: [
+      {
+        type: "http-json",
+        auth: "provider-api-key",
+        endpoint: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains",
+        mapping: {
+          meters: [
+            {
+              id: "five_hour_quota",
+              kind: "quota",
+              label: "5H用量",
+              remaining: "$.model_remains[?(@.model_name==\"general\")].current_interval_remaining_percent",
+              resetAt: "$.model_remains[?(@.model_name==\"general\")].end_time",
+              unit: "%",
+              window: "5h"
+            },
+            {
+              id: "weekly_quota",
+              kind: "quota",
+              label: "7D用量",
+              remaining: "$.model_remains[?(@.model_name==\"general\")].current_weekly_remaining_percent",
+              resetAt: "$.model_remains[?(@.model_name==\"general\")].weekly_end_time",
+              unit: "%",
+              window: "weekly"
+            }
+          ]
+        },
+        method: "GET"
+      }
+    ],
+    enabled: true
+  };
+
+  const draft = createProviderAccountDraftFromConfig(account);
+  assert.equal(draft.accountMode, "raw");
+  const connectors = JSON.parse(draft.accountConnectorsText);
+  assert.equal(connectors.length, 1);
+  assert.equal(connectors[0].mapping.meters.length, 2);
+  assert.equal(connectors[0].mapping.meters[0].id, "five_hour_quota");
+  assert.equal(connectors[0].mapping.meters[0].window, "5h");
+  assert.equal(connectors[0].mapping.meters[1].window, "weekly");
+});


### PR DESCRIPTION
## Summary

Polish the account balance cards across the dashboard and tray, and fix two bugs that silently discarded custom HTTP JSON account connectors.

## Changes

### Account balance UI
- Meter rows are now compact single lines: label, reset countdown (`🕛 3h28m` / `☀️ 1d17h`) with monospace digits, percentage right-aligned.
- Day-scale windows (7D/30D) use `☀️`, hour-scale (5H) uses `🕛`; the wordy `expires in` prefix is dropped and durations are zero-padded (`3h28m`, `1d17h`) so rows align.
- Percent values warn in amber at ≥75 and turn red at ≥90 (percent-unit meters only).
- The tray account panel and the dashboard gauge/label surfaces share the same compact format (`formatProviderAccountMeterTitleCompact`) with monospace digits.

### Fixes: account connector persistence
- Saving with `accountMode: "raw"` no longer falls into the HTTP JSON form branch when a stale form URL is present; pasted Connectors JSON is now always used for raw mode.
- Reopening an http-json connector whose meters are quota/tokens/time-window keeps them intact in raw mode instead of flattening everything into a single `subscription` meter (which dropped meters and the window).
- Regression tests cover both paths.

## Verification
- `tsc --noEmit`: clean.
- ui workspace tests: 152 passing (component + integration).
- Manual: configured a MiniMax coding-plan http-json connector (5H用量 / 7D用量 meters), confirmed it saves, reopens in raw mode, and renders the compact format in both dashboard and tray.
