### PR TITLE
fix(gateway): hot-refresh claude-code-oauth token when Claude Code rotates credentials

### DIFF
--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -219,7 +219,7 @@ export function scanClaudeCodeLogin(): ClaudeCodeLoginScan {
   return scan;
 }
 
-function claudeCredentialFiles(): string[] {
+export function claudeCredentialFiles(): string[] {
   return uniqueStrings([
     path.join(claudeCodeStorageDir(), ".credentials.json"),
     path.join(os.homedir(), ".claude", ".credentials.json"),

--- a/packages/core/src/gateway/application/gateway-service.ts
+++ b/packages/core/src/gateway/application/gateway-service.ts
@@ -12,6 +12,9 @@ import { pluginService } from "@ccr/core/plugins/service";
 import { proxyService } from "@ccr/core/proxy/service";
 import { ClaudeCodeRouterPlugin } from "@ccr/core/gateway/claude-code-router-plugin";
 import { compileCoreGatewayConfig } from "@ccr/core/gateway/core-runtime/config-compiler";
+import { startLocalOauthCredentialWatch } from "@ccr/core/gateway/core-runtime/local-oauth-watch";
+import { claudeCredentialFiles, readClaudeCodeOauth } from "@ccr/core/agents/local-providers/claude-code";
+import { isLocalClaudeCodeOauthProviderPlugin } from "@ccr/core/providers/oauth-plugin";
 import { closeServer, formatError } from "@ccr/core/gateway/http/io";
 import { RawTraceSynchronizer } from "@ccr/core/observability/raw-trace-sync";
 import { GatewayBillingSynchronizer } from "@ccr/core/usage/billing-sync";
@@ -82,6 +85,7 @@ class GatewayService {
 
   private browserAutomationMcpIntegration?: BrowserAutomationMcpIntegration;
   private browserWebSearchMcpIntegration?: BrowserWebSearchMcpIntegration;
+  private oauthCredentialWatchStop?: () => void;
   private readonly billingSynchronizer = new GatewayBillingSynchronizer({
     getConfig: () => this.config,
     getGlobalBillingConfig: () => pluginService.getCoreGatewayConfig().billing
@@ -214,6 +218,7 @@ class GatewayService {
         pid: this.child?.pid,
         state: "running"
       };
+      this.startOauthCredentialWatchIfNeeded(config);
       return this.status;
     } catch (error) {
       await this.stop();
@@ -227,6 +232,8 @@ class GatewayService {
   }
 
   async stop(options: GatewayStopOptions = {}): Promise<GatewayStatus> {
+    this.oauthCredentialWatchStop?.();
+    this.oauthCredentialWatchStop = undefined;
     const child = this.child;
     this.child = undefined;
     this.coreAuthToken = "";
@@ -272,6 +279,34 @@ class GatewayService {
         ? gatewayNetworkEndpoints(this.config.gateway.host, this.config.gateway.port)
         : this.status.networkEndpoints
     };
+  }
+
+  private startOauthCredentialWatchIfNeeded(config: AppConfig): void {
+    this.oauthCredentialWatchStop?.();
+    this.oauthCredentialWatchStop = undefined;
+    if (!(config.providerPlugins ?? []).some(isLocalClaudeCodeOauthProviderPlugin)) {
+      return;
+    }
+    // The spawned gateway's Anthropic auth is stamped from the credentials file
+    // at compile time (withClaudeCodeOauthRuntimeDefaults) and applied statically
+    // per request. Claude Code rotates that file on its own schedule, so without
+    // a live refresh the provider starts 401ing between restarts. Restart on
+    // rotation; the restart recompiles and stamps the fresh token (#1628).
+    this.oauthCredentialWatchStop = startLocalOauthCredentialWatch({
+      files: claudeCredentialFiles(),
+      readAccessToken: () => readClaudeCodeOauth()?.accessToken,
+      onAccessTokenChanged: () => {
+        const currentConfig = this.config;
+        if (!currentConfig || this.status.state !== "running") {
+          return;
+        }
+        console.info("[gateway] Claude Code OAuth credentials rotated; restarting with refreshed token.");
+        void this.start(currentConfig).catch((error: unknown) => {
+          console.warn(`[gateway] OAuth-rotation restart failed: ${formatError(error)}`);
+        });
+      },
+      log: (message) => console.info(message)
+    });
   }
 
   async updateConfig(config: AppConfig): Promise<void> {

--- a/packages/core/src/gateway/core-runtime/local-oauth-watch.ts
+++ b/packages/core/src/gateway/core-runtime/local-oauth-watch.ts
@@ -1,0 +1,81 @@
+import { existsSync, watch, type FSWatcher } from "node:fs";
+import { dirname } from "node:path";
+
+export interface LocalOauthCredentialWatchOptions {
+  /** Credential files to observe (missing files fall back to watching their parent dir, which catches atomic rename writes). */
+  files: string[];
+  /** Returns the currently valid access token, or undefined when unreadable. */
+  readAccessToken: () => string | undefined;
+  /** Called once per actual token change (debounced, and only when the new token differs). */
+  onAccessTokenChanged: () => void;
+  debounceMs?: number;
+  log?: (message: string) => void;
+}
+
+/**
+ * Watches local agent OAuth credential files and fires when the access token
+ * changes. Claude Code rotates `~/.claude/.credentials.json` on its own
+ * refresh schedule; any provider whose auth was stamped from an older copy
+ * (see withClaudeCodeOauthRuntimeDefaults) starts 401ing until recompiled.
+ * The watcher lets the owning service refresh as soon as the rotation lands
+ * instead of at the next manual restart.
+ */
+export function startLocalOauthCredentialWatch(
+  options: LocalOauthCredentialWatchOptions
+): () => void {
+  const debounceMs = options.debounceMs ?? 1500;
+  const log = options.log ?? (() => {});
+  let currentToken = options.readAccessToken();
+  let timer: NodeJS.Timeout | undefined;
+  const watchers: FSWatcher[] = [];
+
+  const scheduleCheck = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      const nextToken = options.readAccessToken();
+      if (!nextToken || nextToken === currentToken) {
+        return;
+      }
+      currentToken = nextToken;
+      log(`[local-oauth-watch] access token changed on disk`);
+      options.onAccessTokenChanged();
+    }, debounceMs);
+    timer.unref?.();
+  };
+
+  const watchedTargets = new Set<string>();
+  for (const file of options.files) {
+    const target = existsSync(file) ? file : dirname(file);
+    if (watchedTargets.has(target)) {
+      continue;
+    }
+    try {
+      const watcher = watch(target, { persistent: false }, () => scheduleCheck());
+      watcher.on("error", () => {
+        // Watched path disappeared between the existsSync check and watch(); ignore.
+      });
+      watchers.push(watcher);
+      watchedTargets.add(target);
+    } catch {
+      // Parent dir may not exist either; nothing sensible to watch.
+    }
+  }
+
+  if (watchedTargets.size > 0) {
+    log(`[local-oauth-watch] watching ${watchedTargets.size} credential target(s)`);
+  }
+
+  return () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    for (const watcher of watchers) {
+      watcher.close();
+    }
+    watchers.length = 0;
+  };
+}

--- a/packages/core/test/unit/gateway/local-oauth-watch.test.mjs
+++ b/packages/core/test/unit/gateway/local-oauth-watch.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test("fires once when the access token changes on disk", async () => {
+  const { startLocalOauthCredentialWatch } = await import("@ccr/core/gateway/core-runtime/local-oauth-watch.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "oauth-watch-"));
+  const file = path.join(dir, ".credentials.json");
+  let token = "tok-old";
+  writeFileSync(file, JSON.stringify({ claudeAiOauth: { accessToken: token } }));
+
+  let calls = 0;
+  const stop = startLocalOauthCredentialWatch({
+    files: [file],
+    readAccessToken: () => token,
+    onAccessTokenChanged: () => { calls += 1; },
+    debounceMs: 20
+  });
+
+  token = "tok-new";
+  writeFileSync(file, JSON.stringify({ claudeAiOauth: { accessToken: token } }));
+  await sleep(300);
+  assert.equal(calls, 1);
+
+  stop();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("does not fire when the token is unchanged or becomes unreadable", async () => {
+  const { startLocalOauthCredentialWatch } = await import("@ccr/core/gateway/core-runtime/local-oauth-watch.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "oauth-watch-"));
+  const file = path.join(dir, ".credentials.json");
+  let token = "tok-same";
+  writeFileSync(file, "{}");
+
+  let calls = 0;
+  const stop = startLocalOauthCredentialWatch({
+    files: [file],
+    readAccessToken: () => token,
+    onAccessTokenChanged: () => { calls += 1; },
+    debounceMs: 20
+  });
+
+  writeFileSync(file, '{"touched":true}');
+  await sleep(250);
+  token = undefined;
+  writeFileSync(file, '{"touched":2}');
+  await sleep(250);
+  assert.equal(calls, 0);
+
+  stop();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("close() stops future notifications", async () => {
+  const { startLocalOauthCredentialWatch } = await import("@ccr/core/gateway/core-runtime/local-oauth-watch.ts");
+  const dir = mkdtempSync(path.join(tmpdir(), "oauth-watch-"));
+  const file = path.join(dir, ".credentials.json");
+  let token = "tok-1";
+  writeFileSync(file, "{}");
+
+  let calls = 0;
+  const stop = startLocalOauthCredentialWatch({
+    files: [file],
+    readAccessToken: () => token,
+    onAccessTokenChanged: () => { calls += 1; },
+    debounceMs: 20
+  });
+
+  stop();
+  token = "tok-2";
+  writeFileSync(file, '{"touched":true}');
+  await sleep(250);
+  assert.equal(calls, 0);
+
+  rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Fixes #1628.

## Problem

The local Claude Code OAuth provider's upstream auth is stamped from `~/.claude/.credentials.json` when the gateway config is compiled (`withClaudeCodeOauthRuntimeDefaults` in `config-compiler.ts`) and then applied **statically** per request. Claude Code rotates that file on its own refresh schedule (and interactive CLI sessions rotate the whole token family), so the spawned gateway starts **401ing within hours** until someone restarts it. Verified live: the gateway sends the stale embedded token while a direct API call with the current file token succeeds; every fallback chain degrades or fails.

Unlike `codexOauth` (which carries a refreshToken and refreshes in-process), the claude plugin has no refresh lifecycle — and the spawned `ai-gateway` dispatcher has no `claude-code-oauth` handling at all.

## Fix

Add a credential-file watcher owned by the gateway service (`local-oauth-watch.ts`):

- Watches the same credential paths the login scanner uses (including `CLAUDE_CONFIG_DIR` relocation; `claudeCredentialFiles()` is now exported)
- Debounced, and only fires when the on-disk access token **actually changed** (unreadable snapshots ignored, e.g. mid-rewrite)
- On rotation, the service restarts itself — which recompiles and stamps the fresh token via the existing `withClaudeCodeOauthRuntimeDefaults` path
- Closed on `stop()`; only starts when a claude-code-oauth plugin is configured

Rotations are rare (~8h+ token lifetimes), so restarts are rare and only cost a dropped compile cycle, not ongoing churn.

## Tests

3 new unit tests for the watcher (fires once on real change; silent on unchanged/unreadable snapshots; `close()` stops future notifications). Core suite: **691 pass / 3 fail** — the 3 failures are pre-existing bundled-plugin tests that also fail on main (verified against a stashed baseline; all 3 new tests fail there as expected). `tsc --noEmit` clean.

## Out of scope

A codex-style in-process refresh lifecycle (refresh endpoint + atomic write-back into the credentials file) would remove restarts entirely, but that refresh endpoint is Cloudflare-gated for non-CLI clients today. This PR fixes the staleness with the primitives that already work.