### PR TITLE
fix(kimi): adopt peer-rotated credential on refresh 401

### DIFF
--- a/packages/core/src/agents/local-providers/kimi.ts
+++ b/packages/core/src/agents/local-providers/kimi.ts
@@ -54,6 +54,16 @@ type KimiConfiguredProvider = {
   sourceFile: string;
 };
 
+export class KimiRefreshAuthError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "KimiRefreshAuthError";
+    this.status = status;
+  }
+}
+
 export type KimiTokenSet = {
   accessToken?: string;
   expiresAt?: number;
@@ -163,7 +173,13 @@ export function readKimiAuth(reference?: KimiOauthReference): KimiTokenSet | und
   if (!oauthKey) {
     return undefined;
   }
-  const sourceFile = kimiCredentialFile(oauthKey);
+  return readKimiAuthFromFile(
+    kimiCredentialFile(oauthKey),
+    reference?.oauthHost?.trim() || provider?.oauthHost
+  );
+}
+
+function readKimiAuthFromFile(sourceFile: string, oauthHost?: string): KimiTokenSet | undefined {
   const record = readJsonRecord(sourceFile);
   if (!record) {
     return undefined;
@@ -173,7 +189,7 @@ export function readKimiAuth(reference?: KimiOauthReference): KimiTokenSet | und
     accessToken: readString(record.access_token) || readString(record.accessToken),
     expiresAt,
     expiresIn: numberValue(record.expires_in) ?? numberValue(record.expiresIn),
-    oauthHost: reference?.oauthHost?.trim() || provider?.oauthHost,
+    oauthHost,
     refreshToken: readString(record.refresh_token) || readString(record.refreshToken),
     scope: readString(record.scope),
     sourceFile,
@@ -189,12 +205,29 @@ export async function resolveKimiAuth(reference?: KimiOauthReference): Promise<K
   const key = auth.sourceFile;
   let refresh = kimiRefreshInFlight.get(key);
   if (!refresh) {
-    refresh = refreshKimiAuth(auth).finally(() => {
-      kimiRefreshInFlight.delete(key);
-    });
+    refresh = refreshKimiAuth(auth)
+      .catch((error: unknown) => adoptPeerRotatedKimiAuth(auth, error))
+      .finally(() => {
+        kimiRefreshInFlight.delete(key);
+      });
     kimiRefreshInFlight.set(key, refresh);
   }
   return refresh;
+}
+
+function adoptPeerRotatedKimiAuth(auth: KimiTokenSet, error: unknown): KimiTokenSet {
+  if (!(error instanceof KimiRefreshAuthError)) {
+    throw error;
+  }
+  // The refresh token rotates on every refresh. When a peer process sharing
+  // this credential file (for example the Kimi CLI) refreshes first, our copy
+  // is stale and the server rejects it, but the file on disk already holds
+  // the newer credential. Adopt it instead of failing the request.
+  const latest = readKimiAuthFromFile(auth.sourceFile, auth.oauthHost);
+  if (latest?.refreshToken && latest.refreshToken !== auth.refreshToken) {
+    return latest;
+  }
+  throw error;
 }
 
 export function kimiAccessTokenExpired(auth: KimiTokenSet): boolean {
@@ -386,7 +419,11 @@ async function refreshKimiAuth(auth: KimiTokenSet): Promise<KimiTokenSet> {
     const text = await response.text();
     const payload = parseJsonRecord(text);
     if (!response.ok) {
-      throw new Error(`Kimi CLI OAuth token refresh returned HTTP ${response.status}${tokenRefreshErrorMessage(payload, text)}`);
+      const message = `Kimi CLI OAuth token refresh returned HTTP ${response.status}${tokenRefreshErrorMessage(payload, text)}`;
+      if (response.status === 401 || response.status === 403) {
+        throw new KimiRefreshAuthError(response.status, message);
+      }
+      throw new Error(message);
     }
     const accessToken = readString(payload?.access_token) || readString(payload?.accessToken);
     const refreshToken = readString(payload?.refresh_token) || readString(payload?.refreshToken);

--- a/packages/core/src/agents/local-providers/kimi.ts
+++ b/packages/core/src/agents/local-providers/kimi.ts
@@ -54,7 +54,7 @@ type KimiConfiguredProvider = {
   sourceFile: string;
 };
 
-export class KimiRefreshAuthError extends Error {
+class KimiRefreshAuthError extends Error {
   readonly status: number;
 
   constructor(status: number, message: string) {
@@ -224,7 +224,7 @@ function adoptPeerRotatedKimiAuth(auth: KimiTokenSet, error: unknown): KimiToken
   // is stale and the server rejects it, but the file on disk already holds
   // the newer credential. Adopt it instead of failing the request.
   const latest = readKimiAuthFromFile(auth.sourceFile, auth.oauthHost);
-  if (latest?.refreshToken && latest.refreshToken !== auth.refreshToken) {
+  if (latest?.refreshToken && latest.accessToken && latest.refreshToken !== auth.refreshToken) {
     return latest;
   }
   throw error;

--- a/packages/core/test/unit/agents/local-agent-provider-kimi.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-kimi.test.mjs
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { importKimiProvider, kimiCandidates } from "@ccr/core/agents/local-providers/kimi.ts";
+import { importKimiProvider, kimiCandidates, resolveKimiAuth } from "@ccr/core/agents/local-providers/kimi.ts";
 
 test("Kimi CLI OAuth login is discovered from inline TOML and imported", async () => {
   await withKimiHome(async (kimiHome) => {
@@ -141,6 +141,83 @@ oauth = { storage = "file", key = "oauth/kimi-code", oauth_host = "http://127.0.
     assert.equal(persisted.access_token, "refreshed-access-token");
     assert.equal(persisted.refresh_token, "refreshed-refresh-token");
     assert.equal(persisted.expires_in, 7200);
+  });
+});
+
+test("Kimi CLI OAuth adopts a credential rotated by a peer process on refresh 401", async (t) => {
+  await withKimiHome(async (kimiHome) => {
+    writeFileSync(path.join(kimiHome, "config.toml"), `
+[providers."managed:kimi-code"]
+type = "kimi"
+base_url = "https://api.kimi.com/coding/v1"
+oauth = { storage = "file", key = "oauth/kimi-code", oauth_host = "http://127.0.0.1" }
+`);
+    const credentialsDir = path.join(kimiHome, "credentials");
+    mkdirSync(credentialsDir, { recursive: true });
+    const credentialFile = path.join(credentialsDir, "kimi-code.json");
+    writeFileSync(credentialFile, JSON.stringify({
+      access_token: "expired-token",
+      expires_at: 1,
+      expires_in: 3600,
+      refresh_token: "stale-refresh-token"
+    }));
+
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      // The Kimi CLI refreshed first: it persisted the rotated credential and
+      // invalidated the refresh token this process still holds.
+      writeFileSync(credentialFile, JSON.stringify({
+        access_token: "peer-access-token",
+        expires_at: 32503680000,
+        expires_in: 7200,
+        refresh_token: "peer-refresh-token",
+        token_type: "Bearer"
+      }));
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        headers: { "content-type": "application/json" },
+        status: 401
+      });
+    };
+    t.after(() => {
+      globalThis.fetch = previousFetch;
+    });
+
+    const auth = await resolveKimiAuth({ key: "oauth/kimi-code", oauthHost: "http://127.0.0.1" });
+    assert.equal(auth.accessToken, "peer-access-token");
+    assert.equal(auth.refreshToken, "peer-refresh-token");
+  });
+});
+
+test("Kimi CLI OAuth surfaces refresh 401 when no peer rotation is on disk", async (t) => {
+  await withKimiHome(async (kimiHome) => {
+    writeFileSync(path.join(kimiHome, "config.toml"), `
+[providers."managed:kimi-code"]
+type = "kimi"
+base_url = "https://api.kimi.com/coding/v1"
+oauth = { storage = "file", key = "oauth/kimi-code", oauth_host = "http://127.0.0.1" }
+`);
+    const credentialsDir = path.join(kimiHome, "credentials");
+    mkdirSync(credentialsDir, { recursive: true });
+    writeFileSync(path.join(credentialsDir, "kimi-code.json"), JSON.stringify({
+      access_token: "expired-token",
+      expires_at: 1,
+      expires_in: 3600,
+      refresh_token: "stale-refresh-token"
+    }));
+
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(JSON.stringify({ error: "invalid_grant" }), {
+      headers: { "content-type": "application/json" },
+      status: 401
+    });
+    t.after(() => {
+      globalThis.fetch = previousFetch;
+    });
+
+    await assert.rejects(
+      () => resolveKimiAuth({ key: "oauth/kimi-code", oauthHost: "http://127.0.0.1" }),
+      /HTTP 401/
+    );
   });
 });
 

--- a/packages/core/test/unit/agents/local-agent-provider-kimi.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-kimi.test.mjs
@@ -221,6 +221,48 @@ oauth = { storage = "file", key = "oauth/kimi-code", oauth_host = "http://127.0.
   });
 });
 
+test("Kimi CLI OAuth does not adopt a rotated credential without an access token", async (t) => {
+  await withKimiHome(async (kimiHome) => {
+    writeFileSync(path.join(kimiHome, "config.toml"), `
+[providers."managed:kimi-code"]
+type = "kimi"
+base_url = "https://api.kimi.com/coding/v1"
+oauth = { storage = "file", key = "oauth/kimi-code", oauth_host = "http://127.0.0.1" }
+`);
+    const credentialsDir = path.join(kimiHome, "credentials");
+    mkdirSync(credentialsDir, { recursive: true });
+    const credentialFile = path.join(credentialsDir, "kimi-code.json");
+    writeFileSync(credentialFile, JSON.stringify({
+      access_token: "expired-token",
+      expires_at: 1,
+      expires_in: 3600,
+      refresh_token: "stale-refresh-token"
+    }));
+
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      // Partial write: a new refresh token landed without an access token.
+      writeFileSync(credentialFile, JSON.stringify({
+        expires_at: 1,
+        expires_in: 7200,
+        refresh_token: "peer-refresh-token"
+      }));
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        headers: { "content-type": "application/json" },
+        status: 401
+      });
+    };
+    t.after(() => {
+      globalThis.fetch = previousFetch;
+    });
+
+    await assert.rejects(
+      () => resolveKimiAuth({ key: "oauth/kimi-code", oauthHost: "http://127.0.0.1" }),
+      /HTTP 401/
+    );
+  });
+});
+
 async function withKimiHome(run) {
   const kimiHome = mkdtempSync(path.join(os.tmpdir(), "ccr-kimi-provider-"));
   const previous = {


### PR DESCRIPTION
## Problem

Kimi's OAuth refresh token **rotates on every refresh**. CCR reads and writes the same `~/.kimi/credentials/*.json` file as the Kimi CLI. When the CLI (or any other consumer of that file) refreshes first, the refresh token CCR just read is invalidated, and CCR's refresh fails with HTTP 401/403.

Previously that error propagated straight to the caller (`Kimi CLI OAuth token refresh returned HTTP 401`), even though the credential file on disk already held a valid, newer credential written by the peer process. The only recovery was to wait for the next request and hope, or re-login.

## Fix

In `resolveKimiAuth`, when the refresh fails with 401/403 (now a typed `KimiRefreshAuthError`), re-read the credential file once:

- if the stored refresh token **differs** from the one that was just rejected, a peer rotated it: adopt the on-disk credential and return it instead of failing;
- otherwise the error propagates exactly as before.

Non-auth refresh errors (network, 5xx, timeouts) are unaffected. `readKimiAuth` was refactored so the file-reading logic (`readKimiAuthFromFile`) can be reused without re-resolving the provider config.

This mirrors the peer-rotation adoption that `xaionaro-go/kimi-oauth-proxy` implements against the same OAuth backend and shared lock.

## Tests

Two new tests in `test/unit/agents/local-agent-provider-kimi.test.mjs`:

- **adopts a credential rotated by a peer process on refresh 401**: the fetch stub simulates the CLI persisting a rotated credential and rejecting the stale token; `resolveKimiAuth` returns the peer credential;
- **surfaces refresh 401 when no peer rotation is on disk**: an untouched file keeps the previous behavior and the 401 propagates.

`local-agent-provider-kimi.test`: 5/5 passing. Full core suite: 681 passing, 21 failing; the same 21 fail on a clean `main` checkout (legacy config migration tests, unrelated to this change).