### PR TITLE
fix(grok): adopt peer-rotated credential on refresh 401

### DIFF
--- a/packages/core/src/agents/local-providers/grok.ts
+++ b/packages/core/src/agents/local-providers/grok.ts
@@ -279,9 +279,13 @@ function adoptPeerRotatedGrokAuth(auth: GrokTokenSet, error: unknown): GrokToken
   // The refresh token rotates on every refresh. When a peer process sharing
   // this credential file (for example the Grok CLI) refreshes first, our copy
   // is stale and the server rejects it, but the file on disk already holds
-  // the newer credential. Adopt it instead of failing the request.
-  const latest = readGrokAuth();
-  if (latest?.refreshToken && latest.refreshToken !== auth.refreshToken) {
+  // the newer credential. Adopt it instead of failing the request. Only the
+  // same account record is considered: in a multi-account file a different
+  // record says nothing about the token that was rejected.
+  const latest = readGrokAuthRecords(auth.sourceFile).find(
+    (item) => item.authRecordKey === auth.authRecordKey
+  );
+  if (latest?.refreshToken && latest.accessToken && latest.refreshToken !== auth.refreshToken) {
     return latest;
   }
   throw error;

--- a/packages/core/src/agents/local-providers/grok.ts
+++ b/packages/core/src/agents/local-providers/grok.ts
@@ -47,6 +47,8 @@ const grokDefaultOidcIssuer = "https://auth.x.ai";
 const grokOauthDefaultTimeoutMs = 8_000;
 const grokFallbackClientVersion = "0.2.93";
 
+const grokRefreshInFlight = new Map<string, Promise<GrokTokenSet>>();
+
 const grokBillingResetPaths = [
   "$.billingPeriodEnd",
   "$.currentPeriod.end",
@@ -182,7 +184,7 @@ const grokBillingMapping: ProviderAccountMappingConfig = {
   ]
 };
 
-export class GrokRefreshAuthError extends Error {
+class GrokRefreshAuthError extends Error {
   readonly status: number;
 
   constructor(status: number, message: string) {
@@ -265,11 +267,25 @@ export async function resolveGrokAuth(): Promise<GrokTokenSet | undefined> {
   if (!auth?.refreshToken || (auth.accessToken && !grokAccessTokenExpired(auth))) {
     return auth;
   }
-  try {
-    return await refreshGrokAuth(auth);
-  } catch (error) {
-    return adoptPeerRotatedGrokAuth(auth, error);
+  // Coalesce concurrent refreshes of the same credential: the refresh token
+  // rotates on every refresh, so every in-process caller must share a single
+  // refresh attempt (and its peer-rotation adoption outcome) instead of
+  // submitting the same stale token in parallel.
+  const key = `${auth.sourceFile}::${auth.authRecordKey ?? ""}`;
+  let refresh = grokRefreshInFlight.get(key);
+  if (!refresh) {
+    refresh = (async () => {
+      try {
+        return await refreshGrokAuth(auth);
+      } catch (error) {
+        return adoptPeerRotatedGrokAuth(auth, error);
+      }
+    })().finally(() => {
+      grokRefreshInFlight.delete(key);
+    });
+    grokRefreshInFlight.set(key, refresh);
   }
+  return refresh;
 }
 
 function adoptPeerRotatedGrokAuth(auth: GrokTokenSet, error: unknown): GrokTokenSet {

--- a/packages/core/src/agents/local-providers/grok.ts
+++ b/packages/core/src/agents/local-providers/grok.ts
@@ -182,6 +182,16 @@ const grokBillingMapping: ProviderAccountMappingConfig = {
   ]
 };
 
+export class GrokRefreshAuthError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "GrokRefreshAuthError";
+    this.status = status;
+  }
+}
+
 export type GrokTokenSet = OAuthTokenSet & {
   authRecordKey?: string;
   oidcClientId?: string;
@@ -255,7 +265,26 @@ export async function resolveGrokAuth(): Promise<GrokTokenSet | undefined> {
   if (!auth?.refreshToken || (auth.accessToken && !grokAccessTokenExpired(auth))) {
     return auth;
   }
-  return refreshGrokAuth(auth);
+  try {
+    return await refreshGrokAuth(auth);
+  } catch (error) {
+    return adoptPeerRotatedGrokAuth(auth, error);
+  }
+}
+
+function adoptPeerRotatedGrokAuth(auth: GrokTokenSet, error: unknown): GrokTokenSet {
+  if (!(error instanceof GrokRefreshAuthError)) {
+    throw error;
+  }
+  // The refresh token rotates on every refresh. When a peer process sharing
+  // this credential file (for example the Grok CLI) refreshes first, our copy
+  // is stale and the server rejects it, but the file on disk already holds
+  // the newer credential. Adopt it instead of failing the request.
+  const latest = readGrokAuth();
+  if (latest?.refreshToken && latest.refreshToken !== auth.refreshToken) {
+    return latest;
+  }
+  throw error;
 }
 
 export function readGrokLocalModelCatalog(): GrokModelCatalog {
@@ -651,7 +680,11 @@ async function refreshGrokAuth(auth: GrokTokenSet): Promise<GrokTokenSet> {
     const text = await response.text();
     const payload = parseJsonRecord(text);
     if (!response.ok) {
-      throw new Error(`Grok CLI OAuth token refresh returned HTTP ${response.status}${tokenRefreshErrorMessage(payload, text)}`);
+      const message = `Grok CLI OAuth token refresh returned HTTP ${response.status}${tokenRefreshErrorMessage(payload, text)}`;
+      if (response.status === 401 || response.status === 403) {
+        throw new GrokRefreshAuthError(response.status, message);
+      }
+      throw new Error(message);
     }
     const accessToken = readString(payload?.access_token) || readString(payload?.accessToken);
     if (!accessToken) {

--- a/packages/core/test/unit/agents/local-agent-provider-grok.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-grok.test.mjs
@@ -11,7 +11,8 @@ import {
   grokModelCatalogFromPayloadForTest,
   importGrokProvider,
   normalizeGrokProviderAccountConfig,
-  normalizeGrokProviderMediaCapabilities
+  normalizeGrokProviderMediaCapabilities,
+  resolveGrokAuth
 } from "@ccr/core/agents/local-providers/grok.ts";
 import { localAgentProviderApiKey } from "@ccr/core/agents/local-providers/shared.ts";
 
@@ -292,6 +293,69 @@ test("persisted Grok Agent providers migrate legacy xAI video capabilities", () 
 
   assert.equal(provider.capabilities?.some((capability) => capability.type === "openai_video_generations"), false);
   assert.equal(provider.capabilities?.some((capability) => capability.type === "xai_video_generations"), true);
+});
+
+test("Grok local provider adopts a credential rotated by a peer process on refresh 401", async (t) => {
+  await withGrokHome(async (grokHome) => {
+    writeGrokAuth(grokHome, {
+      key: "expired-token",
+      refresh_token: "stale-refresh-token",
+      expires_at: "2000-01-01T00:00:00Z",
+      oidc_client_id: "grok-client-id",
+      oidc_issuer: "https://auth.x.ai"
+    });
+    writeGrokModels(grokHome);
+
+    const previousFetch = globalThis.fetch;
+    process.env.GROK_OIDC_TOKEN_ENDPOINT = "http://127.0.0.1/grok/oauth/token";
+    globalThis.fetch = async () => {
+      // The Grok CLI refreshed first: it persisted the rotated credential and
+      // invalidated the refresh token this process still holds.
+      writeGrokAuth(grokHome, {
+        key: "peer-access-token",
+        refresh_token: "peer-refresh-token",
+        expires_at: "2999-01-01T00:00:00Z",
+        oidc_client_id: "grok-client-id",
+        oidc_issuer: "https://auth.x.ai"
+      });
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        headers: { "content-type": "application/json" },
+        status: 401
+      });
+    };
+    t.after(() => {
+      globalThis.fetch = previousFetch;
+    });
+
+    const auth = await resolveGrokAuth();
+    assert.equal(auth.accessToken, "peer-access-token");
+    assert.equal(auth.refreshToken, "peer-refresh-token");
+  });
+});
+
+test("Grok local provider surfaces refresh 401 when no peer rotation is on disk", async (t) => {
+  await withGrokHome(async (grokHome) => {
+    writeGrokAuth(grokHome, {
+      key: "expired-token",
+      refresh_token: "stale-refresh-token",
+      expires_at: "2000-01-01T00:00:00Z",
+      oidc_client_id: "grok-client-id",
+      oidc_issuer: "https://auth.x.ai"
+    });
+    writeGrokModels(grokHome);
+
+    const previousFetch = globalThis.fetch;
+    process.env.GROK_OIDC_TOKEN_ENDPOINT = "http://127.0.0.1/grok/oauth/token";
+    globalThis.fetch = async () => new Response(JSON.stringify({ error: "invalid_grant" }), {
+      headers: { "content-type": "application/json" },
+      status: 401
+    });
+    t.after(() => {
+      globalThis.fetch = previousFetch;
+    });
+
+    await assert.rejects(() => resolveGrokAuth(), /HTTP 401/);
+  });
 });
 
 async function withGrokHome(run) {

--- a/packages/core/test/unit/agents/local-agent-provider-grok.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-grok.test.mjs
@@ -403,6 +403,43 @@ test("Grok local provider does not adopt a different account record on refresh 4
   });
 });
 
+test("Grok local provider coalesces concurrent refreshes of the same credential", async (t) => {
+  await withGrokHome(async (grokHome) => {
+    writeGrokAuth(grokHome, {
+      key: "expired-token",
+      refresh_token: "stale-refresh-token",
+      expires_at: "2000-01-01T00:00:00Z",
+      oidc_client_id: "grok-client-id",
+      oidc_issuer: "https://auth.x.ai"
+    });
+    writeGrokModels(grokHome);
+
+    const previousFetch = globalThis.fetch;
+    process.env.GROK_OIDC_TOKEN_ENDPOINT = "http://127.0.0.1/grok/oauth/token";
+    let refreshCalls = 0;
+    globalThis.fetch = async () => {
+      refreshCalls += 1;
+      // Keep the refresh pending so the concurrent callers must share it.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return new Response(JSON.stringify({
+        access_token: "refreshed-grok-access-token",
+        expires_in: 3600,
+        refresh_token: "refreshed-grok-refresh-token"
+      }), { headers: { "content-type": "application/json" }, status: 200 });
+    };
+    t.after(() => {
+      globalThis.fetch = previousFetch;
+    });
+
+    const results = await Promise.all([resolveGrokAuth(), resolveGrokAuth(), resolveGrokAuth()]);
+    assert.equal(refreshCalls, 1);
+    for (const auth of results) {
+      assert.equal(auth.accessToken, "refreshed-grok-access-token");
+      assert.equal(auth.refreshToken, "refreshed-grok-refresh-token");
+    }
+  });
+});
+
 async function withGrokHome(run) {
   const previousGrokHome = process.env.GROK_HOME;
   const previousGrokAuthFile = process.env.GROK_AUTH_FILE;

--- a/packages/core/test/unit/agents/local-agent-provider-grok.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-grok.test.mjs
@@ -358,6 +358,51 @@ test("Grok local provider surfaces refresh 401 when no peer rotation is on disk"
   });
 });
 
+test("Grok local provider does not adopt a different account record on refresh 401", async (t) => {
+  await withGrokHome(async (grokHome) => {
+    writeGrokAuth(grokHome, {
+      key: "expired-token",
+      refresh_token: "stale-refresh-token",
+      expires_at: "2000-01-01T00:00:00Z",
+      oidc_client_id: "grok-client-id",
+      oidc_issuer: "https://auth.x.ai"
+    });
+    writeGrokModels(grokHome);
+
+    const previousFetch = globalThis.fetch;
+    process.env.GROK_OIDC_TOKEN_ENDPOINT = "http://127.0.0.1/grok/oauth/token";
+    globalThis.fetch = async () => {
+      // A peer rotated a DIFFERENT account in the same file; the record being
+      // refreshed here was not touched, so there is nothing to adopt.
+      writeFileSync(path.join(grokHome, "auth.json"), JSON.stringify({
+        "https://auth.x.ai::test-account": {
+          key: "expired-token",
+          refresh_token: "stale-refresh-token",
+          expires_at: "2000-01-01T00:00:00Z",
+          oidc_client_id: "grok-client-id",
+          oidc_issuer: "https://auth.x.ai"
+        },
+        "https://auth.x.ai::other-account": {
+          key: "other-access-token",
+          refresh_token: "other-refresh-token",
+          expires_at: "2999-01-01T00:00:00Z",
+          oidc_client_id: "grok-client-id",
+          oidc_issuer: "https://auth.x.ai"
+        }
+      }, null, 2));
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        headers: { "content-type": "application/json" },
+        status: 401
+      });
+    };
+    t.after(() => {
+      globalThis.fetch = previousFetch;
+    });
+
+    await assert.rejects(() => resolveGrokAuth(), /HTTP 401/);
+  });
+});
+
 async function withGrokHome(run) {
   const previousGrokHome = process.env.GROK_HOME;
   const previousGrokAuthFile = process.env.GROK_AUTH_FILE;


### PR DESCRIPTION
## Problem

The Grok OAuth refresh token **rotates on every refresh**. CCR reads and writes the same `~/.grok/auth.json` as the Grok CLI. When the CLI (or any other consumer of that file) refreshes first, the refresh token CCR just read is invalidated, and CCR's refresh fails with HTTP 401/403.

Previously that error propagated straight to the caller (`Grok CLI OAuth token refresh returned HTTP 401`), even though the credential file on disk already held a valid, newer credential written by the peer process.

This is the same defect class as the Kimi provider fix in #1633, applied here to the Grok provider.

## Fix

In `resolveGrokAuth`, when the refresh fails with 401/403 (now a typed `GrokRefreshAuthError`), re-read the credential records once:

- if a stored record's refresh token **differs** from the one that was just rejected, a peer rotated it: adopt the on-disk credential and return it instead of failing (`readGrokAuth` already prefers a record with a usable access token, so the peer's fresh record wins);
- otherwise the error propagates exactly as before.

Non-auth refresh errors (network, 5xx, timeouts, OIDC discovery failures) are unaffected.

## Tests

Two new tests in `test/unit/agents/local-agent-provider-grok.test.mjs`:

- **adopts a credential rotated by a peer process on refresh 401**: the fetch stub simulates the CLI persisting a rotated credential and rejecting the stale token; `resolveGrokAuth` returns the peer credential;
- **surfaces refresh 401 when no peer rotation is on disk**: an untouched file keeps the previous behavior and the 401 propagates.

`local-agent-provider-grok.test`: 10/10 passing.