### PR TITLE
fix(gateway,ui): 配置热更新、协议 capability 残留及设置交互修复

### DIFF
--- a/packages/core/src/gateway/application/gateway-service.ts
+++ b/packages/core/src/gateway/application/gateway-service.ts
@@ -325,19 +325,35 @@ class GatewayService {
       return;
     }
     try {
-      const response = await fetch(`${endpoint(config.gateway.coreHost, config.gateway.corePort)}/manager/config`, {
-        body: serialized,
-        headers: {
-          "content-type": "application/json",
-          [coreGatewayAuthHeader]: this.coreAuthToken
-        },
-        method: "PUT"
-      });
-      if (!response.ok) {
-        const detail = (await response.text().catch(() => "")).slice(0, 300);
-        throw new Error(`Core gateway rejected the config update with HTTP ${response.status}: ${detail}`);
+      // 子进程可能正在启动（上一次重启还没就绪），连接级失败做短暂重试;
+      // 只有收到明确拒绝(4xx)或重试耗尽才回退完整重启。
+      let lastError: unknown;
+      let responded = false;
+      for (let attempt = 0; attempt < 6 && !responded; attempt += 1) {
+        try {
+          const response = await fetch(`${endpoint(config.gateway.coreHost, config.gateway.corePort)}/manager/config`, {
+            body: serialized,
+            headers: {
+              "content-type": "application/json",
+              [coreGatewayAuthHeader]: this.coreAuthToken
+            },
+            method: "PUT"
+          });
+          responded = true;
+          if (!response.ok) {
+            const detail = (await response.text().catch(() => "")).slice(0, 300);
+            throw new Error(`Core gateway rejected the config update with HTTP ${response.status}: ${detail}`);
+          }
+          this.lastAppliedGatewayConfig = serialized;
+          return;
+        } catch (error) {
+          lastError = error;
+          if (!responded) {
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+        }
       }
-      this.lastAppliedGatewayConfig = serialized;
+      throw lastError instanceof Error ? lastError : new Error(String(lastError));
     } catch (error) {
       console.warn(`[gateway] Restarting the core gateway to apply the config change (hot push unavailable: ${formatError(error)})`);
       this.lastAppliedGatewayConfig = undefined;

--- a/packages/core/src/gateway/application/gateway-service.ts
+++ b/packages/core/src/gateway/application/gateway-service.ts
@@ -334,7 +334,8 @@ class GatewayService {
         method: "PUT"
       });
       if (!response.ok) {
-        throw new Error(`Core gateway rejected the config update with HTTP ${response.status}.`);
+        const detail = (await response.text().catch(() => "")).slice(0, 300);
+        throw new Error(`Core gateway rejected the config update with HTTP ${response.status}: ${detail}`);
       }
       this.lastAppliedGatewayConfig = serialized;
     } catch (error) {

--- a/packages/core/src/gateway/application/gateway-service.ts
+++ b/packages/core/src/gateway/application/gateway-service.ts
@@ -89,6 +89,7 @@ class GatewayService {
   private child?: ChildProcess;
   private config?: AppConfig;
   private coreAuthToken = "";
+  private lastAppliedGatewayConfig?: string;
   private plugin?: ClaudeCodeRouterPlugin;
   private readonly rawTraceSynchronizer = new RawTraceSynchronizer({
     getConfig: () => this.config
@@ -205,6 +206,9 @@ class GatewayService {
         assertManagedGatewayStartupContinues(managedChild, startupFailure);
         await waitForManagedCoreGatewayReady(this.status.coreEndpoint, runtimeId, managedChild);
         assertManagedGatewayStartupContinues(managedChild, startupFailure);
+        this.lastAppliedGatewayConfig = JSON.stringify(coreGatewayConfig);
+      } else {
+        this.lastAppliedGatewayConfig = undefined;
       }
 
       this.status = {
@@ -230,6 +234,7 @@ class GatewayService {
     const child = this.child;
     this.child = undefined;
     this.coreAuthToken = "";
+    this.lastAppliedGatewayConfig = undefined;
     if (child && !child.killed) {
       child.kill();
     }
@@ -295,6 +300,48 @@ class GatewayService {
       endpoint: endpoint(config.gateway.host, config.gateway.port),
       networkEndpoints: gatewayNetworkEndpoints(config.gateway.host, config.gateway.port)
     };
+    await this.pushConfigToManagedCoreGateway(config);
+  }
+
+  // The managed core gateway child receives its config once over IPC at spawn
+  // time. Without this push, any config save that does not trigger a full
+  // restart leaves the child running stale providers/models/keys until the
+  // next launch.
+  private async pushConfigToManagedCoreGateway(config: AppConfig): Promise<void> {
+    if (!this.child || !this.coreAuthToken) {
+      return;
+    }
+    const upstreamProxyUrl = proxyService.getUpstreamProxyUrl("https") ?? await getSystemProxyUrlForProtocol("https", config);
+    const coreGatewayConfig = await compileCoreGatewayConfig(
+      config,
+      this.rawTraceSynchronizer.token,
+      this.billingSynchronizer.token,
+      this.coreAuthToken,
+      this.browserWebSearchMcpIntegration,
+      upstreamProxyUrl
+    );
+    const serialized = JSON.stringify(coreGatewayConfig);
+    if (serialized === this.lastAppliedGatewayConfig) {
+      return;
+    }
+    try {
+      const response = await fetch(`${endpoint(config.gateway.coreHost, config.gateway.corePort)}/manager/config`, {
+        body: serialized,
+        headers: {
+          "content-type": "application/json",
+          [coreGatewayAuthHeader]: this.coreAuthToken
+        },
+        method: "PUT"
+      });
+      if (!response.ok) {
+        throw new Error(`Core gateway rejected the config update with HTTP ${response.status}.`);
+      }
+      this.lastAppliedGatewayConfig = serialized;
+    } catch (error) {
+      console.warn(`[gateway] Hot config push failed, restarting the core gateway: ${formatError(error)}`);
+      this.lastAppliedGatewayConfig = undefined;
+      await this.start(config);
+    }
   }
 
   validateRouteScript(request: RouteScriptValidationRequest): Promise<RouteScriptValidationResult> {

--- a/packages/core/src/gateway/application/gateway-service.ts
+++ b/packages/core/src/gateway/application/gateway-service.ts
@@ -279,7 +279,7 @@ class GatewayService {
     };
   }
 
-  async updateConfig(config: AppConfig): Promise<void> {
+  async updateConfig(config: AppConfig): Promise<GatewayStatus> {
     assertLoopbackCoreHost(config.gateway.coreHost);
     const scriptValidationErrors = await this.routeScriptRuntime.prepare(config.Router.rules);
     const nextPlugin = new ClaudeCodeRouterPlugin(config, {
@@ -300,16 +300,16 @@ class GatewayService {
       endpoint: endpoint(config.gateway.host, config.gateway.port),
       networkEndpoints: gatewayNetworkEndpoints(config.gateway.host, config.gateway.port)
     };
-    await this.pushConfigToManagedCoreGateway(config);
+    return this.pushConfigToManagedCoreGateway(config);
   }
 
   // The managed core gateway child receives its config once over IPC at spawn
   // time. Without this push, any config save that does not trigger a full
   // restart leaves the child running stale providers/models/keys until the
   // next launch.
-  private async pushConfigToManagedCoreGateway(config: AppConfig): Promise<void> {
+  private async pushConfigToManagedCoreGateway(config: AppConfig): Promise<GatewayStatus> {
     if (!this.child || !this.coreAuthToken) {
-      return;
+      return this.getStatus();
     }
     const upstreamProxyUrl = proxyService.getUpstreamProxyUrl("https") ?? await getSystemProxyUrlForProtocol("https", config);
     const coreGatewayConfig = await compileCoreGatewayConfig(
@@ -322,7 +322,7 @@ class GatewayService {
     );
     const serialized = JSON.stringify(coreGatewayConfig);
     if (serialized === this.lastAppliedGatewayConfig) {
-      return;
+      return this.getStatus();
     }
     try {
       // 子进程可能正在启动（上一次重启还没就绪），连接级失败做短暂重试;
@@ -345,7 +345,7 @@ class GatewayService {
             throw new Error(`Core gateway rejected the config update with HTTP ${response.status}: ${detail}`);
           }
           this.lastAppliedGatewayConfig = serialized;
-          return;
+          return this.getStatus();
         } catch (error) {
           lastError = error;
           if (!responded) {
@@ -357,7 +357,7 @@ class GatewayService {
     } catch (error) {
       console.warn(`[gateway] Restarting the core gateway to apply the config change (hot push unavailable: ${formatError(error)})`);
       this.lastAppliedGatewayConfig = undefined;
-      await this.start(config);
+      return this.start(config);
     }
   }
 

--- a/packages/core/src/gateway/application/gateway-service.ts
+++ b/packages/core/src/gateway/application/gateway-service.ts
@@ -339,7 +339,7 @@ class GatewayService {
       }
       this.lastAppliedGatewayConfig = serialized;
     } catch (error) {
-      console.warn(`[gateway] Hot config push failed, restarting the core gateway: ${formatError(error)}`);
+      console.warn(`[gateway] Restarting the core gateway to apply the config change (hot push unavailable: ${formatError(error)})`);
       this.lastAppliedGatewayConfig = undefined;
       await this.start(config);
     }

--- a/packages/core/src/gateway/core-runtime/gateway-bootstrap.ts
+++ b/packages/core/src/gateway/core-runtime/gateway-bootstrap.ts
@@ -42,7 +42,7 @@ process.on("message", (message: unknown) => {
 
 function installVirtualConfigFile(config: Record<string, unknown>): void {
   const fs = requireFromHere("node:fs") as MutableFs;
-  const content = `${JSON.stringify(config)}\n`;
+  let content = `${JSON.stringify(config)}\n`;
   const originalExistsSync = fs.existsSync.bind(fs);
   const originalReadFileSync = fs.readFileSync.bind(fs);
   const originalRenameSync = fs.renameSync.bind(fs);
@@ -57,13 +57,18 @@ function installVirtualConfigFile(config: Record<string, unknown>): void {
   };
   fs.writeFileSync = (file, data, options) => {
     if (isManagedConfigPath(file)) {
-      throw new Error("Gateway configuration is managed by Claude Code Router.");
+      // Embedded mode keeps the config in memory. Writing through (instead of
+      // throwing) lets the gateway's own /manager/config hot-reload apply.
+      content = typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8");
+      return;
     }
     originalWriteFileSync(file, data, options);
   };
   fs.renameSync = (oldPath, newPath) => {
     if (isManagedConfigPath(oldPath) || isManagedConfigPath(newPath)) {
-      throw new Error("Gateway configuration is managed by Claude Code Router.");
+      // writeJsonFile 先写 <path>.tmp 再改名覆盖；内容已在 writeFileSync 时
+      // 进入内存，这里无需动作。
+      return;
     }
     originalRenameSync(oldPath, newPath);
   };

--- a/packages/core/src/web/management-server.ts
+++ b/packages/core/src/web/management-server.ts
@@ -267,7 +267,7 @@ const rpcHandlers: Record<string, RpcHandler> = {
     if (synced.configChanged || shouldRestartGatewayForRuntimeConfigChange(previousConfig, savedConfig) || runtimeStatus.state !== "running") {
       runtimeStatus = await gatewayService.start(savedConfig);
     } else {
-      await gatewayService.updateConfig(savedConfig);
+      runtimeStatus = await gatewayService.updateConfig(savedConfig);
     }
     if (config || synced.configChanged) {
       invalidateProviderAccountSnapshotCache();
@@ -422,7 +422,7 @@ const rpcHandlers: Record<string, RpcHandler> = {
     if (syncedClaudeAppConfig.configChanged || shouldRestartGatewayForRuntimeConfigChange(previousConfig, savedConfig)) {
       runtimeStatus = await gatewayService.start(savedConfig);
     } else {
-      await gatewayService.updateConfig(savedConfig);
+      runtimeStatus = await gatewayService.updateConfig(savedConfig);
     }
     if ((options as AppSaveConfigOptions | undefined)?.applyProfile !== false) {
       await applyProfileIfServiceRunning(savedConfig, runtimeStatus);

--- a/packages/core/test/unit/gateway/gateway-config-hot-reload.test.mjs
+++ b/packages/core/test/unit/gateway/gateway-config-hot-reload.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+import { createDefaultAppConfig } from "@ccr/core/config/default-config.ts";
+import { gatewayService } from "@ccr/core/gateway/service.ts";
+
+function hotReloadTestConfig() {
+  const config = createDefaultAppConfig();
+  config.gateway.coreHost = "127.0.0.1";
+  config.gateway.corePort = 34579;
+  return config;
+}
+
+function pretendManagedCoreGatewayRunning() {
+  gatewayService.child = {
+    killed: false,
+    pid: 424242,
+    kill() {
+      this.killed = true;
+      return true;
+    }
+  };
+  gatewayService.coreAuthToken = "test-core-token";
+  gatewayService.lastAppliedGatewayConfig = undefined;
+}
+
+test("updateConfig pushes the recompiled config to the managed core gateway", async () => {
+  await gatewayService.stop();
+  pretendManagedCoreGatewayRunning();
+  const calls = [];
+  mock.method(globalThis, "fetch", async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{\"ok\":true}", { status: 200 });
+  });
+  try {
+    await gatewayService.updateConfig(hotReloadTestConfig());
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "http://127.0.0.1:34579/manager/config");
+    assert.equal(calls[0].init.method, "PUT");
+    assert.equal(calls[0].init.headers["x-ccr-core-auth"], "test-core-token");
+    const pushed = JSON.parse(calls[0].init.body);
+    assert.ok(Array.isArray(pushed.providers));
+    assert.equal(gatewayService.lastAppliedGatewayConfig, calls[0].init.body);
+  } finally {
+    mock.restoreAll();
+    await gatewayService.stop();
+  }
+});
+
+test("updateConfig skips the push when the compiled config is unchanged", async () => {
+  await gatewayService.stop();
+  pretendManagedCoreGatewayRunning();
+  const calls = [];
+  mock.method(globalThis, "fetch", async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{\"ok\":true}", { status: 200 });
+  });
+  try {
+    const config = hotReloadTestConfig();
+    await gatewayService.updateConfig(config);
+    await gatewayService.updateConfig(config);
+    assert.equal(calls.length, 1);
+  } finally {
+    mock.restoreAll();
+    await gatewayService.stop();
+  }
+});
+
+test("updateConfig falls back to a full restart when the hot push fails", async () => {
+  await gatewayService.stop();
+  pretendManagedCoreGatewayRunning();
+  const startCalls = [];
+  mock.method(globalThis, "fetch", async () => {
+    throw new Error("connection refused");
+  });
+  mock.method(gatewayService, "start", async (config) => {
+    startCalls.push(config);
+    return { state: "running" };
+  });
+  try {
+    await gatewayService.updateConfig(hotReloadTestConfig());
+    assert.equal(startCalls.length, 1);
+    assert.equal(gatewayService.lastAppliedGatewayConfig, undefined);
+  } finally {
+    mock.restoreAll();
+    await gatewayService.stop();
+  }
+});
+
+test("updateConfig does not push when no managed core gateway is running", async () => {
+  await gatewayService.stop();
+  const calls = [];
+  mock.method(globalThis, "fetch", async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200 });
+  });
+  try {
+    await gatewayService.updateConfig(hotReloadTestConfig());
+    assert.equal(calls.length, 0);
+  } finally {
+    mock.restoreAll();
+    await gatewayService.stop();
+  }
+});

--- a/packages/core/test/unit/gateway/gateway-config-hot-reload.test.mjs
+++ b/packages/core/test/unit/gateway/gateway-config-hot-reload.test.mjs
@@ -21,6 +21,12 @@ function pretendManagedCoreGatewayRunning() {
   };
   gatewayService.coreAuthToken = "test-core-token";
   gatewayService.lastAppliedGatewayConfig = undefined;
+  gatewayService.status = {
+    coreEndpoint: "http://127.0.0.1:34579",
+    endpoint: "http://127.0.0.1:3456",
+    networkEndpoints: ["http://127.0.0.1:3456"],
+    state: "running"
+  };
 }
 
 test("updateConfig pushes the recompiled config to the managed core gateway", async () => {
@@ -32,7 +38,7 @@ test("updateConfig pushes the recompiled config to the managed core gateway", as
     return new Response("{\"ok\":true}", { status: 200 });
   });
   try {
-    await gatewayService.updateConfig(hotReloadTestConfig());
+    const status = await gatewayService.updateConfig(hotReloadTestConfig());
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, "http://127.0.0.1:34579/manager/config");
     assert.equal(calls[0].init.method, "PUT");
@@ -40,6 +46,7 @@ test("updateConfig pushes the recompiled config to the managed core gateway", as
     const pushed = JSON.parse(calls[0].init.body);
     assert.ok(Array.isArray(pushed.providers));
     assert.equal(gatewayService.lastAppliedGatewayConfig, calls[0].init.body);
+    assert.equal(status.state, "running");
   } finally {
     mock.restoreAll();
     await gatewayService.stop();
@@ -56,9 +63,11 @@ test("updateConfig skips the push when the compiled config is unchanged", async 
   });
   try {
     const config = hotReloadTestConfig();
-    await gatewayService.updateConfig(config);
-    await gatewayService.updateConfig(config);
+    const firstStatus = await gatewayService.updateConfig(config);
+    const secondStatus = await gatewayService.updateConfig(config);
     assert.equal(calls.length, 1);
+    assert.equal(firstStatus.state, "running");
+    assert.equal(secondStatus.state, "running");
   } finally {
     mock.restoreAll();
     await gatewayService.stop();
@@ -77,9 +86,10 @@ test("updateConfig falls back to a full restart when the hot push fails", async 
     return { state: "running" };
   });
   try {
-    await gatewayService.updateConfig(hotReloadTestConfig());
+    const status = await gatewayService.updateConfig(hotReloadTestConfig());
     assert.equal(startCalls.length, 1);
     assert.equal(gatewayService.lastAppliedGatewayConfig, undefined);
+    assert.equal(status.state, "running");
   } finally {
     mock.restoreAll();
     await gatewayService.stop();
@@ -94,8 +104,32 @@ test("updateConfig does not push when no managed core gateway is running", async
     return new Response("{}", { status: 200 });
   });
   try {
-    await gatewayService.updateConfig(hotReloadTestConfig());
+    const status = await gatewayService.updateConfig(hotReloadTestConfig());
     assert.equal(calls.length, 0);
+    assert.equal(status.state, "stopped");
+  } finally {
+    mock.restoreAll();
+    await gatewayService.stop();
+  }
+});
+
+test("updateConfig returns the failed fallback restart status", async () => {
+  await gatewayService.stop();
+  pretendManagedCoreGatewayRunning();
+  mock.method(globalThis, "fetch", async () => {
+    throw new Error("connection refused");
+  });
+  mock.method(gatewayService, "start", async () => ({
+    coreEndpoint: "http://127.0.0.1:34579",
+    endpoint: "http://127.0.0.1:3456",
+    lastError: "restart failed",
+    networkEndpoints: ["http://127.0.0.1:3456"],
+    state: "error"
+  }));
+  try {
+    const status = await gatewayService.updateConfig(hotReloadTestConfig());
+    assert.equal(status.state, "error");
+    assert.equal(status.lastError, "restart failed");
   } finally {
     mock.restoreAll();
     await gatewayService.stop();

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -221,7 +221,7 @@ ipcMain.handle(IPC_CHANNELS.appApplyClaudeAppGateway, async (_event, config?: Ap
   if (synced.configChanged || shouldRestartGatewayForRuntimeConfigChange(previousConfig, savedConfig) || runtimeStatus.state !== "running") {
     runtimeStatus = await gatewayService.start(savedConfig);
   } else {
-    await gatewayService.updateConfig(savedConfig);
+    runtimeStatus = await gatewayService.updateConfig(savedConfig);
   }
 
   await builtInBrowserService.syncProxy(savedConfig);
@@ -323,7 +323,7 @@ ipcMain.handle(IPC_CHANNELS.appSaveConfig, async (_event, config: AppConfig, opt
   if (syncedClaudeAppConfig.configChanged || shouldRestartGatewayForRuntimeConfigChange(previousConfig, savedConfig)) {
     runtimeStatus = await gatewayService.start(savedConfig);
   } else {
-    await gatewayService.updateConfig(savedConfig);
+    runtimeStatus = await gatewayService.updateConfig(savedConfig);
   }
   if (options?.applyProfile !== false) {
     await applyProfileIfServiceRunning(savedConfig, runtimeStatus);

--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -4,7 +4,7 @@ import {
   AppLanguagePreference, applyProviderProbeResult, AppToast, BotGatewaySavedConfig, buildExtensionList, claudeDesignRoutingConfigFromDraft,
   ClaudeDesignRoutingDraft, ClaudeDesignRoutingRuleDraft, cloneConfig, createApiKeyDraft, createApiKeyEditDraft,
   createApiKeyList, createClaudeDesignRoutingDraft, createClaudeDesignRoutingRuleDraft, createCursorProxyRoutingDraft, createCursorProxyRoutingRuleDraft, createEmptyAgentAnalysis,
-  copyTextToClipboard, createEmptyRequestLogPage, createEmptyUsageStats, createExtensionInstallDraft, createGeneratedApiKey, createPluginSettingsDraft, createProfileDraft,
+  copyTextToClipboard, createEmptyRequestLogPage, createEmptyUsageStats, createExtensionInstallDraft, createGeneratedApiKey, createPluginSettingsDraft, createProfileDraft, createRestartableTimer,
   createProfileDraftFromProfile, createProviderDraft, createProviderDraftFromDeepLinkPayload, createProviderDraftFromProvider, createRoutingRuleDraft, createRoutingRuleDraftFromRule,
   createVirtualModelDraft, createVirtualModelDraftFromProfile, DEFAULT_TRAY_WIDGETS, detectSystemLanguage, detectSystemTheme,
   enforceSingleEnabledGlobalProfilePerAgent,
@@ -702,25 +702,34 @@ function App() {
   }, [draftConfig.plugins, pluginRoutingConfigTarget]);
   const providers = useMemo(() => draftConfig.Providers.map((provider, index) => ({ provider, index })), [draftConfig.Providers]);
   const gatewayEndpoint = gatewayStatus.endpoint || draftConfig.routerEndpoint;
-  // 重启/适配窗口内状态可能瞬时落到 error；4 秒内视为"适配中"过渡,
-  // 只有持续的错误才弹出失败横幅。
-  const gatewayErrorSinceRef = useRef<number>();
-  if (gatewayStatus.state === "error") {
-    gatewayErrorSinceRef.current ??= Date.now();
-  } else {
-    gatewayErrorSinceRef.current = undefined;
-  }
-  const gatewayErrorPersistent = gatewayStatus.state === "error" &&
-    gatewayErrorSinceRef.current !== undefined &&
-    Date.now() - gatewayErrorSinceRef.current >= 4000;
-  const gatewayStartupError = gatewayErrorPersistent
+  // 重启/适配窗口内状态可能瞬时落到 error；只有持续 4 秒的错误才弹出失败横幅。
+  const [gatewayErrorPersistent, setGatewayErrorPersistent] = useState(false);
+  const gatewayErrorTimerRef = useRef<ReturnType<typeof createRestartableTimer>>();
+  useEffect(() => {
+    gatewayErrorTimerRef.current ??= createRestartableTimer(
+      () => setGatewayErrorPersistent(true),
+      4000
+    );
+    if (gatewayStatus.state === "error") {
+      setGatewayErrorPersistent(false);
+      gatewayErrorTimerRef.current.restart();
+    } else {
+      gatewayErrorTimerRef.current.cancel();
+      setGatewayErrorPersistent(false);
+    }
+    return () => gatewayErrorTimerRef.current?.cancel();
+  }, [gatewayStatus.state]);
+  const gatewayErrorVisible = gatewayStatus.state === "error" && gatewayErrorPersistent;
+  const gatewayStartupError = gatewayErrorVisible
     ? translateAppErrorMessage(copy, gatewayStatus.lastError || "Service did not start.")
     : "";
-  const [gatewayAdaptingUntil, setGatewayAdaptingUntil] = useState(0);
-  const gatewayAdapting = !gatewayErrorPersistent &&
+  const [gatewayConfigAdapting, setGatewayConfigAdapting] = useState(false);
+  const gatewayConfigAdaptingTimerRef = useRef<ReturnType<typeof createRestartableTimer>>();
+  useEffect(() => () => gatewayConfigAdaptingTimerRef.current?.cancel(), []);
+  const gatewayAdapting = !gatewayErrorVisible &&
     (gatewayStatus.state === "starting" ||
       gatewayStatus.state === "error" ||
-      Date.now() < gatewayAdaptingUntil);
+      gatewayConfigAdapting);
   const networkCaptureEnabled = draftConfig.proxy.enabled && draftConfig.proxy.captureNetwork;
   const visibleNavigation = useMemo(
     () => navigation.filter((item) =>
@@ -1015,8 +1024,13 @@ function App() {
       const saved = await window.ccr.saveConfig(configWithTheme, saveOptions);
       syncConfigState(saved);
       setError("");
-      // 配置已变更，展示"适配中"提示一段时间（覆盖网关热推送/重启窗口）
-      setGatewayAdaptingUntil(Date.now() + 4000);
+      // 配置已变更，展示"适配中"提示一段时间（覆盖网关热推送/重启窗口）。
+      setGatewayConfigAdapting(true);
+      gatewayConfigAdaptingTimerRef.current ??= createRestartableTimer(
+        () => setGatewayConfigAdapting(false),
+        4000
+      );
+      gatewayConfigAdaptingTimerRef.current.restart();
       return true;
     } catch (error) {
       setError(formatError(error));

--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -716,8 +716,11 @@ function App() {
   const gatewayStartupError = gatewayErrorPersistent
     ? translateAppErrorMessage(copy, gatewayStatus.lastError || "Service did not start.")
     : "";
+  const [gatewayAdaptingUntil, setGatewayAdaptingUntil] = useState(0);
   const gatewayAdapting = !gatewayErrorPersistent &&
-    (gatewayStatus.state === "starting" || gatewayStatus.state === "error");
+    (gatewayStatus.state === "starting" ||
+      gatewayStatus.state === "error" ||
+      Date.now() < gatewayAdaptingUntil);
   const networkCaptureEnabled = draftConfig.proxy.enabled && draftConfig.proxy.captureNetwork;
   const visibleNavigation = useMemo(
     () => navigation.filter((item) =>
@@ -1012,6 +1015,8 @@ function App() {
       const saved = await window.ccr.saveConfig(configWithTheme, saveOptions);
       syncConfigState(saved);
       setError("");
+      // 配置已变更，展示"适配中"提示一段时间（覆盖网关热推送/重启窗口）
+      setGatewayAdaptingUntil(Date.now() + 4000);
       return true;
     } catch (error) {
       setError(formatError(error));

--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -702,9 +702,22 @@ function App() {
   }, [draftConfig.plugins, pluginRoutingConfigTarget]);
   const providers = useMemo(() => draftConfig.Providers.map((provider, index) => ({ provider, index })), [draftConfig.Providers]);
   const gatewayEndpoint = gatewayStatus.endpoint || draftConfig.routerEndpoint;
-  const gatewayStartupError = gatewayStatus.state === "error"
+  // 重启/适配窗口内状态可能瞬时落到 error；4 秒内视为"适配中"过渡,
+  // 只有持续的错误才弹出失败横幅。
+  const gatewayErrorSinceRef = useRef<number>();
+  if (gatewayStatus.state === "error") {
+    gatewayErrorSinceRef.current ??= Date.now();
+  } else {
+    gatewayErrorSinceRef.current = undefined;
+  }
+  const gatewayErrorPersistent = gatewayStatus.state === "error" &&
+    gatewayErrorSinceRef.current !== undefined &&
+    Date.now() - gatewayErrorSinceRef.current >= 4000;
+  const gatewayStartupError = gatewayErrorPersistent
     ? translateAppErrorMessage(copy, gatewayStatus.lastError || "Service did not start.")
     : "";
+  const gatewayAdapting = !gatewayErrorPersistent &&
+    (gatewayStatus.state === "starting" || gatewayStatus.state === "error");
   const networkCaptureEnabled = draftConfig.proxy.enabled && draftConfig.proxy.captureNetwork;
   const visibleNavigation = useMemo(
     () => navigation.filter((item) =>
@@ -2921,6 +2934,7 @@ function App() {
         <div className="relative flex h-full min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground max-[720px]:flex-col">
           {activeView === "onboarding" ? (
             <OnboardingLayout
+              gatewayAdapting={gatewayAdapting}
               gatewayStartupError={gatewayStartupError}
               loaded={configLoaded && onboardingStatusLoaded && providerPresetsLoaded}
               onboarding={{
@@ -2957,6 +2971,7 @@ function App() {
               config={draftConfig}
               copy={copy}
               gatewayActionBusy={gatewayActionBusy}
+              gatewayAdapting={gatewayAdapting}
               gatewayEndpoint={gatewayEndpoint}
               gatewayStartupError={gatewayStartupError}
               gatewayStatus={gatewayStatus}

--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -4,7 +4,7 @@ import {
   AppLanguagePreference, applyProviderProbeResult, AppToast, BotGatewaySavedConfig, buildExtensionList, claudeDesignRoutingConfigFromDraft,
   ClaudeDesignRoutingDraft, ClaudeDesignRoutingRuleDraft, cloneConfig, createApiKeyDraft, createApiKeyEditDraft,
   createApiKeyList, createClaudeDesignRoutingDraft, createClaudeDesignRoutingRuleDraft, createCursorProxyRoutingDraft, createCursorProxyRoutingRuleDraft, createEmptyAgentAnalysis,
-  copyTextToClipboard, createEmptyRequestLogPage, createEmptyUsageStats, createExtensionInstallDraft, createGeneratedApiKey, createPluginSettingsDraft, createProfileDraft, createRestartableTimer,
+  copyTextToClipboard, createEmptyRequestLogPage, createEmptyUsageStats, createExtensionInstallDraft, createGeneratedApiKey, createPluginSettingsDraft, createProfileActionError, createProfileDraft, createRestartableTimer,
   createProfileDraftFromProfile, createProviderDraft, createProviderDraftFromDeepLinkPayload, createProviderDraftFromProvider, createRoutingRuleDraft, createRoutingRuleDraftFromRule,
   createVirtualModelDraft, createVirtualModelDraftFromProfile, DEFAULT_TRAY_WIDGETS, detectSystemLanguage, detectSystemTheme,
   enforceSingleEnabledGlobalProfilePerAgent,
@@ -23,7 +23,7 @@ import {
   OverviewWidgetConfig, parseProviderAccountDraft, pluginConfigPatchFromSettingsDraft,
   providerCredentialsFromDraft,
   persistLanguagePreference, PluginInstallCandidate, PluginMarketplaceEntry, PluginRoutingConfigTarget, PluginSettingsDraft, presetCapabilitiesFromDraft,
-  probeProviderCandidates, probeProviderDeepLinkPayload, profileAgentLabel, profileAgentOptionsForRuntime, profileDraftWithDetectedAppPath, profileEnvRowsForAgent, ProfileConfig, ProfileOpenSurface, ProfileRuntimeStatus, profileConfigFromDraft, providerAccountApiKeySafetyIssue,
+  probeProviderCandidates, probeProviderDeepLinkPayload, profileActionErrorAfterGatewayStatus, profileAgentLabel, profileAgentOptionsForRuntime, profileDraftWithDetectedAppPath, profileEnvRowsForAgent, ProfileConfig, ProfileOpenSurface, ProfileRuntimeStatus, profileConfigFromDraft, providerAccountApiKeySafetyIssue,
   profileOpenCommandFallback, profileOpenSurfaces, ProviderAccountSnapshot, providerApiKeySafetyIssue, ProviderConnectivityCheckReport, ProviderDeepLinkPayload, ProviderDeepLinkRequest, providerIdentitySafetyIssue, providerProbeCandidates,
   providerBaseUrl, providerCapabilitiesForProtocols, providerCapabilitiesForSave, providerConnectivityApiKeyFromDraft, providerConnectivityProviderPlugins, providerGlobalBaseUrlForProbe, providerProbeCandidatesApiKeySafetyIssue, providerProbeHasSupportedProtocol, providerProbeInputKey, providerProtocolOptions, providerSelectableProtocolsFromProbe, ProxyNetworkSnapshot,
   ProxyStatus, readLanguagePreference, RequestLogListFilter, RequestLogPage, ResolvedLanguage,
@@ -172,7 +172,11 @@ function App() {
   const [gatewayActionTargetActive, setGatewayActionTargetActive] = useState<boolean>();
   const [, setActionMessage] = useState("");
   const [, setActionError] = useState("");
-  const [profileActionError, setProfileActionError] = useState("");
+  const [profileActionErrorState, setProfileActionErrorState] = useState(() => createProfileActionError(""));
+  const profileActionError = profileActionErrorState?.message ?? "";
+  const setProfileActionError = (message: string) => {
+    setProfileActionErrorState(createProfileActionError(message));
+  };
   const [profileAddOpen, setProfileAddOpen] = useState(false);
   const [profileAgentTab, setProfileAgentTab] = useState<ProfileConfig["agent"]>("claude-code");
   const [profileDraft, setProfileDraft] = useState<AddProfileDraft>(() => createProfileDraft());
@@ -718,6 +722,9 @@ function App() {
       setGatewayErrorPersistent(false);
     }
     return () => gatewayErrorTimerRef.current?.cancel();
+  }, [gatewayStatus.state]);
+  useEffect(() => {
+    setProfileActionErrorState((current) => profileActionErrorAfterGatewayStatus(current, gatewayStatus.state));
   }, [gatewayStatus.state]);
   const gatewayErrorVisible = gatewayStatus.state === "error" && gatewayErrorPersistent;
   const gatewayStartupError = gatewayErrorVisible
@@ -2641,11 +2648,29 @@ function App() {
       await refreshProfileRuntimeStatus();
       showToast(translateAppErrorMessage(copy, result.message));
     } catch (error) {
-      setProfileActionError(formatError(error));
+      await recordProfileOpenError(error);
     } finally {
       setProfileActionBusy((current) =>
         current?.profileId === profile.id && current.surface === "app" ? undefined : current
       );
+    }
+  }
+
+  async function recordProfileOpenError(error: unknown): Promise<void> {
+    const message = formatError(error);
+    if (!window.ccr?.getGatewayStatus) {
+      setProfileActionError(message);
+      return;
+    }
+    try {
+      const latestStatus = await window.ccr.getGatewayStatus();
+      setGatewayStatus((current) => preserveEqualPollingSnapshot(current, latestStatus));
+      setProfileActionErrorState(createProfileActionError(
+        message,
+        latestStatus.state === "running" ? "profile" : "gateway"
+      ));
+    } catch {
+      setProfileActionError(message);
     }
   }
 

--- a/packages/ui/src/pages/home/components/layout.tsx
+++ b/packages/ui/src/pages/home/components/layout.tsx
@@ -68,10 +68,12 @@ type MainViewProps = {
 };
 
 export function OnboardingLayout({
+  gatewayAdapting,
   gatewayStartupError,
   loaded,
   onboarding
 }: {
+  gatewayAdapting?: boolean;
   gatewayStartupError?: string;
   loaded: boolean;
   onboarding: ComponentProps<typeof OnboardingView>;
@@ -81,6 +83,9 @@ export function OnboardingLayout({
       <div className="app-drag absolute inset-x-0 top-0 z-10 h-10" />
       <div className="pointer-events-none absolute inset-x-0 top-12 z-30 px-5 max-[720px]:top-10 max-[720px]:px-3">
         <GatewayStartupErrorBanner className="pointer-events-auto mx-auto max-w-2xl shadow-lg" message={gatewayStartupError} />
+        {gatewayAdapting && !gatewayStartupError ? (
+          <GatewayAdaptingBanner className="pointer-events-auto mx-auto max-w-2xl shadow-lg" />
+        ) : null}
       </div>
       {loaded ? <OnboardingView {...onboarding} /> : null}
     </main>
@@ -93,6 +98,7 @@ export function MainLayout({
   config,
   copy,
   gatewayActionBusy,
+  gatewayAdapting,
   gatewayEndpoint,
   gatewayStartupError,
   gatewayStatus,
@@ -120,6 +126,7 @@ export function MainLayout({
   config: AppConfig;
   copy: AppCopy;
   gatewayActionBusy: boolean;
+  gatewayAdapting?: boolean;
   gatewayEndpoint: string;
   gatewayStartupError?: string;
   gatewayStatus: GatewayStatus;
@@ -281,6 +288,9 @@ export function MainLayout({
           message={gatewayStartupError}
           onOpenServerSettings={onOpenServerSettings}
         />
+        {gatewayAdapting && !gatewayStartupError ? (
+          <GatewayAdaptingBanner className="mx-5 mt-3 max-[720px]:mx-3" />
+        ) : null}
         <div
           className={cn(
             "min-h-0 flex-1 px-5 pb-5 pt-5 max-[720px]:px-3 max-[720px]:pb-3 max-[720px]:pt-3",
@@ -386,6 +396,23 @@ export function UpdateEntryButton({
         />
       ) : null}
     </Button>
+  );
+}
+
+export function GatewayAdaptingBanner({ className }: { className?: string }) {
+  const t = useAppText();
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "app-no-drag flex min-w-0 items-center gap-3 rounded-md border border-border bg-muted/60 px-3 py-2 text-[12px] text-muted-foreground",
+        className
+      )}
+      role="status"
+    >
+      <LoaderCircle className="h-3.5 w-3.5 shrink-0 animate-spin" />
+      <div className="min-w-0 flex-1 font-medium">{t("Adapting the gateway, please wait…")}</div>
+    </div>
   );
 }
 

--- a/packages/ui/src/pages/home/shared/controls.tsx
+++ b/packages/ui/src/pages/home/shared/controls.tsx
@@ -10,7 +10,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { PopoverContent } from "@/components/ui/popover";
 import { Select } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
@@ -61,7 +60,7 @@ export function Field({
   requirementLabel?: string;
 }) {
   return (
-    <Label className={cn("block min-w-0 space-y-1", className)}>
+    <div className={cn("block min-w-0 space-y-1", className)}>
       <span className="flex min-w-0 items-center gap-1.5">
         <span className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{label}</span>
         {requirement ? (
@@ -76,7 +75,7 @@ export function Field({
         ) : null}
       </span>
       {children}
-    </Label>
+    </div>
   );
 }
 

--- a/packages/ui/src/pages/home/shared/i18n.tsx
+++ b/packages/ui/src/pages/home/shared/i18n.tsx
@@ -266,6 +266,8 @@ export const appCopy: Record<ResolvedLanguage, AppCopy> = {
       "Available models": "Available models",
       "Available after saving": "Available after saving",
       "Automatic": "Automatic",
+
+"Adapting the gateway, please wait…": "Adapting the gateway, please wait…",
       "Add credentials": "Add credentials",
       "Add the API key CCR will use for model requests.": "Add the API key CCR will use for model requests.",
       "A real model request succeeded with the selected provider settings.": "A real model request succeeded with the selected provider settings.",
@@ -782,6 +784,7 @@ export const appCopy: Record<ResolvedLanguage, AppCopy> = {
       "Add API key": "添加 API 密钥",
       "Add key": "添加 Key",
       "Add credentials": "添加凭据",
+      "Adapting the gateway, please wait…": "正在适配网关，请稍候…",
       "Add the API key CCR will use for model requests.": "填写 CCR 发起模型请求时使用的 API Key。",
       "Add limit": "添加限制",
       "Add parameter": "添加参数",

--- a/packages/ui/src/pages/home/shared/index.tsx
+++ b/packages/ui/src/pages/home/shared/index.tsx
@@ -19,5 +19,6 @@ export * from "./routing";
 export * from "./virtual-models";
 export * from "./extensions";
 export * from "./providers";
+export * from "./timers";
 export { isGatewayProviderEnabled } from "@ccr/core/contracts/app";
 export type { OverviewAccountCardSize, RouterBuiltInAgentRuleConfig, RouterBuiltInAgentRuleId, RouterBuiltInRulesConfig } from "@ccr/core/contracts/app";

--- a/packages/ui/src/pages/home/shared/profiles.ts
+++ b/packages/ui/src/pages/home/shared/profiles.ts
@@ -16,6 +16,7 @@ import type {
   AppConfig,
   BotGatewayRuntimeConfig,
   BotGatewaySavedConfig,
+  GatewayStatus,
   GatewayProviderConfig,
   ProfileConfig,
   ProfileOpenSurface,
@@ -36,6 +37,29 @@ import { endpointFromHostPort } from "./services";
 import { keyValueRowsFromRecord, recordFromKeyValueRows, stringRecordValue, validateProfileEnvRows } from "./virtual-models";
 import { isGatewayProviderEnabled } from "@ccr/core/contracts/app";
 import type { AddProfileDraft, BotGatewayConfigDraft } from "./types";
+
+export type ProfileActionErrorSource = "gateway" | "profile";
+
+export type ProfileActionErrorState = {
+  message: string;
+  source: ProfileActionErrorSource;
+};
+
+export function createProfileActionError(
+  message: string,
+  source: ProfileActionErrorSource = "profile"
+): ProfileActionErrorState | undefined {
+  return message ? { message, source } : undefined;
+}
+
+export function profileActionErrorAfterGatewayStatus(
+  current: ProfileActionErrorState | undefined,
+  gatewayState: GatewayStatus["state"]
+): ProfileActionErrorState | undefined {
+  return gatewayState === "running" && current?.source === "gateway"
+    ? undefined
+    : current;
+}
 
 export function gatewayEndpointFromConfig(config: AppConfig): string {
   if (config.routerEndpoint) {

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -1960,17 +1960,18 @@ export function providerCapabilitiesForSave(
   const normalizedNextBaseUrl = normalizeProviderBaseUrl(nextBaseUrl) || nextBaseUrl.trim();
   const preserveExisting = normalizedExistingBaseUrl === undefined ||
     normalizedExistingBaseUrl === normalizedNextBaseUrl;
-  // Selectable protocols (the LLM checkboxes) only keep capabilities the user
-  // still has selected — otherwise an unchecked capability silently merges
-  // back on every save. Non-selectable media protocols are always preserved.
+  // The capabilities rebuilt from the current form are authoritative for
+  // selectable protocols. Preserving an older capability for the same
+  // protocol can keep a stale endpoint alive beside the newly detected one.
+  // Non-selectable media protocols may use independent origins, so keep them
+  // while the provider's global base URL is unchanged.
   const selectableTypes = new Set(providerProtocolOptions.map((option) => option.value));
-  const selectedTypes = new Set(currentCapabilities.map((capability) => capability.type));
-  const preservedSelectedCapabilities = preservedCapabilities.filter((capability) =>
-    !selectableTypes.has(capability.type as GatewayProviderProtocol) || selectedTypes.has(capability.type)
+  const preservedMediaCapabilities = preservedCapabilities.filter((capability) =>
+    !selectableTypes.has(capability.type as GatewayProviderProtocol)
   );
   return mergeProviderCapabilities(
     currentCapabilities,
-    ...(preserveExisting ? [preservedSelectedCapabilities] : [])
+    ...(preserveExisting ? [preservedMediaCapabilities] : [])
   );
 }
 

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -1960,9 +1960,17 @@ export function providerCapabilitiesForSave(
   const normalizedNextBaseUrl = normalizeProviderBaseUrl(nextBaseUrl) || nextBaseUrl.trim();
   const preserveExisting = normalizedExistingBaseUrl === undefined ||
     normalizedExistingBaseUrl === normalizedNextBaseUrl;
+  // Selectable protocols (the LLM checkboxes) only keep capabilities the user
+  // still has selected — otherwise an unchecked capability silently merges
+  // back on every save. Non-selectable media protocols are always preserved.
+  const selectableTypes = new Set(providerProtocolOptions.map((option) => option.value));
+  const selectedTypes = new Set(currentCapabilities.map((capability) => capability.type));
+  const preservedSelectedCapabilities = preservedCapabilities.filter((capability) =>
+    !selectableTypes.has(capability.type as GatewayProviderProtocol) || selectedTypes.has(capability.type)
+  );
   return mergeProviderCapabilities(
     currentCapabilities,
-    ...(preserveExisting ? [preservedCapabilities] : [])
+    ...(preserveExisting ? [preservedSelectedCapabilities] : [])
   );
 }
 

--- a/packages/ui/src/pages/home/shared/timers.ts
+++ b/packages/ui/src/pages/home/shared/timers.ts
@@ -1,0 +1,27 @@
+export type RestartableTimer = {
+  cancel(): void;
+  restart(): void;
+};
+
+export function createRestartableTimer(onExpire: () => void, delayMs: number): RestartableTimer {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+
+  const cancel = () => {
+    if (handle === undefined) {
+      return;
+    }
+    clearTimeout(handle);
+    handle = undefined;
+  };
+
+  return {
+    cancel,
+    restart() {
+      cancel();
+      handle = setTimeout(() => {
+        handle = undefined;
+        onExpire();
+      }, delayMs);
+    }
+  };
+}

--- a/packages/ui/test/component/tray-components.test.tsx
+++ b/packages/ui/test/component/tray-components.test.tsx
@@ -20,7 +20,7 @@ import {
 } from "@ccr/ui/pages/tray/components/index.ts";
 import { TrayApp } from "@ccr/ui/pages/tray/TrayApp.tsx";
 import { TrayDetailApp } from "@ccr/ui/pages/tray/TrayDetailApp.tsx";
-import { applyTrayThemePreference, createSourceTabs } from "@ccr/ui/pages/tray/shared.tsx";
+import { applyTrayThemePreference, createSourceTabs, formatCompactNumber } from "@ccr/ui/pages/tray/shared.tsx";
 import { accountSnapshots, installBrowserGlobals, usageStats, usageTotals } from "../fixtures/index.ts";
 
 installBrowserGlobals();
@@ -119,7 +119,7 @@ test("TrayStatusStrip renders open and quit actions", () => {
 
   assert.match(html, /aria-label="Open CCR"/);
   assert.match(html, /title="Open CCR"/);
-  assert.match(html, /12\.5K tokens/);
+  assert.ok(html.includes(`${formatCompactNumber(12500)} tokens`));
   assert.match(html, /CCR/);
   assert.match(html, /aria-label="Quit"/);
 });

--- a/packages/ui/test/integration/providers.test.ts
+++ b/packages/ui/test/integration/providers.test.ts
@@ -161,6 +161,30 @@ test("provider save keeps explicit secondary media origins when the base URL is 
   );
 });
 
+test("provider save replaces a stale selectable capability for the same protocol", () => {
+  const current = [{
+    baseUrl: "https://gateway.example/anthropic",
+    endpoint: "https://gateway.example/anthropic/v1/messages",
+    source: "detected" as const,
+    type: "anthropic_messages" as const
+  }];
+  const stale = [{
+    baseUrl: "https://gateway.example",
+    source: "preset" as const,
+    type: "anthropic_messages" as const
+  }];
+
+  assert.deepEqual(
+    providerCapabilitiesForSave(
+      current,
+      stale,
+      "https://gateway.example/v1",
+      "https://gateway.example/v1"
+    ),
+    current
+  );
+});
+
 test("provider save drops an unchecked selectable protocol capability", () => {
   const current = [{
     baseUrl: "https://chat.example/v1",

--- a/packages/ui/test/integration/providers.test.ts
+++ b/packages/ui/test/integration/providers.test.ts
@@ -161,6 +161,31 @@ test("provider save keeps explicit secondary media origins when the base URL is 
   );
 });
 
+test("provider save drops an unchecked selectable protocol capability", () => {
+  const current = [{
+    baseUrl: "https://chat.example/v1",
+    source: "detected" as const,
+    type: "openai_chat_completions" as const
+  }];
+  const previous = [
+    {
+      baseUrl: "https://chat.example/v1",
+      source: "detected" as const,
+      type: "openai_chat_completions" as const
+    },
+    {
+      baseUrl: "https://chat.example/anthropic",
+      source: "detected" as const,
+      type: "anthropic_messages" as const
+    }
+  ];
+
+  assert.deepEqual(
+    providerCapabilitiesForSave(current, previous, "https://chat.example/v1", "https://chat.example/v1"),
+    current
+  );
+});
+
 test("provider probe result drops unavailable selected protocols", () => {
   const draft = {
     ...createProviderDraft([]),

--- a/packages/ui/test/integration/providers.test.ts
+++ b/packages/ui/test/integration/providers.test.ts
@@ -17,6 +17,7 @@ import {
   createProviderDraftFromProvider,
   createProviderInstallLinkFromDraft,
   customProviderPresetId,
+  Field,
   FieldGroup,
   localAgentProviderIconUrls,
   providerCapabilitiesForProtocols,
@@ -54,6 +55,23 @@ test("composite field groups do not label their nested controls", () => {
   assert.doesNotMatch(html, /^<label/);
   assert.match(html, /Search models/);
   assert.match(html, /Model settings/);
+});
+
+test("fields never wrap nested controls in a label element", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(
+      Field,
+      { label: "Protocol details" },
+      React.createElement("input", { "aria-label": "First option" }),
+      React.createElement("input", { "aria-label": "Second option" })
+    )
+  );
+
+  assert.match(html, /^<div/);
+  assert.doesNotMatch(html, /<label/);
+  assert.match(html, /Protocol details/);
+  assert.match(html, /First option/);
+  assert.match(html, /Second option/);
 });
 
 test("Gemini preset keeps full protocol probing candidates", () => {

--- a/packages/ui/test/unit/profile-action-error.test.ts
+++ b/packages/ui/test/unit/profile-action-error.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createProfileActionError,
+  profileActionErrorAfterGatewayStatus
+} from "@ccr/ui/pages/home/shared/profiles.ts";
+
+test("gateway recovery clears a gateway profile action error", () => {
+  const error = createProfileActionError(
+    "listen EADDRINUSE: address already in use 127.0.0.1:3456",
+    "gateway"
+  );
+
+  assert.equal(profileActionErrorAfterGatewayStatus(error, "running"), undefined);
+});
+
+test("a gateway profile action error remains visible until recovery", () => {
+  const error = createProfileActionError(
+    "listen EADDRINUSE: address already in use 127.0.0.1:3456",
+    "gateway"
+  );
+
+  assert.equal(profileActionErrorAfterGatewayStatus(error, "error"), error);
+  assert.equal(profileActionErrorAfterGatewayStatus(error, "starting"), error);
+});
+
+test("gateway recovery does not clear a profile validation error", () => {
+  const error = createProfileActionError("Select a model before saving.");
+
+  assert.equal(profileActionErrorAfterGatewayStatus(error, "running"), error);
+});

--- a/packages/ui/test/unit/timers.test.ts
+++ b/packages/ui/test/unit/timers.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRestartableTimer } from "@ccr/ui/pages/home/shared/timers.ts";
+
+test("restartable timer expires only after the configured delay", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let expirations = 0;
+  const timer = createRestartableTimer(() => {
+    expirations += 1;
+  }, 4000);
+
+  timer.restart();
+  t.mock.timers.tick(3999);
+  assert.equal(expirations, 0);
+  t.mock.timers.tick(1);
+  assert.equal(expirations, 1);
+});
+
+test("restartable timer resets and can be cancelled", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let expirations = 0;
+  const timer = createRestartableTimer(() => {
+    expirations += 1;
+  }, 4000);
+
+  timer.restart();
+  t.mock.timers.tick(3000);
+  timer.restart();
+  t.mock.timers.tick(3000);
+  assert.equal(expirations, 0);
+  timer.cancel();
+  t.mock.timers.tick(4000);
+  assert.equal(expirations, 0);
+});


### PR DESCRIPTION
## 变更内容

本 PR 包含配置热更新、协议 capability 保存和界面交互方面的修复。

### 1. 配置变更后网关进程不生效

**问题**：在界面上修改供应商配置（接口地址、密钥等）并保存后，正在运行的内嵌网关进程不会收到新配置，仍按旧配置工作，需重启应用才能生效。

**原因**：内嵌网关仅在启动时通过 IPC 获取一次配置；保存配置时若判定无需重启，热更新路径只更新 CCR 主进程自身，不通知网关子进程。

**修复**：`gatewayService.updateConfig()` 在配置变化时重新编译并推送至运行中的网关（`PUT /manager/config`）；推送失败自动回退为完整重启，保证最终一致。配套修复 `gateway-bootstrap`：内嵌模式的虚拟配置允许写入内存；推送遇到子进程启动竞态时短暂重试，避免误判失败触发二次重启。

支持在高级设置页面调整协议相关参数：

<p align="center">
  <img width="7000" alt="高级设置配置"
       src="https://github.com/user-attachments/assets/8395919f-be0f-4e17-8014-c05024e4360f">
</p>

修改配置后，服务端口能够同步加载最新协议设置：

<p align="center">
  <img width="700" alt="动态加载服务端口"
       src="https://github.com/user-attachments/assets/51ef03c3-c113-4846-bcfa-1b9255d7c43c">
</p>

### 2. 切换配置时的提示文案

此前切换或保存配置时可能闪现“服务启动失败”横幅。现在保存配置后立即显示“正在适配网关，请稍候…”约 4 秒；瞬时错误不再弹失败横幅，只有持续错误才报失败。

<p align="center">
  <img width="700" alt="适配中提示" src="https://github.com/user-attachments/assets/2944c784-f57e-4694-bbc1-59ff1160aae6">
</p>

### 3. 可选协议 capability 被旧配置合并回来

**问题一**：在“协议详情”里取消勾选某个协议并保存后，旧 capability 会被重新合并，编辑时再次显示为已勾选。

**问题二**：自动探测为同一协议生成新 endpoint 后，旧 preset capability 仍可能同时保留。后续请求可能继续使用旧地址，兼容服务（例如 MiMo）会因此请求到错误路径并返回 404。

**修复**：当前表单生成的可选协议 capability 作为最终结果，不再保留同协议的旧 capability；只有不能在表单中勾选、并可能使用独立地址的 image/video capability，才会在供应商全局 base URL 未变化时保留。

新增回归测试覆盖取消勾选、同协议 endpoint 替换以及独立媒体地址保留。

### 4. 点击设置区空白处误触发第一个选项

**问题**：在协议详情等多控件区域，点击空白处会激活该区域第一个选项。

**修复**：`Field` 组件外层由 `<label>` 改为 `<div>`，与 `FieldGroup` 保持一致；新增回归测试。

### 5. 托盘组件测试在中文系统下失败

**问题**：测试将预期数字格式写死为英文 `12.5K tokens`，但中文系统会显示为“1.3万 tokens”。

**修复**：测试改用与组件相同的格式化函数计算预期结果，产品功能不变。

## 验证

- `npm run typecheck` 通过
- UI 测试 166/166 通过
- MiMo 旧 endpoint 替换回归测试通过

