### PR TITLE
feat: add deepseek request adapter for thinking-disable, reasoning-effort, and placeholder thinking

### DIFF
--- a/packages/core/src/gateway/features/deepseek-request-adapter.ts
+++ b/packages/core/src/gateway/features/deepseek-request-adapter.ts
@@ -1,0 +1,161 @@
+/**
+ * DeepSeek request adapter.
+ *
+ * Adapts the outbound request body for DeepSeek upstreams on the Anthropic
+ * protocol. The wire body is Anthropic-shaped (`model`, `max_tokens`,
+ * `thinking`, `messages`), so this feature operates on that shape:
+ *
+ * - reasoning-effort passthrough: DeepSeek's Anthropic endpoint accepts a
+ *   top-level `reasoning_effort` field. Pass through one the client sent
+ *   directly (it is not a standard Anthropic field, but DeepSeek and
+ *   OpenRouter-hosted DeepSeek read it). We do not invent an effort from
+ *   `thinking.budget_tokens` - the Anthropic-native DeepSeek endpoint ignores
+ *   it, and mapping a budget to an effort level is guesswork.
+ * - NOTHINK_BELOW: below a max_tokens threshold DeepSeek refuses the request
+ *   or burns budget on thinking. We disable thinking entirely (`thinking:
+ *   {type:"disabled"}`) instead of truncating max_tokens, preserving user
+ *   intent. This survives on the anthropic_messages protocol (the executor
+ *   only strips `thinking` for OpenAI protocols).
+ * - placeholder thinking: on routes that drop thinking blocks, inject a
+ *   placeholder thinking block into outbound assistant messages so message
+ *   history stays well-formed. Only applied while thinking stays enabled.
+ *
+ * Gated to DeepSeek upstreams by model identity: the provider part of the
+ * routed model selector is `deepseek`, or the model name is a known DeepSeek
+ * family id (which covers OpenRouter-hosted `deepseek/deepseek-v4-*` selectors
+ * whose provider part is `openrouter`).
+ */
+import { stringValue } from "@ccr/core/gateway/internal/value";
+import { serializeJsonBody, takeJsonObject } from "@ccr/core/gateway/http/body";
+import { parseProviderModelSelector } from "@ccr/core/routing/model-registry";
+
+const DEEPSEEK_PROVIDER_ID = "deepseek";
+const DEEPSEEK_FAMILY_PREFIXES = [
+  "deepseek-v4",
+  "deepseek-v3",
+  "deepseek-r1",
+  "deepseek-reasoner",
+  "deepseek-chat",
+];
+
+const NOTHINK_BELOW = 8192;
+// DeepSeek 400s on an assistant history that is missing a thinking block for a
+// tool_use message. It does not validate the signature, so a placeholder block
+// is enough. The shape mirrors cc-ds4's proven placeholder (a content block,
+// not a top-level message.thinking field).
+const PLACEHOLDER = { type: "thinking", thinking: "(elided)", signature: "ccr-deepseek-adapter" };
+
+export type DeepSeekRequestAdapterPreparation = {
+  body: Buffer;
+  diagnostic: string;
+};
+
+export function prepareDeepSeekRequestAdapter(input: {
+  body?: Buffer;
+  config: unknown;
+  headers: unknown;
+  method: string;
+  path: string;
+  routedModel?: string;
+}): DeepSeekRequestAdapterPreparation | undefined {
+  if ((input.method || "GET").toUpperCase() !== "POST") {
+    return undefined;
+  }
+
+  if (!input.body || input.body.byteLength === 0) {
+    return undefined;
+  }
+  let body: Record<string, unknown>;
+  try {
+    body = takeJsonObject(input.body);
+  } catch {
+    return undefined;
+  }
+
+  // Gate on the routed model if available, else the body model. The routed
+  // selector may be absent when no route matched (default routing) even though
+  // the client sent a DeepSeek model directly.
+  const model = stringValue(body.model) || input.routedModel;
+  if (!isDeepSeekModel(input.routedModel) && !isDeepSeekModel(model)) {
+    return undefined;
+  }
+
+  const changes: string[] = [];
+  const maxTokens = body.max_tokens;
+  const disableThinking =
+    typeof maxTokens !== "number" || maxTokens <= NOTHINK_BELOW;
+
+  // Reasoning-effort handling. A client-sent top-level `reasoning_effort` is
+  // passed through as-is (the DeepSeek / OpenRouter-hosted DeepSeek field).
+  // When thinking is disabled, effort is meaningless without thinking and the
+  // wire should not carry a contradictory pair, so drop it.
+  if (disableThinking && body.reasoning_effort !== undefined) {
+    delete body.reasoning_effort;
+    changes.push("effort-removed");
+  }
+
+  if (disableThinking) {
+    body.thinking = { type: "disabled" };
+    body.enable_thinking = false;
+    changes.push("thinking-disabled");
+  }
+
+  // Placeholder thinking injection. Only meaningful while thinking is on; a
+  // disabled-thinking request does not need a well-formed thinking history.
+  // Mirrors cc-ds4: inject a content block at content[0] only into assistant
+  // messages that carry a tool_use block but no thinking block (DeepSeek 400s
+  // on a history where that is missing). The endpoint does not validate the
+  // signature, so a placeholder is enough.
+  if (!disableThinking && Array.isArray(body.messages)) {
+    for (const message of body.messages) {
+      if (!isRecord(message) || message.role !== "assistant") {
+        continue;
+      }
+      const content = message.content;
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      const kinds = new Set(
+        content
+          .filter(isRecord)
+          .map((part) => part.type)
+      );
+      if (kinds.has("tool_use") && !kinds.has("thinking")) {
+        content.unshift({ ...PLACEHOLDER });
+        changes.push("placeholder-thinking");
+      }
+    }
+  }
+
+  if (changes.length === 0) {
+    return undefined;
+  }
+
+  return {
+    body: serializeJsonBody(body),
+    diagnostic: changes.join(","),
+  };
+}
+
+function isDeepSeekModel(model: string | undefined): boolean {
+  if (!model) {
+    return false;
+  }
+  const parsed = parseProviderModelSelector(model);
+  if (parsed) {
+    return (
+      parsed.provider.toLowerCase() === DEEPSEEK_PROVIDER_ID ||
+      isDeepSeekFamily(parsed.model)
+    );
+  }
+  return isDeepSeekFamily(model);
+}
+
+function isDeepSeekFamily(model: string): boolean {
+  const normalized = model.toLowerCase();
+  return DEEPSEEK_FAMILY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/gateway/request/pipeline.ts
+++ b/packages/core/src/gateway/request/pipeline.ts
@@ -33,6 +33,7 @@ import { codexApplyPatchBridgeResponseStream, prepareCodexApplyPatchBridgeReques
 import { codexMultiAgentBridgeResponseStream, prepareCodexMultiAgentBridgeRequest } from "@ccr/core/gateway/features/codex-multi-agent-bridge";
 import { rewriteAnthropicMessageStartModelStream, shouldRewriteAnthropicMessageStartModel } from "@ccr/core/gateway/features/anthropic-response-model";
 import { prepareCursorOpenAICompatChatBody } from "@ccr/core/gateway/features/cursor-compat";
+import { prepareDeepSeekRequestAdapter } from "@ccr/core/gateway/features/deepseek-request-adapter";
 import { filteredResponseHeaders, formatError, formatUpstreamErrorForLog, forwardHeaders, inferGatewayClient, readRequestBody, sendJson, shouldCaptureGatewayUsage, shouldSendBody, stripLocalGatewayAuthHeaders } from "@ccr/core/gateway/http/io";
 import { serializeJsonBody, takeJsonObject } from "@ccr/core/gateway/http/body";
 import { createGatewayModelsResponse, prepareClaudeAppDiscoveredModelRequest, prepareClaudeCodeDiscoveredModelRequest, shouldServeGatewayModelsResponse } from "@ccr/core/gateway/features/model-discovery";
@@ -408,6 +409,33 @@ export class GatewayRequestPipeline {
           name: "compatibility.codex-multi-agent",
           phase: "compatibility",
           startedAtMs: codexMultiAgentBridgeStartedAt
+        });
+      }
+
+      const deepSeekAdapterStartedAt = Date.now();
+      const deepSeekAdapterRequest = prepareDeepSeekRequestAdapter({
+        body: bodyToForward,
+        config: this.config,
+        headers: request.headers,
+        method,
+        path,
+        routedModel
+      });
+      if (deepSeekAdapterRequest) {
+        bodyToForward = deepSeekAdapterRequest.body;
+        headers["x-ccr-deepseek-adapter"] = sanitizeHeaderValue(deepSeekAdapterRequest.diagnostic);
+        headers["content-type"] = "application/json";
+        routeTrace?.capture({
+          changes: [
+            { operation: "replace", path: "/body", scope: "body" },
+            { after: headers["x-ccr-deepseek-adapter"], operation: "add", path: "/headers/x-ccr-deepseek-adapter", scope: "headers" },
+            { after: headers["content-type"], operation: "replace", path: "/headers/content-type", scope: "headers" }
+          ],
+          durationMs: Date.now() - deepSeekAdapterStartedAt,
+          kind: "mutation",
+          name: "compatibility.deepseek-adapter",
+          phase: "compatibility",
+          startedAtMs: deepSeekAdapterStartedAt
         });
       }
 

--- a/packages/core/src/providers/presets/deepseek/index.ts
+++ b/packages/core/src/providers/presets/deepseek/index.ts
@@ -44,6 +44,10 @@ export const deepSeekProviderPreset: ProviderPreset = {
     {
       baseUrl: "https://api.deepseek.com",
       protocols: ["openai_chat_completions"]
+    },
+    {
+      baseUrl: "https://api.deepseek.com/anthropic",
+      protocols: ["anthropic_messages"]
     }
   ],
   id: "deepseek",

--- a/packages/core/test/unit/gateway/deepseek-request-adapter.test.mjs
+++ b/packages/core/test/unit/gateway/deepseek-request-adapter.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { prepareDeepSeekRequestAdapter } from "@ccr/core/gateway/features/deepseek-request-adapter.ts";
+
+const config = {};
+
+function call(body, routedModel) {
+  return prepareDeepSeekRequestAdapter({
+    body: Buffer.from(JSON.stringify(body)),
+    config,
+    headers: {},
+    method: "POST",
+    path: "/v1/messages",
+    routedModel
+  });
+}
+
+function assistantWithToolUse() {
+  return {
+    role: "assistant",
+    content: [
+      { type: "text", text: "let me check" },
+      { type: "tool_use", id: "tool_1", name: "exec", input: {} }
+    ]
+  };
+}
+
+test("DeepSeek adapter preserves a client-sent reasoning_effort through a reserialize", () => {
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      max_tokens: 65536,
+      reasoning_effort: "xhigh",
+      messages: [{ role: "user", content: "hi" }, assistantWithToolUse()]
+    },
+    "deepseek/deepseek-v4-flash"
+  );
+
+  assert.ok(result);
+  const body = JSON.parse(result.body.toString("utf8"));
+  // Thinking stays on, so effort survives the reserialize.
+  assert.equal(body.reasoning_effort, "xhigh");
+});
+
+test("DeepSeek adapter disables thinking below the max_tokens threshold", () => {
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      max_tokens: 4096,
+      reasoning_effort: "high",
+      messages: [{ role: "user", content: "hi" }]
+    },
+    "deepseek/deepseek-v4-flash"
+  );
+
+  assert.ok(result);
+  const body = JSON.parse(result.body.toString("utf8"));
+  assert.deepEqual(body.thinking, { type: "disabled" });
+  assert.equal(body.enable_thinking, false);
+  // Disabling thinking drops the contradictory effort.
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("DeepSeek adapter treats missing max_tokens as below-threshold", () => {
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      reasoning_effort: "low",
+      messages: [{ role: "user", content: "hi" }]
+    },
+    "deepseek/deepseek-v4-flash"
+  );
+
+  assert.ok(result);
+  const body = JSON.parse(result.body.toString("utf8"));
+  assert.deepEqual(body.thinking, { type: "disabled" });
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("DeepSeek adapter injects a thinking content block before a tool_use assistant message", () => {
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      max_tokens: 65536,
+      messages: [{ role: "user", content: "hi" }, assistantWithToolUse()]
+    },
+    "deepseek/deepseek-v4-flash"
+  );
+
+  assert.ok(result);
+  const body = JSON.parse(result.body.toString("utf8"));
+  const assistant = body.messages[1];
+  assert.equal(assistant.content[0].type, "thinking");
+  assert.equal(assistant.content[0].thinking, "(elided)");
+  assert.equal(assistant.content[0].signature, "ccr-deepseek-adapter");
+  // The tool_use block is preserved after the injected placeholder.
+  assert.equal(assistant.content[1].type, "text");
+  assert.equal(assistant.content[2].type, "tool_use");
+});
+
+test("DeepSeek adapter does not inject placeholder into an assistant message without tool_use", () => {
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      max_tokens: 65536,
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "plain answer" }] },
+        { role: "user", content: "next" }
+      ]
+    },
+    "deepseek/deepseek-v4-flash"
+  );
+
+  assert.equal(result, undefined);
+});
+
+test("DeepSeek adapter does not inject placeholder when thinking is disabled", () => {
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      max_tokens: 4096,
+      messages: [{ role: "user", content: "hi" }, assistantWithToolUse()]
+    },
+    "deepseek/deepseek-v4-flash"
+  );
+
+  assert.ok(result);
+  const body = JSON.parse(result.body.toString("utf8"));
+  assert.deepEqual(body.thinking, { type: "disabled" });
+  // No placeholder injected - no contradictory pair.
+  assert.equal(body.messages[1].content[0].type, "text");
+});
+
+test("DeepSeek adapter adapts OpenRouter-hosted DeepSeek selectors", () => {
+  const result = call(
+    {
+      model: "deepseek/deepseek-v4-flash-0731",
+      max_tokens: 4096,
+      messages: [{ role: "user", content: "hi" }]
+    },
+    "deepseek/deepseek-v4-flash-0731"
+  );
+
+  assert.ok(result);
+  const body = JSON.parse(result.body.toString("utf8"));
+  assert.deepEqual(body.thinking, { type: "disabled" });
+});
+
+test("DeepSeek adapter adapts a DeepSeek body.model even when routedModel is absent", () => {
+  // Default routing may leave routedModel undefined; the body.model must still
+  // gate the adapter (finding: the old split gate missed this case).
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      max_tokens: 4096,
+      messages: [{ role: "user", content: "hi" }]
+    },
+    undefined
+  );
+
+  assert.ok(result);
+  const body = JSON.parse(result.body.toString("utf8"));
+  assert.deepEqual(body.thinking, { type: "disabled" });
+});
+
+test("DeepSeek adapter leaves non-DeepSeek routes untouched", () => {
+  const result = call(
+    {
+      model: "claude-sonnet-4-5",
+      max_tokens: 4096,
+      messages: [{ role: "user", content: "hi" }]
+    },
+    "anthropic/claude-sonnet-4-5"
+  );
+
+  assert.equal(result, undefined);
+});
+
+test("DeepSeek adapter returns undefined when nothing needs changing", () => {
+  const result = call(
+    {
+      model: "deepseek-v4-flash",
+      max_tokens: 65536,
+      messages: [{ role: "user", content: "hi" }]
+    },
+    "deepseek/deepseek-v4-flash"
+  );
+
+  assert.equal(result, undefined);
+});


### PR DESCRIPTION
## What

Adds a `deepseek-request-adapter` gateway feature that adapts outbound requests for DeepSeek upstreams on the Anthropic protocol: thinking-disable below a max_tokens threshold, reasoning-effort passthrough, and placeholder-thinking injection for tool_use histories. Also adds an `anthropic_messages` endpoint to the DeepSeek provider preset.

## Why

We run DeepSeek V4 inside Claude Code and hit three gaps on the Anthropic-shaped wire body:

1. **NOTHINK_BELOW.** Below a `max_tokens` threshold DeepSeek refuses the request or burns budget on thinking. The correct fix is to disable thinking (`thinking: {type:"disabled"}`) rather than truncate max_tokens, which preserves user intent.
2. **Reasoning effort.** DeepSeek reads a top-level `reasoning_effort` field. A client-sent value is passed through; when thinking is disabled it is dropped so the wire never carries a contradictory pair.
3. **Placeholder thinking.** DeepSeek 400s on an assistant history with a `tool_use` message that has no thinking block. The endpoint does not validate the signature, so a placeholder content block is enough. Mirrors what cc-ds4's proxy does in production.

The DeepSeek preset previously declared only `openai_chat_completions`. The adapter's thinking-disable relies on the Anthropic protocol (the executor strips `thinking` for OpenAI protocols), so the preset now also declares the `anthropic_messages` endpoint at `api.deepseek.com/anthropic`.

## What changes

- `packages/core/src/gateway/features/deepseek-request-adapter.ts` - new feature, wired into the gateway request pipeline (mirrors the codex-bridge feature pattern).
- `packages/core/src/gateway/request/pipeline.ts` - calls the adapter after routing, before hosted-web-search.
- `packages/core/src/providers/presets/deepseek/index.ts` - adds the `anthropic_messages` endpoint.
- `packages/core/test/unit/gateway/deepseek-request-adapter.test.mjs` - 10 unit tests.

## Design notes

- **Wire shape.** The request body is Anthropic-shaped (`model`, `max_tokens`, `thinking`, `messages`), so the adapter operates on that shape - not the unified `reasoning` field the old v2 transformer architecture used.
- **Gate.** The adapter runs for DeepSeek model identities: provider `deepseek` or a known DeepSeek family id (covers OpenRouter-hosted `deepseek/deepseek-v4-*` selectors). Gated on `routedModel` if present, else `body.model`.
- **NOTHINK_BELOW.** Default threshold 8192, matching cc-ds4. A missing `max_tokens` counts as below-threshold.
- **Placeholder shape.** A content block `{type:"thinking", thinking:"(elided)", signature}` inserted at `content[0]` of assistant messages that have a `tool_use` block but no thinking block. This is the shape DeepSeek's Anthropic endpoint accepts in message history (top-level `message.thinking` is a Claude-Code replay convention, not the wire contract).
- **Limitation: existing DeepSeek providers.** The `anthropic_messages` endpoint is picked up by freshly-probed providers via the UI onboarding path. Existing providers persisted with only the `openai_chat_completions` capability keep the OpenAI protocol, where the executor strips `thinking`; they need to be re-probed/re-saved to use the Anthropic route. We did not change routing behavior to force this - re-probing is a user action.

## Testing

- `tsc --noEmit` on `packages/core`: clean.
- 10 new unit tests pass (thinking-disable, effort passthrough + removal, placeholder injection + gating, OpenRouter selectors, non-DeepSeek no-op, body.model-without-routedModel).
- The repo's core suite has 5 pre-existing failures (macOS Keychain, bundled-plugin config, Claude Design migration, RequestLogStore heap) unrelated to this change; verified identical with and without it.
