### PR TITLE
fix(observability): raw trace spool never persists a bundle on Windows

### DIFF
--- a/packages/core/src/observability/raw-trace-sync.ts
+++ b/packages/core/src/observability/raw-trace-sync.ts
@@ -1022,12 +1022,7 @@ async function writeDurableJsonFile(
   const filePath = join(directory, fileName);
   const temporaryPath = join(directory, `.${fileName}-${randomUUID()}.tmp`);
   await writeFile(temporaryPath, JSON.stringify(value));
-  const temporaryFile = await open(temporaryPath, "r");
-  try {
-    await temporaryFile.sync();
-  } finally {
-    await temporaryFile.close();
-  }
+  await syncFile(temporaryPath);
   await rename(temporaryPath, filePath);
   await syncDirectory(directory);
 }
@@ -1049,14 +1044,7 @@ async function syncRawTracePartFiles(
       throw new Error(`Raw trace part is shorter than its manifest: ${filePath}`);
     }
     if (syncPartFile) await syncPartFile(filePath);
-    else {
-      const handle = await open(filePath, "r");
-      try {
-        await handle.sync();
-      } finally {
-        await handle.close();
-      }
-    }
+    else await syncFile(filePath);
   }
   await syncDirectory(directory);
 }
@@ -1096,14 +1084,47 @@ async function readRawTraceDeliveryState(
   };
 }
 
+// Windows maps fsync to FlushFileBuffers, which requires the handle to carry
+// write access: flushing a handle opened read-only fails with EPERM. Every
+// file flushed here was just written by this process, so reopening it as "r+"
+// keeps the barrier real on Windows instead of trading it for a tolerated
+// error. POSIX accepts a read-write handle for fsync just as readily.
+async function syncFile(filePath: string): Promise<void> {
+  const handle = await open(filePath, "r+");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+// Flushing a directory entry is a best-effort durability barrier: POSIX never
+// required it to succeed, and platforms are free to reject the request. Linux
+// and macOS answer with EINVAL/ENOTSUP/EISDIR depending on the filesystem;
+// Windows rejects fsync on a directory handle with EPERM. All of those mean
+// "this platform will not flush a directory", not "this spool is broken", so
+// the rename that precedes the call still stands and we continue. Any other
+// code (EACCES, EIO, ENOSPC, EBADF, ...) is a real storage failure and must
+// keep propagating, so the caller can refuse the bundle instead of reporting a
+// durability guarantee it never obtained.
+const toleratedDirectorySyncErrorCodes = new Set(["EINVAL", "EISDIR", "ENOTSUP", "EPERM"]);
+
+function isToleratedDirectorySyncError(error: unknown): boolean {
+  const code = nodeErrorCode(error);
+  return code !== undefined && toleratedDirectorySyncErrorCodes.has(code);
+}
+
+export function isToleratedDirectorySyncErrorForTest(error: unknown): boolean {
+  return isToleratedDirectorySyncError(error);
+}
+
 async function syncDirectory(directory: string): Promise<void> {
   let handle;
   try {
     handle = await open(directory, "r");
     await handle.sync();
   } catch (error) {
-    const code = nodeErrorCode(error);
-    if (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EISDIR") throw error;
+    if (!isToleratedDirectorySyncError(error)) throw error;
   } finally {
     await handle?.close().catch(() => undefined);
   }

--- a/packages/core/test/unit/observability/raw-trace-sync.test.mjs
+++ b/packages/core/test/unit/observability/raw-trace-sync.test.mjs
@@ -11,6 +11,7 @@ import {
   applyRawTraceRequestLogPolicy,
   buildRawTraceConfig,
   createBodySampler,
+  isToleratedDirectorySyncErrorForTest,
   readRawTraceRequestLogBundle,
   RawTraceSynchronizer
 } from "@ccr/core/observability/raw-trace-sync.ts";
@@ -873,6 +874,48 @@ test("fallback raw bundles keep unique bundle ids while sharing the logical requ
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+// A real directory handle cannot drive these cases: on Linux and macOS the
+// fsync either succeeds or fails with a code that depends on the filesystem
+// under the temp directory, and on Windows it always fails. The predicate is
+// the only place where the platform-independent contract can be pinned down.
+test("raw trace tolerates every directory fsync rejection a platform may return", () => {
+  // Node rejects fsync on a directory handle with EPERM on Windows
+  // (errno -4048, verified on Node 24.14.1 win32) and with EINVAL, ENOTSUP or
+  // EISDIR across POSIX filesystems. Flushing a directory is a best-effort
+  // barrier, so none of these may fail the spool.
+  for (const code of ["EINVAL", "EISDIR", "ENOTSUP", "EPERM"]) {
+    assert.equal(
+      isToleratedDirectorySyncErrorForTest(directorySyncError(code)),
+      true,
+      `expected a directory fsync ${code} to be tolerated`
+    );
+  }
+});
+
+test("raw trace still propagates real storage failures from a directory fsync", () => {
+  // The tolerated set must stay a set. If it ever degrades into a blanket
+  // catch, an unwritable or failing spool would be acknowledged as durable.
+  for (const code of ["EACCES", "EIO", "ENOSPC", "EROFS", "EBADF", "EMFILE"]) {
+    assert.equal(
+      isToleratedDirectorySyncErrorForTest(directorySyncError(code)),
+      false,
+      `expected a directory fsync ${code} to keep propagating`
+    );
+  }
+  assert.equal(isToleratedDirectorySyncErrorForTest(new Error("fsync failed")), false);
+  assert.equal(isToleratedDirectorySyncErrorForTest(directorySyncError("")), false);
+  assert.equal(isToleratedDirectorySyncErrorForTest(undefined), false);
+});
+
+function directorySyncError(code) {
+  // Shaped like the rejection Node produces for fsync on a directory handle,
+  // e.g. "EPERM: operation not permitted, fsync" on Windows.
+  const error = new Error(`${code}: directory fsync rejected, fsync`);
+  error.code = code;
+  error.syscall = "fsync";
+  return error;
+}
 
 function createConfig() {
   const config = createDefaultAppConfig();


### PR DESCRIPTION
## Cuerpo (copiar desde aquí)

## Summary

On Windows the raw trace spool cannot complete a single durable write. With
`observability.requestLogs` enabled, `RawTraceSynchronizer.handle()` answers
`503 spool_unavailable` for every bundle and no request log body is ever
persisted.

The cause is `fsync`. Windows implements it as `FlushFileBuffers`, which
diverges from POSIX in two ways this file depends on, and the spool hits both.

**1. Flushing a directory handle is rejected with `EPERM`.**
`syncDirectory()` tolerated `EINVAL`, `ENOTSUP` and `EISDIR` — the codes
POSIX platforms return — so on Windows the barrier that follows every
`rename()` threw instead of being skipped.

**2. Flushing a file handle requires that handle to carry write access.**
Both file-flush sites opened their target with `"r"`, so `FlushFileBuffers`
was refused and they failed with `EPERM` as well.

Reproduced on Node 24.14.1, win32 x64:

```js
const { open, mkdtemp, writeFile } = require("node:fs/promises");
const os = require("node:os");
const path = require("node:path");

(async () => {
  const dir = await mkdtemp(path.join(os.tmpdir(), "fsync-"));
  const file = path.join(dir, "part.json");
  await writeFile(file, "{}");

  for (const [label, target, mode] of [
    ["directory", dir, "r"],
    ["file (read-only handle)", file, "r"],
    ["file (read-write handle)", file, "r+"]
  ]) {
    let handle;
    try {
      handle = await open(target, mode);
      await handle.sync();
      console.log(label, "-> ok");
    } catch (error) {
      console.log(label, "->", error.code);
    } finally {
      await handle?.close().catch(() => undefined);
    }
  }
})();
```

```
directory -> EPERM
file (read-only handle) -> EPERM
file (read-write handle) -> ok
```

## What is proven, and what is not

**Proven.** The spool is inoperative on Windows. This is not an inference —
the repository's own test suite demonstrates it. On unmodified `main`, running
`npm run test:core` on Windows, 12 existing tests in
`packages/core/test/unit/observability/raw-trace-sync.test.mjs` fail, including:

```
✖ raw trace sync acknowledges only after durable inbox ownership and retains queue rejections
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

  503 !== 202

    actual: 503,
    expected: 202,
```

with `[gateway] Failed to durably accept raw trace bundle: EPERM: operation not permitted, fsync`
logged alongside. That is exactly the user-visible failure.

**Not proven — and I believe it is incorrect.** #1635 reports that this
prevents the gateway from starting. I could not reproduce that, and reading the
code suggests the fsync failure is not the mechanism:

- `RawTraceSynchronizer.start()` only creates directories; it never calls
  `syncDirectory()`, so it cannot throw this error.
- `scheduleStartupReplay()` wraps its whole body in `.catch()` and downgrades
  any failure to a `console.warn`. It is not awaited by `start()`.
- The dead-letter path already wraps its call in
  `syncDirectory(directory).catch(...)`, which is where the
  `[gateway] Failed to sync raw trace dead-letter directory: EPERM ...` line
  quoted in the issue comes from — a warning, not a fatal error.

So the `Core gateway did not accept runtime config within 5000ms` symptom in
that report is most likely a separate problem, with this `EPERM` warning
appearing next to it in the log rather than causing it. This PR is offered on
the strength of the spool failure it does prove, not on the startup failure it
does not.

## The fix

For directories, tolerate `EPERM` alongside the existing codes. Flushing a
directory is a best-effort barrier that POSIX never required to succeed, and
"this platform will not flush a directory" is not the same as "this spool is
broken" — the `rename()` that precedes the call still stands.

For files, open as `"r+"` instead of `"r"`. Every file flushed here was just
written by this process, so a read-write handle keeps the barrier real on
Windows rather than trading a durability guarantee for a tolerated error.
Both file-flush sites now share one `syncFile()` helper.

I deliberately did not branch on `process.platform`: tolerating the specific
error code is narrower, and it also covers filesystems on other platforms that
reject directory flushes.

The tolerated set is extracted into a predicate and exported as
`isToleratedDirectorySyncErrorForTest`, following the existing convention in
this package (`parseProvidersForTest`,
`normalizeProviderPresetCapabilitiesForTest`, and others).

## Tests

Two tests added to the existing
`packages/core/test/unit/observability/raw-trace-sync.test.mjs`.

The predicate is tested directly rather than through a real directory, because
a real directory cannot discriminate: on Linux the directory `fsync` simply
succeeds, so the test would pass with or without the fix. The predicate is the
only place the platform-independent contract can be pinned down.

- `raw trace tolerates every directory fsync rejection a platform may return` —
  covers `EINVAL`, `EISDIR`, `ENOTSUP` and `EPERM`.
- `raw trace still propagates real storage failures from a directory fsync` —
  covers `EACCES`, `EIO`, `ENOSPC`, `EROFS`, `EBADF`, `EMFILE`, plus a plain
  `Error`, an empty code and `undefined`. This one matters: it stops the change
  from quietly degrading into a blanket `catch` that would acknowledge an
  unwritable spool as durable.

With the source fix reverted but the tests in place, the first one fails for
the right reason:

```
✖ raw trace tolerates every directory fsync rejection a platform may return
  AssertionError [ERR_ASSERTION]: expected a directory fsync EPERM to be tolerated

  false !== true

    actual: false,
    expected: true,
```

## Verification

`npm run test:core`, Windows 11, Node 24.14.1. Paths redacted.

Before (unmodified `main` at `47f3649`):

```
PASS: 661
FAIL: 48
```

After:

```
PASS: 675
FAIL: 36
```

The 12 recovered tests are all pre-existing tests in this file, not tests I
added:

```
raw trace sync acknowledges only after durable inbox ownership and retains queue rejections
raw trace sync acknowledges and cleans bundles for terminally dropped records
raw trace startup replay outlives producer retries and applies a pending bundle later
raw trace replay recovers an inbox bundle after the accepting process crashes
raw trace durable ACK waits for every part fsync and refuses ACK when fsync fails
raw trace publishes a fully durable staging directory atomically
raw trace inbox and dead letters stay within configured capacity
raw trace ACK measures only the newly admitted bundle after startup indexing
raw trace moves permanently pending bundles to bounded dead letter after max attempts
raw trace backs off record-pending retries without repeatedly persisting attempts
raw trace replay rotates through a bounded number of bundles per pass
raw trace replay isolates a failing bundle and continues with later bundles
```

Comparing the two failure sets, no test that passed before fails now.

**The remaining 36 failures are pre-existing on unmodified `main` on Windows
and are unrelated to this change** — the set is byte-for-byte identical before
and after. They are in `RequestLogStore`, `UsageStore`, `profile service`,
ToolHub MCP and plugin config, and I have not investigated them here.

Also run: `npm run typecheck` (clean) and `npm run test:architecture`
(4 passed, 0 failed).

## Credit

The diagnosis of the directory `fsync` / `EPERM` mismatch is @Que-Arch's, from
#1635, including locating it in the minified `syncDirectory` helper. This PR
adds the second cause: the read-only file handles, which the one-line fix
proposed in that issue does not address.

That distinction is measurable. I ran the suite with only the directory
tolerance applied — the change suggested in the issue — and the result was
identical to unmodified `main`: 48 failures, the same 48 tests, with all 12
raw trace failures still present. Widening the directory list alone does not
recover a single test. Both causes have to be fixed for the spool to work on
Windows.

Closes #1635

