### PR TITLE
Fix Responses tool output ordering

### DIFF
--- a/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
+++ b/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
@@ -133,9 +133,65 @@ export function rewriteUpstreamProviderUrl(
   return rewriteUrlBase(upstreamUrl, config?.anthropicBaseUrl, targetProviderConfig?.baseurl);
 }
 
+/**
+ * Keeps Responses tool outputs in the tool turn that produced them.
+ *
+ * The core protocol adapter can emit text from an Anthropic user message before
+ * the tool_result blocks in that same message. Responses-compatible providers
+ * may treat that text message as the start of a new turn and reject the later
+ * function_call_output as missing from the preceding tool turn.
+ */
+export function normalizeOpenAIResponsesToolOutputOrder(
+  body: unknown,
+  targetProviderConfig: ProviderPluginRequestInput["targetProviderConfig"]
+): unknown {
+  if (
+    targetProviderConfig?.type?.trim().toLowerCase() !== "openai_responses" ||
+    !isRecord(body) ||
+    !Array.isArray(body.input)
+  ) {
+    return body;
+  }
+
+  const input = [...body.input];
+  let changed = false;
+  for (let outputIndex = 0; outputIndex < input.length; outputIndex += 1) {
+    const output = input[outputIndex];
+    if (!isRecord(output) || output.type !== "function_call_output") continue;
+    const callId = typeof output.call_id === "string" ? output.call_id : undefined;
+    if (!callId) continue;
+
+    const callIndex = input.findIndex((item, index) =>
+      index < outputIndex &&
+      isRecord(item) &&
+      item.type === "function_call" &&
+      item.call_id === callId
+    );
+    if (callIndex < 0) continue;
+
+    const interveningMessageIndex = input.findIndex((item, index) =>
+      index > callIndex &&
+      index < outputIndex &&
+      isRecord(item) &&
+      item.type === "message"
+    );
+    if (interveningMessageIndex < 0) continue;
+
+    input.splice(outputIndex, 1);
+    input.splice(interveningMessageIndex, 0, output);
+    changed = true;
+  }
+
+  return changed ? { ...body, input } : body;
+}
+
 function headerValues(value: string | string[] | undefined): string[] {
   if (value === undefined) return [];
   return Array.isArray(value) ? value : [value];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function rewriteUrlBase(upstreamUrl: string, fromBaseUrl: string | undefined, toBaseUrl: string | undefined): string {
@@ -191,6 +247,10 @@ export function createGatewayPlugin() {
           ok: true as const,
           value: {
             ...input.upstreamRequest,
+            body: normalizeOpenAIResponsesToolOutputOrder(
+              input.upstreamRequest.body,
+              input.targetProviderConfig
+            ),
             headers: mergeUpstreamProviderHeaders(input.request?.headers, input.upstreamRequest.headers),
             url: rewriteUpstreamProviderUrl(input.upstreamRequest.url, input.targetProviderConfig, input.config)
           }

--- a/packages/core/test/unit/gateway/upstream-header-sanitizer.test.mjs
+++ b/packages/core/test/unit/gateway/upstream-header-sanitizer.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createGatewayPlugin,
+  normalizeOpenAIResponsesToolOutputOrder,
   rewriteUpstreamProviderUrl,
   sanitizeUpstreamProviderHeaders
 } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
@@ -43,6 +44,78 @@ test("gateway sanitizer hook runs on the final upstream request shape", async ()
     headers: { "content-type": "application/json" }
   });
   assert.equal(upstreamRequest.headers["x-ccr-provider-credential-id"], "credential-id");
+});
+
+test("Responses tool outputs are moved before intervening user messages", () => {
+  const functionCall = {
+    type: "function_call",
+    call_id: "call_docx",
+    name: "Skill",
+    arguments: '{"skill":"docx"}'
+  };
+  const userMessage = {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "Continue." }]
+  };
+  const functionOutput = {
+    type: "function_call_output",
+    call_id: "call_docx",
+    output: "Launching skill: docx"
+  };
+  const body = {
+    model: "deepseek-v4-flash",
+    input: [functionCall, userMessage, functionOutput]
+  };
+
+  const normalized = normalizeOpenAIResponsesToolOutputOrder(body, {
+    type: "openai_responses"
+  });
+
+  assert.deepEqual(normalized.input, [functionCall, functionOutput, userMessage]);
+  assert.deepEqual(body.input, [functionCall, userMessage, functionOutput]);
+});
+
+test("Responses parallel tool outputs keep their relative order", () => {
+  const callA = { type: "function_call", call_id: "call_a", name: "A", arguments: "{}" };
+  const callB = { type: "function_call", call_id: "call_b", name: "B", arguments: "{}" };
+  const message = { type: "message", role: "user", content: [] };
+  const outputA = { type: "function_call_output", call_id: "call_a", output: "A" };
+  const outputB = { type: "function_call_output", call_id: "call_b", output: "B" };
+
+  const normalized = normalizeOpenAIResponsesToolOutputOrder({
+    input: [callA, callB, message, outputA, outputB]
+  }, {
+    type: "openai_responses"
+  });
+
+  assert.deepEqual(normalized.input, [callA, callB, outputA, outputB, message]);
+});
+
+test("Responses tool output ordering leaves valid and non-Responses bodies unchanged", () => {
+  const validBody = {
+    input: [
+      { type: "function_call", call_id: "call_a", name: "A", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_a", output: "A" },
+      { type: "message", role: "user", content: [] }
+    ]
+  };
+  const invalidOrderBody = {
+    input: [
+      validBody.input[0],
+      validBody.input[2],
+      validBody.input[1]
+    ]
+  };
+
+  assert.equal(
+    normalizeOpenAIResponsesToolOutputOrder(validBody, { type: "openai_responses" }),
+    validBody
+  );
+  assert.equal(
+    normalizeOpenAIResponsesToolOutputOrder(invalidOrderBody, { type: "openai_chat_completions" }),
+    invalidOrderBody
+  );
 });
 
 test("gateway sanitizer hook forwards client headers without overriding provider headers", async () => {


### PR DESCRIPTION
Fixes #1643.

## Root cause

When Anthropic input contains a `tool_result` followed by user text in the same user turn, the gateway conversion can emit the OpenAI Responses items in this order:

1. `function_call`
2. `message`
3. `function_call_output`

Responses providers treat the intervening `message` as a turn boundary, so the later tool output is rejected as missing or unmatched.

## What changed

- Normalize only `openai_responses` request bodies in the final provider hook.
- Move each matching `function_call_output` before the first intervening `message`.
- Preserve parallel tool-output order.
- Leave already valid and non-Responses requests unchanged.

## Validation

- Targeted unit tests: 10 passed.
- `npm run typecheck` passed.
- End-to-end local ai-gateway capture confirmed `function_call` -> `function_call_output` -> `message`.
