### PR TITLE
fix(ui): 美化主界面显示，防止账户余额卡片内容被裁切

### DIFF
--- a/packages/ui/src/pages/home/components/dashboard.tsx
+++ b/packages/ui/src/pages/home/components/dashboard.tsx
@@ -2453,7 +2453,7 @@ function ProviderAccountsOverview({
 }) {
   const t = useAppText();
   const selectedAccountProviders = new Set((accountProviders ?? []).map((provider) => provider.trim()).filter(Boolean));
-  const sortedAccounts = [...accounts].sort(compareProviderAccountSnapshots);
+  const sortedAccounts = accounts.map(providerAccountSnapshotForOverview).sort(compareProviderAccountSnapshots);
   const filteredAccounts = selectedAccountProviders.size > 0
     ? sortedAccounts.filter((account) => providerAccountSelectionMatches(account, selectedAccountProviders))
     : sortedAccounts
@@ -2461,10 +2461,12 @@ function ProviderAccountsOverview({
   const visibleAccounts = providerAccountOrderAccounts(filteredAccounts, accountCardOrder);
   const isSingleAccount = visibleAccounts.length === 1;
   const showHeading = dimensions.height >= 2 && dimensions.width >= 2;
-  const bentoLayout = !isSingleAccount && variant === "cards"
-    ? providerAccountBentoLayout(visibleAccounts, dimensions, accountCardSizes)
-    : undefined;
-  const accountGridItems = bentoLayout?.items ?? visibleAccounts.map((account) => ({ account, span: undefined }));
+  const accountGridItems = variant === "cards"
+    ? visibleAccounts.map((account) => ({
+        account,
+        span: providerAccountUniformSpan(account, dimensions, accountCardSizes)
+      }))
+    : visibleAccounts.map((account) => ({ account, span: undefined }));
   const accountCardSortSensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -2507,7 +2509,7 @@ function ProviderAccountsOverview({
       <CardContent className={cn("min-h-0 flex-1 overflow-hidden", providerAccountContentPaddingClass(dimensions))}>
         {visibleAccounts.length === 0 ? (
           <OverviewEmptyState className="h-full py-4" compact label={t("No account balance connectors configured")} />
-        ) : isSingleAccount ? (
+        ) : isSingleAccount && variant !== "cards" ? (
           <ProviderAccountSinglePanel account={visibleAccounts[0]} dimensions={dimensions} providers={providers} refreshing={refreshing} variant={variant} onRefresh={onRefresh} />
         ) : variant === "compact" ? (
           <div className={cn("grid h-full min-h-0 grid-cols-1 overflow-y-auto pr-1", providerAccountGapClass(dimensions), providerAccountGridClass(dimensions, visibleAccounts.length))}>
@@ -2566,26 +2568,24 @@ function ProviderAccountsOverview({
             <SortableContext items={accountGridItems.map(({ account }) => providerAccountSnapshotKey(account))} strategy={rectSortingStrategy}>
               <div
                 className={cn(
-                  "grid h-full min-h-0 grid-flow-dense items-stretch overflow-hidden",
-                  providerAccountBentoGridRowClass(),
+                  "grid h-full min-h-0 grid-flow-row content-start items-stretch overflow-x-hidden overflow-y-auto pb-2 pr-2 [scrollbar-gutter:stable]",
+                  providerAccountUniformGridRowClass(),
                   providerAccountGapClass(dimensions),
                   providerAccountBentoGridClass(dimensions, visibleAccounts.length)
                 )}
                 data-provider-account-grid="true"
+                data-provider-account-grid-layout="uniform-scroll"
               >
                 {accountGridItems.map(({ account, span }) => {
                   const accountKey = providerAccountSnapshotKey(account);
                   return (
                     <SortableProviderAccountCard account={account} disabled={!editing || !onChangeAccountCardOrder} key={accountKey} span={span}>
                       {(dragHandle) => (
-                        <ProviderAccountSummaryCard account={account} bentoSpan={span} dimensions={dimensions} dragHandle={dragHandle} editing={editing} providers={providers} refreshing={refreshing} variant={variant} onChangeCardSize={onChangeAccountCardSize} onRefresh={onRefresh} />
+                        <ProviderAccountSummaryCard account={account} bentoSpan={span} dimensions={dimensions} dragHandle={dragHandle} editing={editing} providers={providers} refreshing={refreshing} uniformHeight variant={variant} onChangeCardSize={onChangeAccountCardSize} onRefresh={onRefresh} />
                       )}
                     </SortableProviderAccountCard>
                   );
                 })}
-                {(bentoLayout?.hiddenCount ?? 0) > 0 ? (
-                  <ProviderAccountBentoOverflowTile count={bentoLayout?.hiddenCount ?? 0} />
-                ) : null}
               </div>
             </SortableContext>
           </DndContext>
@@ -2754,6 +2754,7 @@ function ProviderAccountSummaryCard({
   onRefresh,
   providers,
   refreshing = false,
+  uniformHeight = false,
   variant
 }: {
   account: ProviderAccountSnapshot;
@@ -2765,37 +2766,44 @@ function ProviderAccountSummaryCard({
   onRefresh?: () => void | Promise<void>;
   providers: GatewayProviderConfig[];
   refreshing?: boolean;
+  uniformHeight?: boolean;
   variant: OverviewAccountVariant;
 }) {
   const t = useAppText();
   const quotaMeters = providerAccountQuotaMeters(account);
   const balanceMeter = primaryProviderAccountBalanceMeter(account);
-  const meters = providerAccountMetersForDisplayOrdered(account, providerAccountMeterLimit(dimensions, false, variant));
+  const meters = providerAccountMetersForDisplayOrdered(account, uniformHeight ? Math.max(1, account.meters.length) : providerAccountMeterLimit(dimensions, false, variant));
   const showQuotaVisual = providerAccountUsesQuotaVisual(variant) && quotaMeters.length > 0;
   const primaryMeter = primaryProviderAccountDisplayMeter(account);
   const secondaryMeters = primaryMeter
-    ? meters.filter((meter) => meter !== primaryMeter).slice(0, providerAccountBentoSecondaryLimit(dimensions))
+    ? meters.filter((meter) => meter !== primaryMeter).slice(0, uniformHeight ? meters.length : providerAccountBentoSecondaryLimit(dimensions))
     : [];
   const extraMeterCount = primaryMeter
     ? Math.max(0, account.meters.length - 1 - secondaryMeters.length)
     : Math.max(0, account.meters.length - meters.length);
   const primaryProgress = primaryMeter && isProviderAccountQuotaMeter(primaryMeter) ? providerAccountMeterProgress(primaryMeter) : undefined;
   const cardBentoSpan = bentoSpan ?? providerAccountBentoSpan(account, dimensions);
-  const compactBento = cardBentoSpan.height === 1;
-  const resizeHandle = editing && onChangeCardSize
+  const compactBento = !uniformHeight && cardBentoSpan.height === 1;
+  const resizeHandle = !uniformHeight && editing && onChangeCardSize
     ? <ProviderAccountCardResizeHandle account={account} currentSize={providerAccountBentoSizeFromSpan(cardBentoSpan)} maxHeight={providerAccountBentoRowCount(dimensions) >= 2 ? 2 : 1} maxWidth={providerAccountBentoColumnCount(dimensions, 2) >= 2 ? 2 : 1} onResize={onChangeCardSize} />
     : null;
 
   if (variant === "cards") {
     if (compactBento) {
       return (
-        <div className={cn("overview-account-bento-tile overview-nested-surface group/account-card relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden border", providerAccountBentoSpanClass(cardBentoSpan), providerAccountCardPaddingClass(dimensions))} data-account-status={account.status}>
-          <div className="flex min-w-0 items-start justify-between gap-2">
-            <div className="flex min-w-0 items-start gap-2">
+        <div className={cn("overview-account-bento-tile overview-nested-surface group/account-card relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden border p-2", providerAccountBentoSpanClass(cardBentoSpan))} data-account-status={account.status} data-provider-account-compact-card="true">
+          <div className="flex min-h-0 min-w-0 flex-1 items-center gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
               <ProviderAccountLogo account={account} className="h-7 w-7 rounded-md" providers={providers} />
               <div className="min-w-0">
                 <div className="truncate text-[12px] font-semibold">{providerAccountSnapshotLabel(account)}</div>
               </div>
+            </div>
+            <div className="min-w-0 max-w-[45%] shrink-0 text-right" data-provider-account-compact-meter="true">
+              <div className="truncate text-[10px] font-medium leading-none text-muted-foreground">
+                {primaryMeter ? formatProviderAccountMeterTitle(primaryMeter, t) : account.message || account.errors?.[0]?.message || t("Unavailable")}
+              </div>
+              {primaryMeter ? <div className="mt-0.5 truncate text-[18px] font-semibold leading-none tracking-tight">{formatProviderAccountMeterValue(primaryMeter, t)}</div> : null}
             </div>
             {dragHandle || providerAccountShowRefresh(dimensions) ? (
               <div className="flex shrink-0 items-center gap-1">
@@ -2804,14 +2812,8 @@ function ProviderAccountSummaryCard({
               </div>
             ) : null}
           </div>
-          <div className="mt-2 min-w-0">
-            <div className="truncate text-[10px] font-medium text-muted-foreground">
-              {primaryMeter ? formatProviderAccountMeterTitle(primaryMeter, t) : account.message || account.errors?.[0]?.message || t("Unavailable")}
-            </div>
-            {primaryMeter ? <div className="mt-0.5 truncate text-[18px] font-semibold leading-tight tracking-tight">{formatProviderAccountMeterValue(primaryMeter, t)}</div> : null}
-          </div>
           {primaryProgress !== undefined && providerAccountShowProgress(dimensions) ? (
-            <div className="overview-account-bento-track mt-auto h-1.5 overflow-hidden rounded-full">
+            <div className="overview-account-bento-track mt-1.5 h-1.5 shrink-0 overflow-hidden rounded-full">
               <div className="overview-account-bento-fill h-full rounded-full" style={{ width: `${primaryProgress}%` }} />
             </div>
           ) : null}
@@ -2821,13 +2823,21 @@ function ProviderAccountSummaryCard({
     }
 
     return (
-      <div className={cn("overview-account-bento-tile overview-nested-surface group/account-card relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden border", providerAccountBentoSpanClass(cardBentoSpan), providerAccountCardPaddingClass(dimensions))} data-account-status={account.status}>
+      <div
+        className={cn(
+          "overview-account-bento-tile overview-nested-surface group/account-card relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden border",
+          !uniformHeight && providerAccountBentoSpanClass(cardBentoSpan),
+          providerAccountCardPaddingClass(dimensions)
+        )}
+        data-account-status={account.status}
+        data-provider-account-uniform-card={uniformHeight ? "true" : undefined}
+      >
         <div className="flex min-w-0 shrink-0 items-start justify-between gap-3">
           <div className="flex min-w-0 items-start gap-2">
             <ProviderAccountLogo account={account} className="h-8 w-8 rounded-md" providers={providers} />
             <div className="min-w-0">
               <div className="truncate text-[13px] font-semibold">{providerAccountSnapshotLabel(account)}</div>
-              {providerAccountShowRefreshTime(dimensions) ? <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{formatProviderAccountRefreshTime(account, t)}</div> : null}
+              {uniformHeight || providerAccountShowRefreshTime(dimensions) ? <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{formatProviderAccountRefreshTime(account, t)}</div> : null}
             </div>
           </div>
           {dragHandle || providerAccountShowRefresh(dimensions) ? (
@@ -2840,25 +2850,31 @@ function ProviderAccountSummaryCard({
 
         {primaryMeter ? (
           <>
-            <div className="mt-3 min-w-0">
-              <div className="flex min-w-0 items-end justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="truncate text-[11px] font-medium text-muted-foreground">{formatProviderAccountMeterTitle(primaryMeter, t)}</div>
-                  <div className={cn("truncate font-semibold tracking-tight", dimensions.height >= 3 ? "text-[22px]" : "text-[20px]")}>{formatProviderAccountMeterValue(primaryMeter, t)}</div>
+            {isProviderAccountManualResetMeter(primaryMeter) ? (
+              <div className={cn("mt-3 min-w-0", uniformHeight && "shrink-0")}>
+                <ProviderAccountMeterLine account={account} dimensions={dimensions} meter={primaryMeter} single onRefresh={onRefresh} />
+              </div>
+            ) : (
+              <div className={cn("mt-3 min-w-0", uniformHeight && "shrink-0")}>
+                <div className="flex min-w-0 items-end justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-[11px] font-medium text-muted-foreground">{formatProviderAccountMeterTitle(primaryMeter, t)}</div>
+                    <div className={cn("truncate font-semibold tracking-tight", dimensions.height >= 3 ? "text-[22px]" : "text-[20px]")}>{formatProviderAccountMeterValue(primaryMeter, t)}</div>
+                  </div>
+                  {primaryProgress !== undefined && primaryMeter.unit.trim() !== "%" ? (
+                    <div className="overview-account-bento-badge shrink-0">{primaryProgress}%</div>
+                  ) : null}
                 </div>
-                {primaryProgress !== undefined && primaryMeter.unit.trim() !== "%" ? (
-                  <div className="overview-account-bento-badge shrink-0">{primaryProgress}%</div>
+                {primaryProgress !== undefined && providerAccountShowProgress(dimensions) ? (
+                  <div className="overview-account-bento-track mt-2 h-2 overflow-hidden rounded-full">
+                    <div className="overview-account-bento-fill h-full rounded-full" style={{ width: `${primaryProgress}%` }} />
+                  </div>
                 ) : null}
               </div>
-              {primaryProgress !== undefined && providerAccountShowProgress(dimensions) ? (
-                <div className="overview-account-bento-track mt-2 h-2 overflow-hidden rounded-full">
-                  <div className="overview-account-bento-fill h-full rounded-full" style={{ width: `${primaryProgress}%` }} />
-                </div>
-              ) : null}
-            </div>
+            )}
 
             {secondaryMeters.length > 0 || (providerAccountShowExtraCount(dimensions) && extraMeterCount > 0) ? (
-              <div className="mt-auto min-h-0 space-y-1.5 border-t border-border/45 pt-2">
+              <div className={cn("mt-auto space-y-1.5 border-t border-border/45 pt-2", uniformHeight ? "shrink-0" : "min-h-0")}>
                 {secondaryMeters.map((meter) => (
                   <ProviderAccountMeterLine account={account} compact dimensions={dimensions} key={meter.id} meter={meter} onRefresh={onRefresh} />
                 ))}
@@ -3144,16 +3160,6 @@ function providerAccountCardResizeHandleIcon(handle: OverviewAccountCardResizeHa
         )}
       />
     </span>
-  );
-}
-
-function ProviderAccountBentoOverflowTile({ count }: { count: number }) {
-  const t = useAppText();
-  return (
-    <div className="overview-account-bento-more overview-account-bento-tile overview-nested-surface row-span-1 flex min-h-0 min-w-0 flex-col justify-center overflow-hidden border p-3 text-center" data-account-status="unknown">
-      <div className="truncate text-[22px] font-semibold tracking-tight">+{count}</div>
-      <div className="truncate text-[11px] font-medium text-muted-foreground">{t("More")}</div>
-    </div>
   );
 }
 
@@ -3921,6 +3927,19 @@ function primaryProviderAccountDisplayMeter(account: ProviderAccountSnapshot): P
   return providerAccountQuotaMeters(account)[0] ?? primaryProviderAccountBalanceMeter(account) ?? primaryProviderAccountMeter(account);
 }
 
+const providerAccountBalanceBreakdownMeterIds = new Set(["granted_balance", "topped_up_balance"]);
+
+function providerAccountSnapshotForOverview(account: ProviderAccountSnapshot): ProviderAccountSnapshot {
+  const hasTotalBalance = account.meters.some((meter) => meter.kind === "balance" && meter.id.trim().toLowerCase() === "balance");
+  if (!hasTotalBalance) {
+    return account;
+  }
+  const meters = account.meters.filter((meter) => (
+    meter.kind !== "balance" || !providerAccountBalanceBreakdownMeterIds.has(meter.id.trim().toLowerCase())
+  ));
+  return meters.length === account.meters.length ? account : { ...account, meters };
+}
+
 function providerAccountSelectionMatches(account: ProviderAccountSnapshot, values: ReadonlySet<string>): boolean {
   return values.has(providerAccountSnapshotKey(account)) || values.has(account.provider);
 }
@@ -4083,8 +4102,8 @@ function providerAccountCardPaddingClass(dimensions: OverviewWidgetDimensions): 
   return dimensions.height <= 1 || dimensions.width <= 1 ? "p-2" : "p-3";
 }
 
-function providerAccountBentoGridRowClass(): string {
-  return "auto-rows-fr";
+function providerAccountUniformGridRowClass(): string {
+  return "auto-rows-[176px]";
 }
 
 function providerAccountBentoSecondaryLimit(dimensions: OverviewWidgetDimensions): number {
@@ -4098,58 +4117,13 @@ type ProviderAccountBentoSpan = {
   width: 1 | 2;
 };
 
-function providerAccountBentoLayout(accounts: ProviderAccountSnapshot[], dimensions: OverviewWidgetDimensions, cardSizes: Record<string, OverviewAccountCardSize> | undefined): {
-  hiddenCount: number;
-  items: Array<{ account: ProviderAccountSnapshot; span: ProviderAccountBentoSpan }>;
-} {
-  const maxUnits = providerAccountBentoMaxUnits(dimensions, accounts.length);
-  const items = accounts.map((account) => ({
-    account,
-    manual: providerAccountConfiguredCardSize(account, cardSizes) !== undefined,
-    span: providerAccountBentoSpan(account, dimensions, cardSizes)
-  }));
-  let usedUnits = providerAccountBentoUsedUnits(items);
-
-  for (let index = items.length - 1; index >= 0 && usedUnits > maxUnits; index -= 1) {
-    if (items[index].span.height === 2 && !items[index].manual) {
-      usedUnits -= items[index].span.width;
-      items[index] = { ...items[index], span: { ...items[index].span, height: 1 } };
-    }
-  }
-
-  if (usedUnits <= maxUnits) {
-    return { hiddenCount: 0, items };
-  }
-
-  const visibleBudget = Math.max(0, maxUnits - 1);
-  const visibleItems: Array<{ account: ProviderAccountSnapshot; span: ProviderAccountBentoSpan }> = [];
-  let visibleUnits = 0;
-
-  for (const item of items) {
-    const itemUnits = providerAccountBentoSpanUnits(item.span);
-    if (visibleUnits + itemUnits > visibleBudget) {
-      break;
-    }
-    visibleItems.push(item);
-    visibleUnits += itemUnits;
-  }
-
+function providerAccountUniformSpan(account: ProviderAccountSnapshot, dimensions: OverviewWidgetDimensions, cardSizes?: Record<string, OverviewAccountCardSize>): ProviderAccountBentoSpan {
+  const configuredSize = providerAccountConfiguredCardSize(account, cardSizes);
+  const configuredSpan = configuredSize ? providerAccountBentoSpanFromSize(configuredSize, dimensions) : undefined;
   return {
-    hiddenCount: accounts.length - visibleItems.length,
-    items: visibleItems
+    height: 1,
+    width: configuredSpan?.width ?? 1
   };
-}
-
-function providerAccountBentoUsedUnits(items: Array<{ span: ProviderAccountBentoSpan }>): number {
-  return items.reduce((total, item) => total + providerAccountBentoSpanUnits(item.span), 0);
-}
-
-function providerAccountBentoSpanUnits(span: ProviderAccountBentoSpan): number {
-  return span.width * span.height;
-}
-
-function providerAccountBentoMaxUnits(dimensions: OverviewWidgetDimensions, itemCount: number): number {
-  return Math.max(1, providerAccountBentoColumnCount(dimensions, itemCount) * providerAccountBentoRowCount(dimensions));
 }
 
 function providerAccountBentoColumnCount(dimensions: OverviewWidgetDimensions, itemCount: number): 1 | 2 | 3 {

--- a/packages/ui/test/component/overview-components.test.tsx
+++ b/packages/ui/test/component/overview-components.test.tsx
@@ -143,7 +143,7 @@ test("OverviewView renders the empty widget layout state", () => {
   assert.match(html, /aria-label="Edit widgets"/);
 });
 
-test("OverviewView renders multi-provider account cards as staggered bento tiles without inner scrolling", () => {
+test("OverviewView renders account cards at a uniform height in a scrollable grid", () => {
   const html = renderToStaticMarkup(
     <OverviewView
       overviewWidgets={[{ enabled: true, id: "account", size: "4:2", type: "account-balance", variant: "cards" }]}
@@ -157,19 +157,20 @@ test("OverviewView renders multi-provider account cards as staggered bento tiles
   );
 
   assert.match(html, /data-provider-account-grid="true"/);
-  assert.match(html, /auto-rows-fr/);
-  assert.match(html, /grid-flow-dense/);
+  assert.match(html, /data-provider-account-grid-layout="uniform-scroll"/);
+  assert.match(html, /auto-rows-\[176px\]/);
+  assert.match(html, /grid-flow-row/);
   assert.match(html, /grid-cols-2/);
   assert.match(html, /items-stretch/);
-  assert.match(html, /row-span-1/);
-  assert.match(html, /row-span-2/);
+  assert.match(html, /overflow-y-auto/);
+  assert.match(html, /scrollbar-gutter:stable/);
   assert.match(html, /overview-account-bento-tile/);
   assert.match(html, /data-account-status="warning"/);
-  assert.doesNotMatch(html, /overflow-y-auto/);
-  assert.doesNotMatch(html, /scrollbar-gutter/);
+  assert.equal(html.match(/data-provider-account-uniform-card="true"/g)?.length, accountSnapshots().length);
+  assert.doesNotMatch(html, /data-provider-account-compact-card="true"/);
 });
 
-test("OverviewView folds overflowing account bento cards into a summary tile", () => {
+test("OverviewView keeps every account card available through scrolling", () => {
   const accounts = Array.from({ length: 10 }, (_, index): ProviderAccountSnapshot => ({
     credentialId: `key-${index}`,
     meters: [
@@ -200,11 +201,13 @@ test("OverviewView folds overflowing account bento cards into a summary tile", (
   );
 
   assert.match(html, /grid-cols-3/);
-  assert.match(html, /overview-account-bento-more/);
-  assert.match(html, /\+2/);
+  assert.match(html, /provider-0/);
+  assert.match(html, /provider-9/);
+  assert.equal(html.match(/data-provider-account-uniform-card="true"/g)?.length, accounts.length);
+  assert.doesNotMatch(html, /overview-account-bento-more/);
 });
 
-test("OverviewView compacts large account bento cards before showing a summary tile", () => {
+test("OverviewView gives quota account cards the same fixed row height", () => {
   const accounts = Array.from({ length: 5 }, (_, index): ProviderAccountSnapshot => ({
     credentialId: `quota-${index}`,
     meters: [
@@ -237,12 +240,13 @@ test("OverviewView compacts large account bento cards before showing a summary t
   );
 
   assert.match(html, /quota-provider-4/);
-  assert.match(html, /row-span-1/);
-  assert.match(html, /row-span-2/);
+  assert.match(html, /auto-rows-\[176px\]/);
+  assert.equal(html.match(/data-provider-account-uniform-card="true"/g)?.length, accounts.length);
+  assert.doesNotMatch(html, /data-provider-account-compact-card="true"/);
   assert.doesNotMatch(html, /overview-account-bento-more/);
 });
 
-test("OverviewView places compact bento account values below the meter label", () => {
+test("OverviewView shows only the total DeepSeek balance in uniform cards", () => {
   const html = renderToStaticMarkup(
     <OverviewView
       overviewWidgets={[{ enabled: true, id: "account", size: "4:2", type: "account-balance", variant: "cards" }]}
@@ -255,6 +259,20 @@ test("OverviewView places compact bento account values below the meter label", (
               kind: "balance",
               label: "Balance",
               remaining: 21.59,
+              unit: "CNY"
+            },
+            {
+              id: "granted_balance",
+              kind: "balance",
+              label: "Granted balance",
+              remaining: 20,
+              unit: "CNY"
+            },
+            {
+              id: "topped_up_balance",
+              kind: "balance",
+              label: "Topped-up balance",
+              remaining: 1.59,
               unit: "CNY"
             }
           ],
@@ -273,10 +291,64 @@ test("OverviewView places compact bento account values below the meter label", (
     />
   );
 
-  assert.match(html, /Balance<\/div><div class="mt-0\.5 truncate text-\[18px\][^"]*">¥21\.59<\/div>/);
+  assert.match(html, /data-provider-account-uniform-card="true"/);
+  assert.match(html, /overview-account-bento-tile[^"]*overflow-hidden/);
+  assert.match(html, /DeepSeek/);
+  assert.match(html, /Last updated:/);
+  assert.match(html, /Balance/);
+  assert.match(html, /¥21\.59/);
+  assert.doesNotMatch(html, /Granted balance/);
+  assert.doesNotMatch(html, /Topped-up balance/);
+  assert.doesNotMatch(html, /¥20/);
+  assert.doesNotMatch(html, /¥1\.59/);
 });
 
-test("OverviewView applies manual bento account card sizes", () => {
+test("OverviewView keeps all Codex meters rendered when the widget is short", () => {
+  const html = renderToStaticMarkup(
+    <OverviewView
+      overviewWidgets={[{ enabled: true, id: "account", size: "4:1", type: "account-balance", variant: "cards" }]}
+      providerAccounts={[{
+        credentialId: "codex-api",
+        meters: [
+          {
+            id: "codex_primary_quota",
+            kind: "quota",
+            label: "Primary quota",
+            limit: 100,
+            remaining: 74,
+            unit: "%",
+            window: "weekly"
+          },
+          {
+            id: "codex_manual_resets",
+            kind: "requests",
+            label: "Manual resets",
+            remaining: 2,
+            unit: "resets"
+          }
+        ],
+        provider: "Codex API",
+        source: "standard",
+        status: "ok",
+        updatedAt: "2026-08-09T00:53:01.000Z"
+      }]}
+      refreshProviderAccounts={() => undefined}
+      setUsageRange={() => undefined}
+      usageRange="30d"
+      usageStats={usageStats("30d")}
+      onWidgetsChange={() => undefined}
+    />
+  );
+
+  assert.match(html, /data-provider-account-uniform-card="true"/);
+  assert.match(html, /Codex API/);
+  assert.match(html, /Primary quota/);
+  assert.match(html, /74%/);
+  assert.match(html, /Manual resets/);
+  assert.match(html, /2 resets/);
+});
+
+test("OverviewView keeps saved account widths but normalizes card heights", () => {
   const html = renderToStaticMarkup(
     <OverviewView
       overviewWidgets={[{
@@ -299,8 +371,8 @@ test("OverviewView applies manual bento account card sizes", () => {
     />
   );
 
-  assert.match(html, /overview-account-bento-tile[^"]*col-span-2[^"]*row-span-1[^"]*" data-account-status="warning"/);
-  assert.match(html, /overview-account-bento-tile[^"]*col-span-1[^"]*row-span-2[^"]*" data-account-status="ok"/);
+  assert.match(html, /class="[^"]*col-span-2[^"]*row-span-1[^"]*" data-provider-account-sortable-id="openai::primary"/);
+  assert.match(html, /class="[^"]*col-span-1[^"]*row-span-1[^"]*" data-provider-account-sortable-id="anthropic::secondary"/);
 });
 
 test("OverviewView applies manual bento account card order", () => {
@@ -429,7 +501,7 @@ test("OverviewView renders provider logos in account balance widgets", () => {
   assert.match(html, /src="https:\/\/cdn\.example\.test\/anthropic\.png"/);
 });
 
-test("OverviewView prioritizes Codex manual resets before folded balance meters", () => {
+test("OverviewView keeps every Codex meter rendered and prioritizes manual resets", () => {
   const resetAt = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
   const resetEffectiveAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   const codexAccount: ProviderAccountSnapshot = {
@@ -518,7 +590,9 @@ test("OverviewView prioritizes Codex manual resets before folded balance meters"
   assert.doesNotMatch(html, /Full reset/);
   assert.match(html, /expires in/);
   assert.match(html, /2 resets/);
-  assert.doesNotMatch(html, /Credit balance/);
+  assert.match(html, /Credit balance/);
+  assert.match(html, /Individual limit/);
+  assert.ok(html.indexOf("Manual resets") < html.indexOf("Credit balance"));
 });
 
 test("OverviewView does not render an outer progress bar for Codex manual resets", () => {


### PR DESCRIPTION
## 问题描述

账户余额卡片在部分组件尺寸下会出现额度和余额信息显示不全的问题。

## 修改

- 统一账户卡片高度。
- 账户较多时，仅允许卡片列表滚动，单张卡片不滚动。
- 保留用户已设置的卡片宽度。
- Codex 显示全部额度信息，DeepSeek 仅显示总余额。

<p align="center">
<strong>Wide View · 宽屏完整布局</strong><br><br>
<img width="750" alt="宽屏完整布局" src="https://github.com/user-attachments/assets/8438e694-a3d0-411d-991a-7c64fe9be6ba" /><br><br>

<p align="center">
  <strong>Standard View · 标准窗口布局</strong><br><br>
  <img width="750" alt="标准窗口布局" src="https://github.com/user-attachments/assets/6bdfeb74-f21d-4a3a-966c-92479a735a73" /><br><br>

<p align="center">
  <strong>Compact View · 窄屏自适应布局</strong><br><br>
  <img width="500" alt="窄屏自适应布局" src="https://github.com/user-attachments/assets/df9c0315-4133-43d1-9396-b275b76f178c" />
  </p>


## 测试

- 账户概览组件测试 20 项全部通过。
- TypeScript 类型检查通过。