### PR TITLE
fix(electron): retry gateway start after app launch

### DIFF
--- a/packages/electron/src/main/gateway-start-retry.ts
+++ b/packages/electron/src/main/gateway-start-retry.ts
@@ -1,0 +1,70 @@
+import { NO_AVAILABLE_GATEWAY_MODELS_MESSAGE } from "@ccr/core/contracts/app";
+import type { AppConfig, GatewayStatus } from "@ccr/core/contracts/app";
+
+/**
+ * The first gateway start after a machine boots competes with every other login item for disk and
+ * CPU, so the managed core runtime regularly misses its health deadline even though the
+ * configuration is sound. Retry those failures with growing gaps instead of leaving the app in the
+ * error state until someone starts the gateway by hand.
+ */
+export const gatewayStartRetryDelaysMs = [2_000, 5_000, 10_000];
+
+const permanentGatewayStartErrors = [
+  NO_AVAILABLE_GATEWAY_MODELS_MESSAGE,
+  "Core gateway host must be 127.0.0.1 or ::1."
+];
+
+export type GatewayStartRetryOptions = {
+  getStatus: () => GatewayStatus;
+  onRetry?: (attempt: number, delayMs: number, lastError: string | undefined) => void;
+  shouldAbort?: () => boolean;
+  start: (config: AppConfig) => Promise<GatewayStatus>;
+  wait?: (ms: number) => Promise<void>;
+};
+
+export function isRetryableGatewayStartFailure(status: GatewayStatus): boolean {
+  if (status.state !== "error") {
+    return false;
+  }
+
+  const message = status.lastError ?? "";
+  return !permanentGatewayStartErrors.some((permanent) => message.includes(permanent));
+}
+
+export async function startGatewayWithRetry(
+  config: AppConfig,
+  options: GatewayStartRetryOptions
+): Promise<GatewayStatus> {
+  const wait = options.wait ?? waitFor;
+  const shouldAbort = options.shouldAbort ?? (() => false);
+  let status = await options.start(config);
+
+  for (const [index, delayMs] of gatewayStartRetryDelaysMs.entries()) {
+    if (!isRetryableGatewayStartFailure(status) || shouldAbort()) {
+      return status;
+    }
+
+    options.onRetry?.(index + 1, delayMs, status.lastError);
+    await wait(delayMs);
+    if (shouldAbort()) {
+      return status;
+    }
+
+    // Anything other than the failure we just produced means another caller took over the
+    // gateway while we waited, so leave their result alone.
+    const current = options.getStatus();
+    if (current.state !== "error") {
+      return current;
+    }
+
+    status = await options.start(config);
+  }
+
+  return status;
+}
+
+function waitFor(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/electron/src/main/main-app.ts
+++ b/packages/electron/src/main/main-app.ts
@@ -1,10 +1,12 @@
 import { app, BrowserWindow, dialog, shell } from "electron";
 import { setupApplicationMenu } from "./app-menu";
 import { loadAppConfig } from "@ccr/core/config/config";
+import type { AppConfig, GatewayStatus } from "@ccr/core/contracts/app";
 import { loadOnboardingFinished } from "@ccr/core/config/onboarding-state";
 import { restoreClaudeAppGatewayConfig, syncClaudeAppGatewayConfig } from "@ccr/core/agents/claude-app/gateway-service";
 import { deepLinkService } from "./deep-link";
 import { gatewayService } from "@ccr/core/gateway/service";
+import { gatewayStartRetryDelaysMs, startGatewayWithRetry } from "./gateway-start-retry";
 import "./ipc";
 import { applyProfileConfig, restoreGlobalProfileConfigsOnExit } from "@ccr/core/profiles/service";
 import { ensureCcrCliLauncher, persistPreparedCcrCliPath, prepareCcrCliLauncherRuntime, type CcrCliLauncherPreparation } from "@ccr/core/profiles/launch-service";
@@ -71,7 +73,7 @@ function startPrimaryInstance(): void {
     trayController.start();
     appUpdateService.start();
     appUpdateService.setInstallPreparation(prepareForUpdateInstall);
-    void startConfiguredServices("startup");
+    void startConfiguredServices("startup", { retryGatewayStart: true });
 
     app.on("activate", () => {
       const mainWindow = windowsManager.getWindow("main");
@@ -207,7 +209,7 @@ function stopServicesForQuit(): Promise<void> {
   return stopForQuitPromise;
 }
 
-function startConfiguredServices(reason: string): Promise<void> {
+function startConfiguredServices(reason: string, options: { retryGatewayStart?: boolean } = {}): Promise<void> {
   if (!startServicesPromise) {
     startServicesPromise = loadAppConfig()
       .then(async (config) => {
@@ -226,7 +228,7 @@ function startConfiguredServices(reason: string): Promise<void> {
         } catch (error) {
           console.error(`Failed to sync launch-at-login setting during ${reason}: ${formatError(error)}`);
         }
-        const status = await gatewayService.start(config);
+        const status = await startGateway(config, reason, Boolean(options.retryGatewayStart));
         if (status.state === "error") {
           console.error(`Failed to start gateway during ${reason}: ${status.lastError}`);
         }
@@ -252,6 +254,23 @@ function startConfiguredServices(reason: string): Promise<void> {
       });
   }
   return startServicesPromise;
+}
+
+function startGateway(config: AppConfig, reason: string, retry: boolean): Promise<GatewayStatus> {
+  if (!retry) {
+    return gatewayService.start(config);
+  }
+
+  return startGatewayWithRetry(config, {
+    getStatus: () => gatewayService.getStatus(),
+    onRetry: (attempt, delayMs, lastError) => {
+      console.warn(
+        `Gateway did not start during ${reason} (${lastError}). Retrying in ${delayMs}ms (attempt ${attempt} of ${gatewayStartRetryDelaysMs.length}).`
+      );
+    },
+    shouldAbort: () => stoppingForQuit,
+    start: (startConfig) => gatewayService.start(startConfig)
+  });
 }
 
 function queueEnsureConfiguredProxyModeActive(reason: string): void {

--- a/packages/electron/test/unit/gateway-start-retry.test.ts
+++ b/packages/electron/test/unit/gateway-start-retry.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NO_AVAILABLE_GATEWAY_MODELS_MESSAGE } from "@ccr/core/contracts/app";
+import type { AppConfig, GatewayStatus } from "@ccr/core/contracts/app";
+import { gatewayStartRetryDelaysMs, startGatewayWithRetry } from "@ccr/electron/main/gateway-start-retry.ts";
+
+const config = {} as AppConfig;
+const healthTimeout = "Core gateway runtime 3f9ac did not become healthy within 15000ms.";
+
+function gatewayStatus(state: GatewayStatus["state"], lastError?: string): GatewayStatus {
+  return {
+    coreEndpoint: "http://127.0.0.1:3457",
+    endpoint: "http://127.0.0.1:3456",
+    lastError,
+    networkEndpoints: [],
+    state
+  };
+}
+
+test("gateway start does not retry when the first attempt succeeds", async () => {
+  const waits: number[] = [];
+  let starts = 0;
+
+  const status = await startGatewayWithRetry(config, {
+    getStatus: () => gatewayStatus("running"),
+    start: async () => {
+      starts += 1;
+      return gatewayStatus("running");
+    },
+    wait: async (ms) => {
+      waits.push(ms);
+    }
+  });
+
+  assert.equal(status.state, "running");
+  assert.equal(starts, 1);
+  assert.deepEqual(waits, []);
+});
+
+test("gateway start retries a transient failure until the runtime becomes healthy", async () => {
+  const attempts = [
+    gatewayStatus("error", healthTimeout),
+    gatewayStatus("error", "Core gateway exited during startup with 1."),
+    gatewayStatus("running")
+  ];
+  const waits: number[] = [];
+  let current = gatewayStatus("stopped");
+  let starts = 0;
+
+  const status = await startGatewayWithRetry(config, {
+    getStatus: () => current,
+    start: async () => {
+      current = attempts[starts];
+      starts += 1;
+      return current;
+    },
+    wait: async (ms) => {
+      waits.push(ms);
+    }
+  });
+
+  assert.equal(status.state, "running");
+  assert.equal(starts, 3);
+  assert.deepEqual(waits, gatewayStartRetryDelaysMs.slice(0, 2));
+});
+
+test("gateway start gives up after the configured retries and reports the last error", async () => {
+  const failure = gatewayStatus("error", healthTimeout);
+  const retries: number[] = [];
+  const waits: number[] = [];
+  let starts = 0;
+
+  const status = await startGatewayWithRetry(config, {
+    getStatus: () => failure,
+    onRetry: (attempt) => {
+      retries.push(attempt);
+    },
+    start: async () => {
+      starts += 1;
+      return failure;
+    },
+    wait: async (ms) => {
+      waits.push(ms);
+    }
+  });
+
+  assert.equal(status.state, "error");
+  assert.equal(status.lastError, healthTimeout);
+  assert.equal(starts, gatewayStartRetryDelaysMs.length + 1);
+  assert.deepEqual(waits, gatewayStartRetryDelaysMs);
+  assert.deepEqual(retries, gatewayStartRetryDelaysMs.map((_delayMs, index) => index + 1));
+});
+
+test("gateway start does not retry a configuration failure", async () => {
+  for (const message of [NO_AVAILABLE_GATEWAY_MODELS_MESSAGE, "Core gateway host must be 127.0.0.1 or ::1."]) {
+    const failure = gatewayStatus("error", message);
+    const waits: number[] = [];
+    let starts = 0;
+
+    const status = await startGatewayWithRetry(config, {
+      getStatus: () => failure,
+      start: async () => {
+        starts += 1;
+        return failure;
+      },
+      wait: async (ms) => {
+        waits.push(ms);
+      }
+    });
+
+    assert.equal(status.lastError, message);
+    assert.equal(starts, 1, `${message} must not be retried`);
+    assert.deepEqual(waits, []);
+  }
+});
+
+test("gateway start stops retrying once the app begins quitting", async () => {
+  const failure = gatewayStatus("error", healthTimeout);
+  const waits: number[] = [];
+  let quitting = false;
+  let starts = 0;
+
+  const status = await startGatewayWithRetry(config, {
+    getStatus: () => failure,
+    shouldAbort: () => quitting,
+    start: async () => {
+      starts += 1;
+      return failure;
+    },
+    wait: async (ms) => {
+      waits.push(ms);
+      quitting = true;
+    }
+  });
+
+  assert.equal(status.state, "error");
+  assert.equal(starts, 1);
+  assert.deepEqual(waits, [gatewayStartRetryDelaysMs[0]]);
+});
+
+test("gateway start yields to whoever owns the gateway during the backoff", async () => {
+  for (const takeover of ["running", "stopped"] as const) {
+    let current = gatewayStatus("error", healthTimeout);
+    let starts = 0;
+
+    const status = await startGatewayWithRetry(config, {
+      getStatus: () => current,
+      start: async () => {
+        starts += 1;
+        return current;
+      },
+      wait: async () => {
+        current = gatewayStatus(takeover);
+      }
+    });
+
+    assert.equal(status.state, takeover);
+    assert.equal(starts, 1, `a ${takeover} gateway must not be restarted`);
+  }
+});


### PR DESCRIPTION
## Problem

With **Launch at Login** enabled, CCR starts while the machine is still bringing up every other
login item. The gateway loses that race often enough to be a daily annoyance, and the app lands in
the error state with:

```
Server failed to start
Core gateway runtime <uuid> did not become healthy within 15000ms.
```

Starting the gateway by hand a minute later succeeds every time — nothing is actually
misconfigured. The managed core runtime just misses `gatewayStartupTimeoutMs` (15s, in
`packages/core/src/gateway/core-runtime/supervisor.ts`) while disk and CPU are contended at sign-in.

The boot path gets exactly one attempt at it. In `startConfiguredServices`
(`packages/electron/src/main/main-app.ts`), `gatewayService.start(config)` fails, the error goes to
the console, and that is the end of it — the gateway stays down until the user notices and starts
it manually.

## Change

Retry the boot-path start with growing gaps — `[2s, 5s, 10s]`, one initial attempt plus three
retries — in a new `gateway-start-retry` module. Three guards keep it from doing anything
surprising:

- **Configuration failures are not retried.** A deny-list skips `NO_AVAILABLE_GATEWAY_MODELS_MESSAGE`
  and the loopback-host error, so a fresh install with no provider configured still fails fast
  instead of grinding through the backoff. Everything else — the health-deadline miss,
  `Core gateway exited during startup`, IPC failures, endpoint already in use — is treated as
  transient.
- **It yields to whoever owns the gateway.** Between attempts it re-reads
  `gatewayService.getStatus()`; anything other than `error` (started from the UI, or deliberately
  stopped) ends the loop. This matters because `start()` opens with `await this.stop()`, so a blind
  retry would tear down a gateway the user had just started by hand.
- **It aborts on quit** (`shouldAbort: () => stoppingForQuit`), so a pending backoff cannot spawn a
  gateway while the app is shutting down.

Only the boot path opts in, via `startConfiguredServices("startup", { retryGatewayStart: true })`.
The `activate` and `second-instance` paths keep the existing single-shot behaviour.

The retry module deliberately imports no `electron`, so the policy is unit-testable without an
Electron host.

## Trade-off

A genuinely broken gateway now reaches the error state in roughly 90s instead of ~20s (three
retries of up to ~20s each, plus 17s of backoff), all in the background with a warning logged per
attempt. `gatewayStartRetryDelaysMs` is the single knob if that feels too patient.

## Note on scope

The retry is gated on the app-boot path rather than on a detected launch-at-login, because
`wasOpenedAtLogin` is macOS-only. On Windows, detection means stamping a marker arg into
`setLoginItemSettings({ args })`, which `syncLaunchAtLogin` would never write for users who already
have the toggle on — it early-returns when `openAtLogin` already matches — so it needs a migration
and still leaves a fragile signal. The boot path is a strict superset that covers login with no
detection at all. A manual app launch also retries now, which seems right anyway: same transient
failure, same fix.

Happy to narrow it to a detected login launch if you would rather keep manual launches
single-shot.

## Testing

- `npm run typecheck` — clean
- `npm run test:electron` — 33 pass, 6 new: no retry on success, retry until healthy, give up and
  report the last error, no retry on configuration failures, abort once the app begins quitting,
  yield to another owner. The new tests inject `wait`, so they assert the exact backoff sequence
  without real timers.
- `npm run test:architecture` — 4 pass

The original failure was observed on Windows 11 with Launch at Login enabled. The unit tests cover
the retry policy itself; the login-time race is timing-dependent and was not reproduced
end-to-end after the change.
