### PR TITLE
fix: expose core gateway auth token before the HTTP server binds

### DIFF
--- a/packages/core/src/gateway/application/gateway-service.ts
+++ b/packages/core/src/gateway/application/gateway-service.ts
@@ -159,6 +159,13 @@ class GatewayService {
         return this.status;
       }
 
+      // The HTTP server starts accepting requests as soon as listen() binds, but
+      // the managed core gateway child is spawned later in this method. Expose
+      // the auth token before binding so a request that lands in that startup
+      // window is not rejected with a misleading "core gateway auth token is not
+      // initialized" 502. The token is cleared again by stop() if the child
+      // fails to spawn, and by handleCoreGatewayTermination if it exits later.
+      this.coreAuthToken = coreAuthToken;
       await this.rawTraceSynchronizer.start();
       await this.listen(config);
       if (this.server) {
@@ -186,7 +193,6 @@ class GatewayService {
         const runtimeId = randomUUID();
         const spawnedGateway = spawnGatewayProcess(config, coreGatewayConfig, upstreamProxyUrl, runtimeId, coreAuthToken);
         this.child = spawnedGateway.child;
-        this.coreAuthToken = coreAuthToken;
         const managedChild = this.child;
         let markerWritePromise: Promise<void> | undefined;
         let startupFailure: Error | undefined;

--- a/packages/core/test/unit/gateway/gateway-status.test.mjs
+++ b/packages/core/test/unit/gateway/gateway-status.test.mjs
@@ -166,6 +166,74 @@ test("gateway start completes the IPC and health handshake with the bundled runt
   }
 });
 
+test("gateway startup never serves a request with an uninitialized core auth token", async () => {
+  const previousGatewayEntry = process.env.CCR_GATEWAY_ENTRY;
+  try {
+    await gatewayService.stop();
+    delete process.env.CCR_GATEWAY_ENTRY;
+    const config = gatewayTestConfig(await findAvailablePort());
+    config.gateway.port = await findAvailablePort();
+    config.APIKEY = "test-api-key";
+    // Capabilities-based provider keeps the child config compilation on the
+    // critical path between listen() and the core auth token assignment,
+    // reliably widening the startup window this test guards.
+    config.Providers = [{
+      baseUrl: "http://127.0.0.1:9/v1",
+      capabilities: [{ baseUrl: "http://127.0.0.1:9/v1", type: "openai_chat_completions" }],
+      api_key: "test-provider-key",
+      id: "readiness-provider",
+      models: ["readiness-model"],
+      name: "Readiness Provider"
+    }];
+
+    // Start the gateway without awaiting it and fire concurrent requests the
+    // moment the port accepts. The core auth token must be exposed before the
+    // HTTP server binds; otherwise a request that lands between listen() and
+    // the token assignment reaches the executor with an empty token and the
+    // pipeline returns a misleading "Core gateway auth token is not
+    // initialized." 502.
+    const startPromise = gatewayService.start(config);
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      if (await canConnect(config.gateway.port)) {
+        break;
+      }
+      await delay(5);
+    }
+
+    const request = () => fetch(`http://127.0.0.1:${config.gateway.port}/v1/messages`, {
+      body: JSON.stringify({
+        max_tokens: 64,
+        messages: [{ content: "ping", role: "user" }],
+        model: "Readiness Provider/readiness-model"
+      }),
+      headers: {
+        authorization: "Bearer test-api-key",
+        "content-type": "application/json"
+      },
+      method: "POST"
+    }).then(async (res) => ({ status: res.status, text: await res.text() }))
+      .catch(() => ({ status: -1, text: "connection refused" }));
+
+    const resultsPromise = Promise.all(Array.from({ length: 8 }, () => request()));
+    const status = await startPromise;
+    assert.equal(status.state, "running", status.lastError);
+
+    const results = await resultsPromise;
+    for (const result of results) {
+      assert.equal(
+        result.text.includes("Core gateway auth token is not initialized."),
+        false,
+        `request returned misleading auth error: ${result.status} ${result.text}`
+      );
+    }
+  } finally {
+    restoreEnv("CCR_GATEWAY_ENTRY", previousGatewayEntry);
+    await gatewayService.stop();
+    await deletePersistedRuntimeState("gateway");
+  }
+});
+
 test("gateway start rejects healthy endpoints owned by a different runtime", async () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "ccr-gateway-runtime-identity-test-"));
   const gatewayEntry = path.join(dir, "gateway-entry.cjs");
@@ -261,6 +329,20 @@ async function findAvailablePort() {
           reject(new Error("Failed to allocate a gateway test port."));
         }
       });
+    });
+  });
+}
+
+function canConnect(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect(port, "127.0.0.1");
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
     });
   });
 }


### PR DESCRIPTION
## What

The gateway service assigned `coreAuthToken` after `listen()` had already started accepting requests. A request landing in that startup window reached the executor with an empty token and returned a misleading `Core gateway auth token is not initialized.` 502.

## Fix

Set `coreAuthToken` before `listen()` binds. The token is still cleared on the failure paths (`stop()`, `handleCoreGatewayTermination`), so a failed child spawn or a terminated child behaves exactly as before - only the startup-window requests change.

## Why it matters

The 502 is confusing: it points at the auth token when the real cause is a race between `listen()` and the managed gateway child spawn. On a busy machine (or right after a config reload) the window is wide enough that real requests hit it, and the error sends you down the wrong debugging path.

## Test

`gateway startup never serves a request with an uninitialized core auth token` - starts the gateway un-awaited, fires 8 concurrent requests the moment the port accepts, and asserts none returns the misleading error. Fails on the old ordering, passes with the fix.

Verified: `tsc --noEmit` clean, the new test passes, and the core suite's pre-existing failures are unchanged.
