### PR TITLE
feat(providers): add SenseNova provider preset

### DIFF
--- a/packages/core/src/providers/presets/index.ts
+++ b/packages/core/src/providers/presets/index.ts
@@ -15,6 +15,7 @@ import { openaiProviderPreset } from "@ccr/core/providers/presets/openai/index";
 import { openRouterProviderPreset } from "@ccr/core/providers/presets/openrouter/index";
 import { qiniuAiProviderPreset } from "@ccr/core/providers/presets/qiniu-ai/index";
 import { runApiProviderPreset } from "@ccr/core/providers/presets/runapi/index";
+import { sensenovaProviderPreset } from "@ccr/core/providers/presets/sensenova/index";
 import { siliconFlowProviderPreset } from "@ccr/core/providers/presets/siliconflow/index";
 import { teamoRouterProviderPreset } from "@ccr/core/providers/presets/teamorouter/index";
 import { unity2ProviderPreset } from "@ccr/core/providers/presets/unity2/index";
@@ -66,7 +67,8 @@ export const providerPresets: ProviderPreset[] = [
   fennoProviderPreset,
   infistarAiProviderPreset,
   runApiProviderPreset,
-  teamoRouterProviderPreset,
+    sensenovaProviderPreset,
+    teamoRouterProviderPreset,
   unity2ProviderPreset,
   code0ProviderPreset,
   claudeApiProviderPreset

--- a/packages/core/src/providers/presets/sensenova/index.ts
+++ b/packages/core/src/providers/presets/sensenova/index.ts
@@ -1,0 +1,21 @@
+import { standardProviderAccountConfig, type ProviderPreset } from "@ccr/core/providers/presets/types";
+
+const sensenovaDefaultModels = [
+  "deepseek-v4-flash",
+  "deepseek/deepseek-v4-pro",
+];
+
+export const sensenovaProviderPreset: ProviderPreset = {
+  account: standardProviderAccountConfig,
+  aliases: ["sensenova", "sense nova", "sense-nova", "商汤", "日日商"],
+  defaultModels: sensenovaDefaultModels,
+  endpoints: [
+    {
+      baseUrl: "https://token.sensenova.cn/v1",
+      protocols: ["openai_chat_completions"],
+    },
+  ],
+  id: "sensenova",
+  name: "SenseNova",
+  websiteUrl: "https://www.sensechat.com.cn/",
+};


### PR DESCRIPTION
## Summary

Add a provider preset for **SenseNova** (SenseTime's LLM platform).

## What

New preset id `sensenova`:

- endpoint `https://token.sensenova.cn/v1`, OpenAI chat completions protocol
- default models: `deepseek-v4-flash`, `deepseek/deepseek-v4-pro`
- aliases: `sensenova`, `sense nova`, `sense-nova`, `商汤`, `日日商`
- standard provider-api-key auth (key required, no balance connector — SenseNova's public gateway does not expose a balance endpoint)

Follows the exact shape of the existing `unity2` / `fenno` single-endpoint presets. Registered in `presets/index.ts`.

## Why

SenseNova's OpenAI-compatible gateway is widely used in CN tooling (Hermes, cc-switch proxy, etc.) but was missing from CCR's preset list, forcing users to configure it as a generic custom provider.

## Verification

- `npm run typecheck` passes.
- `npm run test:core` fails in this environment only because the `better-sqlite3` native addon does not build on this Windows host (unrelated to this change — pure preset data addition, no logic touched); CI covers it.
- `git diff --check` clean.

## Notes

- No balance connector: the SenseNova token gateway has no public `/user/info`-style balance API; the preset uses plain `standard` auth (same as `unity2`).
- Model list is intentionally minimal (the two models known to work on the public gateway). Users can add more via custom models in CCR's UI.