### PR TITLE
fix(providers): replace retired default model in Anthropic preset

### DIFF
--- a/packages/core/src/providers/presets/anthropic/index.ts
+++ b/packages/core/src/providers/presets/anthropic/index.ts
@@ -3,7 +3,7 @@ import { defaultProviderAccountConfig, type ProviderPreset } from "@ccr/core/pro
 export const anthropicProviderPreset: ProviderPreset = {
   account: defaultProviderAccountConfig,
   aliases: ["anthropic", "claude"],
-  defaultModels: ["claude-sonnet-4-20250514"],
+  defaultModels: ["claude-sonnet-4-6"],
   endpoints: [
     {
       baseUrl: "https://api.anthropic.com",


### PR DESCRIPTION
## What

`anthropicProviderPreset.defaultModels` is `["claude-sonnet-4-20250514"]`. Anthropic retired that model on the Claude API on 15 June 2026, so a user who adds the Anthropic provider from the preset gets a default that fails on the first request.

Replaced with `claude-sonnet-4-6`, the successor Anthropic lists for it.

## Why this form of the id

`packages/core/models.json` already carries `anthropic/claude-sonnet-4-6`, so the new default resolves against the bundled catalogue. The preset uses the bare id, so I kept that form.

## Not touched

- `packages/core/models.json` — generated by `scripts/generate-models-json.mjs` from LiteLLM, and a catalogue besides: the retired entries belong there so existing user configs keep resolving.
- `packages/electron/bundled-plugins/claude-design/index.cjs` — `DEFAULT_GATEWAY_MODEL` there is the same retired id, but that file is a 16k-line bundle with no source in the repo, so it looked like yours to regenerate rather than mine to hand-edit. Flagging it so it does not get missed.

## Verification

Honest about the limits here:

- No test asserts on this value. `packages/core/test/unit/providers/provider-preset-utils.test.mjs` pins `defaultModels` for the infistar-ai, nvidia and xiaomi presets only, so nothing needs updating alongside.
- I could not run `npm run test:core` in my environment: `npm install` fails building `better-sqlite3` from source on Node 23, before the test harness is reachable. That is my toolchain, not your repo — I did not want to claim a green suite I never saw.
- The change itself is a string literal inside an existing `string[]`, so there is no type surface to move.

## Scope

1 file, 1 line. No refactoring, no other providers or model ids touched.