### PR TITLE
fix(gateway): SSE transforms corrupt multi-byte characters split across chunks

### DIFF
--- a/packages/core/src/gateway/features/codex-multi-agent-bridge.ts
+++ b/packages/core/src/gateway/features/codex-multi-agent-bridge.ts
@@ -1,5 +1,6 @@
 import type { IncomingHttpHeaders } from "node:http";
 import { Readable, Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import type { AppConfig } from "@ccr/core/contracts/app";
 import { normalizeRouteSelector } from "@ccr/core/routing/model-registry";
 import { isRecord, rawStringValue, stringValue } from "@ccr/core/gateway/internal/value";
@@ -345,9 +346,17 @@ function transformMultiAgentFunctionCall(item: Record<string, unknown>): { value
   };
 }
 
+type CodexMultiAgentBridgeSseTransform = Transform & {
+  __ccrCodexMultiAgentBridgeSseDecoder?: StringDecoder;
+  __ccrCodexMultiAgentBridgeSsePending?: string;
+};
+
 function transformSseChunk(stream: Transform, chunk: Buffer | string): void {
-  const state = stream as Transform & { __ccrCodexMultiAgentBridgeSsePending?: string };
-  state.__ccrCodexMultiAgentBridgeSsePending = (state.__ccrCodexMultiAgentBridgeSsePending ?? "") + chunk.toString();
+  const state = stream as CodexMultiAgentBridgeSseTransform;
+  const decoder = state.__ccrCodexMultiAgentBridgeSseDecoder ?? new StringDecoder("utf8");
+  state.__ccrCodexMultiAgentBridgeSseDecoder = decoder;
+  state.__ccrCodexMultiAgentBridgeSsePending = (state.__ccrCodexMultiAgentBridgeSsePending ?? "") +
+    decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   while (state.__ccrCodexMultiAgentBridgeSsePending) {
     const match = /\r?\n\r?\n/.exec(state.__ccrCodexMultiAgentBridgeSsePending);
     if (!match || match.index === undefined) {
@@ -361,7 +370,9 @@ function transformSseChunk(stream: Transform, chunk: Buffer | string): void {
 }
 
 function flushSseTransform(stream: Transform): void {
-  const state = stream as Transform & { __ccrCodexMultiAgentBridgeSsePending?: string };
+  const state = stream as CodexMultiAgentBridgeSseTransform;
+  state.__ccrCodexMultiAgentBridgeSsePending = (state.__ccrCodexMultiAgentBridgeSsePending ?? "") +
+    (state.__ccrCodexMultiAgentBridgeSseDecoder?.end() ?? "");
   if (state.__ccrCodexMultiAgentBridgeSsePending) {
     stream.push(transformCodexMultiAgentBridgeSseEvent(state.__ccrCodexMultiAgentBridgeSsePending));
     state.__ccrCodexMultiAgentBridgeSsePending = "";

--- a/packages/core/src/gateway/features/codex-patch-bridge.ts
+++ b/packages/core/src/gateway/features/codex-patch-bridge.ts
@@ -3,6 +3,7 @@
  */
 import type { IncomingHttpHeaders } from "node:http";
 import { Readable, Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import type { AppConfig } from "@ccr/core/contracts/app";
 import { normalizeRouteSelector } from "@ccr/core/routing/model-registry";
 import { isRecord, rawStringValue, stringValue } from "@ccr/core/gateway/internal/value";
@@ -416,9 +417,17 @@ function patchInputFromVirtualApplyPatchArguments(value: unknown): string | unde
 }
 
 
+type CodexPatchBridgeSseTransform = Transform & {
+  __ccrCodexPatchBridgeSseDecoder?: StringDecoder;
+  __ccrCodexPatchBridgeSsePending?: string;
+};
+
 function transformSseChunk(stream: Transform, chunk: Buffer | string): void {
-  const state = stream as Transform & { __ccrCodexPatchBridgeSsePending?: string };
-  state.__ccrCodexPatchBridgeSsePending = (state.__ccrCodexPatchBridgeSsePending ?? "") + chunk.toString();
+  const state = stream as CodexPatchBridgeSseTransform;
+  const decoder = state.__ccrCodexPatchBridgeSseDecoder ?? new StringDecoder("utf8");
+  state.__ccrCodexPatchBridgeSseDecoder = decoder;
+  state.__ccrCodexPatchBridgeSsePending = (state.__ccrCodexPatchBridgeSsePending ?? "") +
+    decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   while (state.__ccrCodexPatchBridgeSsePending) {
     const match = /\r?\n\r?\n/.exec(state.__ccrCodexPatchBridgeSsePending);
     if (!match || match.index === undefined) {
@@ -433,7 +442,9 @@ function transformSseChunk(stream: Transform, chunk: Buffer | string): void {
 
 
 function flushSseTransform(stream: Transform): void {
-  const state = stream as Transform & { __ccrCodexPatchBridgeSsePending?: string };
+  const state = stream as CodexPatchBridgeSseTransform;
+  state.__ccrCodexPatchBridgeSsePending = (state.__ccrCodexPatchBridgeSsePending ?? "") +
+    (state.__ccrCodexPatchBridgeSseDecoder?.end() ?? "");
   if (state.__ccrCodexPatchBridgeSsePending) {
     stream.push(transformCodexApplyPatchBridgeSseEvent(state.__ccrCodexPatchBridgeSsePending));
     state.__ccrCodexPatchBridgeSsePending = "";

--- a/packages/core/src/gateway/features/hosted-web-search/response-transform.ts
+++ b/packages/core/src/gateway/features/hosted-web-search/response-transform.ts
@@ -1,4 +1,5 @@
 import { Readable, Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import type { GatewayProviderProtocol } from "@ccr/core/contracts/app";
 import { isRecord, numberValue, stringValue } from "@ccr/core/gateway/internal/value";
 import { formatError } from "@ccr/core/gateway/http/io";
@@ -65,6 +66,7 @@ function hostedWebSearchProtocolSseStream(
   const recordsPromise = context.records?.length
     ? Promise.resolve(context.records)
     : selectHostedWebSearchProtocolRecords(context, integration);
+  const decoder = new StringDecoder("utf8");
   let records: BrowserWebSearchProtocolRecord[] | undefined;
   let pending = "";
   let passThrough = false;
@@ -84,7 +86,7 @@ function hostedWebSearchProtocolSseStream(
 
   return input.pipe(new Transform({
     transform(chunk, _encoding, callback) {
-      const text = chunk.toString();
+      const text = decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       const rawText = pending + text;
       void (async () => {
         await ensureRecords();
@@ -103,6 +105,7 @@ function hostedWebSearchProtocolSseStream(
       }).finally(() => callback());
     },
     flush(callback) {
+      pending += decoder.end();
       void (async () => {
         await ensureRecords();
         if (passThrough || !records) {
@@ -263,6 +266,7 @@ function anthropicHostedWebSearchProtocolSseStream(
   const recordsPromise = context.records?.length
     ? Promise.resolve(context.records)
     : selectHostedWebSearchProtocolRecords(context, integration);
+  const decoder = new StringDecoder("utf8");
   let records: BrowserWebSearchProtocolRecord[] | undefined;
   let pending = "";
   let passThrough = false;
@@ -286,7 +290,7 @@ function anthropicHostedWebSearchProtocolSseStream(
 
   return input.pipe(new Transform({
     transform(chunk, _encoding, callback) {
-      const text = chunk.toString();
+      const text = decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       const rawText = pending + text;
       void (async () => {
         await ensureRecords();
@@ -305,6 +309,7 @@ function anthropicHostedWebSearchProtocolSseStream(
       }).finally(() => callback());
     },
     flush(callback) {
+      pending += decoder.end();
       void (async () => {
         await ensureRecords();
         if (passThrough || !records) {

--- a/packages/core/test/unit/gateway/sse-utf8-chunk-boundary.test.mjs
+++ b/packages/core/test/unit/gateway/sse-utf8-chunk-boundary.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test from "node:test";
+import { codexMultiAgentBridgeResponseStream } from "@ccr/core/gateway/features/codex-multi-agent-bridge.ts";
+import { codexApplyPatchBridgeResponseStream } from "@ccr/core/gateway/features/codex-patch-bridge.ts";
+import { hostedWebSearchProtocolResponseStream } from "@ccr/core/gateway/features/hosted-web-search/index.ts";
+
+const sseHeaders = () => new Headers({ "content-type": "text/event-stream" });
+
+const webSearchRecords = [{
+  engine: "test",
+  query: "北京天气",
+  results: [{ content: "多云", snippet: "多云", title: "天气", url: "https://example.test/weather" }],
+  searchUrl: "https://example.test/search"
+}];
+
+function hostedWebSearchContext(protocol) {
+  return {
+    maxUses: 1,
+    protocol,
+    queryHint: "北京天气",
+    records: webSearchRecords,
+    requestId: "req-utf8",
+    sinceMs: 0,
+    toolName: "web_search"
+  };
+}
+
+async function streamText(stream) {
+  const chunks = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// Feeds `text` through `makeStream` once per interior byte offset of the first
+// multi-byte character, so at least one chunk boundary always lands inside it.
+async function assertSurvivesEveryByteSplit(makeStream, text, marker) {
+  const bytes = Buffer.from(text, "utf8");
+  const markerBytes = Buffer.from(marker, "utf8");
+  const markerStart = bytes.indexOf(markerBytes);
+  assert.ok(markerStart >= 0, "marker must be present in the event");
+  assert.ok(markerBytes.length > 1, "marker must be a multi-byte character");
+
+  for (let offset = 1; offset < markerBytes.length; offset += 1) {
+    const splitAt = markerStart + offset;
+    const output = await streamText(makeStream(
+      Readable.from([bytes.subarray(0, splitAt), bytes.subarray(splitAt)])
+    ));
+    assert.equal(
+      output.includes("�"),
+      false,
+      `split at byte ${splitAt} produced U+FFFD: ${JSON.stringify(output)}`
+    );
+    assert.equal(output, text, `split at byte ${splitAt} changed the event`);
+  }
+}
+
+test("Codex multi-agent bridge SSE keeps multi-byte characters split across chunks", async () => {
+  await assertSurvivesEveryByteSplit(
+    (input) => codexMultiAgentBridgeResponseStream(input, sseHeaders()),
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"北京今天多云"}\n\n',
+    "北"
+  );
+});
+
+test("Codex apply_patch bridge SSE keeps multi-byte characters split across chunks", async () => {
+  await assertSurvivesEveryByteSplit(
+    (input) => codexApplyPatchBridgeResponseStream(input, sseHeaders()),
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"北京今天多云"}\n\n',
+    "北"
+  );
+});
+
+test("Hosted web search Anthropic SSE keeps multi-byte characters split across chunks", async () => {
+  await assertSurvivesEveryByteSplit(
+    (input) => hostedWebSearchProtocolResponseStream(
+      input,
+      sseHeaders(),
+      hostedWebSearchContext("anthropic_messages"),
+      undefined
+    ),
+    'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"北京今天多云"}}\n\n',
+    "北"
+  );
+});
+
+test("Hosted web search OpenAI Responses SSE keeps multi-byte characters split across chunks", async () => {
+  await assertSurvivesEveryByteSplit(
+    (input) => hostedWebSearchProtocolResponseStream(
+      input,
+      sseHeaders(),
+      hostedWebSearchContext("openai_responses"),
+      undefined
+    ),
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"delta":"北京今天多云"}\n\n',
+    "北"
+  );
+});
+
+test("Codex bridges keep emoji surrogate pairs split across chunks", async () => {
+  const event = 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"done 🎉"}\n\n';
+  await assertSurvivesEveryByteSplit(
+    (input) => codexMultiAgentBridgeResponseStream(input, sseHeaders()),
+    event,
+    "🎉"
+  );
+  await assertSurvivesEveryByteSplit(
+    (input) => codexApplyPatchBridgeResponseStream(input, sseHeaders()),
+    event,
+    "🎉"
+  );
+});


### PR DESCRIPTION
## The shortest version

`packages/core/src/gateway/request/pipeline.ts` chains five SSE response
transforms. All five run the same loop: accumulate text, split it on
`/\r?\n\r?\n/`, hand each block to a rewriter, push it on.

Four of them decode each upstream chunk with `chunk.toString()`. The fifth,
`anthropic-response-model.ts:25`, decodes through a `node:string_decoder`
`StringDecoder`.

Feed all five the identical event, split at the identical byte — inside the
3-byte sequence for `北`:

```
--- codexMultiAgentBridgeResponseStream (codex-multi-agent-bridge.ts:350)
    out : "...\"delta\":\"���京今天多云\"}\n\n"
    U+FFFD present: true   round-trip equal: false
--- codexApplyPatchBridgeResponseStream (codex-patch-bridge.ts:421)
    U+FFFD present: true   round-trip equal: false
--- hostedWebSearchProtocolResponseStream / anthropic (response-transform.ts:289)
    U+FFFD present: true   round-trip equal: false
--- hostedWebSearchProtocolResponseStream / openai_responses (response-transform.ts:87)
    U+FFFD present: true   round-trip equal: false
--- CONTROL rewriteAnthropicMessageStartModelStream (anthropic-response-model.ts:25, StringDecoder)
    U+FFFD present: false   round-trip equal: true

Corrupted transforms: 4/4
```

Same pipeline, same loop, same input, same cut. The one with the decoder comes
out byte-for-byte identical. The other four destroy the character.

This PR gives the other four the same decoder.

## What actually happens

`Buffer.prototype.toString("utf8")` decodes the buffer it is given and nothing
else. When a chunk boundary lands inside a multi-byte sequence, the tail of
chunk N and the head of chunk N+1 are each decoded as an invalid fragment, and
each fragment becomes `U+FFFD`. `北` (`E5 8C 97`) split after `E5` comes back
as three replacement characters.

The `pending` buffer these transforms already keep does not help. It joins
partial SSE **blocks**, not partial **characters** — by the time bytes reach it
they have already been decoded and lost.

The failure is silent. `U+FFFD` is a perfectly legal character inside a JSON
string, so `JSON.parse` succeeds, the event validates, the rewriter re-emits it,
and the replacement characters go to the client. Nothing logs, nothing 400s.

Any non-ASCII output is affected: CJK, Cyrillic, accented Latin, emoji.

**The worst case is the apply_patch bridge.** `codex-patch-bridge.ts` carries
`apply_patch` payloads — file contents. A character corrupted there is not a
cosmetic glitch in a chat transcript; it is written to disk.

## Reproduction

### 1. End to end over real HTTP

Built the way `pipeline.ts` builds it — `fetch()` →
`Readable.fromWeb(upstreamResponse.body)` → transform. A local server writes the
event in two `res.write()` calls with a 50 ms gap, split inside `北`:

```
== main @ 34da9b6 ==
upstream delivered 2 chunk(s), sizes: 87, 21
split byte offset: 87 (inside the 3-byte sequence for 北)
client sees      : "...\"delta\":\"���京今天多云\"}\n\n"
U+FFFD present   : true
byte-exact       : false

== with this patch ==
upstream delivered 2 chunk(s), sizes: 87, 21
split byte offset: 87 (inside the 3-byte sequence for 北)
client sees      : "...\"delta\":\"北京今天多云\"}\n\n"
U+FFFD present   : false
byte-exact       : true
```

### 2. At the transform boundary

The block quoted at the top of this PR, including the control.

## The fix

`+35 / −8` across three files. Each transform owns one `StringDecoder` for its
lifetime, writes every chunk through it, and drains `decoder.end()` in `flush`
so a truncated stream still emits whatever the decoder was holding.

No platform branches, no behaviour change outside decoding, no new dependency —
`node:string_decoder` is already imported in this package by
`anthropic-response-model.ts`, `request-log-store.ts`, `request-log-runtime.ts`
and `request-log-worker.ts`.

I deliberately left `contextArchiveHandoffResponseStream` and
`codexCompactResponseStream` (`gateway/context-archive.ts:549,576`) alone: they
buffer the whole body and do a single `Buffer.concat().toString()`, which is
already correct.

## Tests

New file: `packages/core/test/unit/gateway/sse-utf8-chunk-boundary.test.mjs`,
5 tests.

They do not pick one convenient cut. For each case the helper splits at **every
interior byte offset** of the multi-byte character — 2 cuts for `北` (3 bytes),
3 for `🎉` (4 bytes) — and asserts both that no `U+FFFD` appears and that the
output is byte-identical to the input.

On unmodified `main` (`34da9b6`), all five fail, each naming the byte that broke
it:

```
✖ Codex multi-agent bridge SSE keeps multi-byte characters split across chunks
  AssertionError: split at byte 87 produced U+FFFD: "...\"delta\":\"���京今天多云\"}\n\n"
✖ Codex apply_patch bridge SSE keeps multi-byte characters split across chunks
  AssertionError: split at byte 87 produced U+FFFD
✖ Hosted web search Anthropic SSE keeps multi-byte characters split across chunks
  AssertionError: split at byte 111 produced U+FFFD
✖ Hosted web search OpenAI Responses SSE keeps multi-byte characters split across chunks
  AssertionError: split at byte 104 produced U+FFFD
✖ Codex bridges keep emoji surrogate pairs split across chunks
  AssertionError: split at byte 92 produced U+FFFD: "...\"delta\":\"done ����\"}\n\n"

ℹ pass 0  ℹ fail 5
```

With the patch: `ℹ pass 5  ℹ fail 0`.

## Verification

Windows 11, Node 24.14.1, base `34da9b6`. Core unit scope, same environment on
both sides, the source change stashed to produce the "before" run:

|         | tests | pass | fail |
|---------|-------|------|------|
| before  | 548   | 496  | 39   |
| after   | 548   | 501  | 34   |

Comparing the two **failure sets**, not the counts:

- recovered: exactly the 5 tests this PR adds
- newly failing: **0**
- unchanged: 34, identical set before and after

`npx tsc --noEmit` → clean. `test:architecture` (the package-boundary
contract, which is what would object to where the new test file lives) → 4
passed, 0 failed. `git diff --check` clean.

## What I did not verify

- **I did not run `npm run test:core` through the repo's own runner.**
  `build/run-tests.mjs` does `import electron from "electron"` at module scope
  and I installed with `--ignore-scripts`, so there is no Electron binary here.
  I replicated its compiled-test discovery and its env vars in a standalone
  runner instead.
- **`better-sqlite3` was therefore never compiled.** Some of the 34 pre-existing
  failures are an artefact of my environment, not of `main`. The **set**
  comparison above is still sound — identical environment on both sides — but
  the absolute numbers are not comparable to a clean checkout, and I am not
  claiming they are.
- **I only ran `--scope unit`.** Integration, ui, electron and cli scopes were
  not run.
- **I did not observe this against a live provider.** My HTTP repro splits the
  character on purpose. Whether a given upstream actually lands a chunk boundary
  inside a multi-byte sequence depends on MTU, TLS record framing and socket
  coalescing, and I did not measure that. What I can say is that the transform
  contract makes no guarantee either way, and that this repository already
  treats the risk as real — `anthropic-response-model.ts` uses a `StringDecoder`
  for exactly this reason.
- Windows 11 / Node 24.14.1 only. Not tested on macOS or Linux.

## Risk

Three edges worth stating rather than hiding:

1. **Chunking changes in `passThrough` mode.** In
   `hostedWebSearchProtocolSseStream`, when the bridge decides to pass through,
   the decoder now holds an incomplete trailing sequence until the next chunk.
   The aggregate output is unchanged; only where the chunk edges fall moves.
   For `text/event-stream` that is inert, and `flush` drains `decoder.end()`.
2. **The codex bridges store the decoder as a `__ccr…` property on the
   `Transform`**, following the convention those functions already used for
   `pending`. If a `Transform` were ever reused across responses the decoder
   would carry state — but so would `pending` today, so this introduces no new
   failure mode.
3. **A truncated stream now surfaces the decoder's held bytes** via
   `decoder.end()` rather than silently dropping them. That is the same
   behaviour `anthropic-response-model.ts` already has.

## Notes

No linked issue: I searched open issues for 乱码, garbled, mojibake, encoding
and UTF-8 and found nothing reporting this, so there is nothing for this to
close. I found it by comparing the five transforms in the response chain against
each other.
