### PR TITLE
feat: add TrustedRouter provider preset

### DIFF
--- a/packages/core/src/providers/presets/index.ts
+++ b/packages/core/src/providers/presets/index.ts
@@ -17,6 +17,7 @@ import { qiniuAiProviderPreset } from "@ccr/core/providers/presets/qiniu-ai/inde
 import { runApiProviderPreset } from "@ccr/core/providers/presets/runapi/index";
 import { siliconFlowProviderPreset } from "@ccr/core/providers/presets/siliconflow/index";
 import { teamoRouterProviderPreset } from "@ccr/core/providers/presets/teamorouter/index";
+import { trustedRouterProviderPreset } from "@ccr/core/providers/presets/trustedrouter/index";
 import { unity2ProviderPreset } from "@ccr/core/providers/presets/unity2/index";
 import {
   xiaomiMimoProviderPreset,
@@ -44,6 +45,7 @@ export const providerPresets: ProviderPreset[] = [
   anthropicProviderPreset,
   geminiProviderPreset,
   openRouterProviderPreset,
+  trustedRouterProviderPreset,
   nvidiaProviderPreset,
   deepSeekProviderPreset,
   xiaomiMimoProviderPreset,

--- a/packages/core/src/providers/presets/trustedrouter/index.ts
+++ b/packages/core/src/providers/presets/trustedrouter/index.ts
@@ -1,0 +1,14 @@
+import type { ProviderPreset } from "@ccr/core/providers/presets/types";
+
+export const trustedRouterProviderPreset: ProviderPreset = {
+  aliases: ["trustedrouter"],
+  endpoints: [
+    {
+      baseUrl: "https://api.trustedrouter.com/v1",
+      protocols: ["openai_chat_completions"]
+    }
+  ],
+  id: "trustedrouter",
+  name: "TrustedRouter",
+  websiteUrl: "https://trustedrouter.com/"
+};


### PR DESCRIPTION
Adds a provider preset for TrustedRouter, an OpenAI-compatible router — one key reaches models from OpenAI, Anthropic, Google, DeepSeek and others, with per-request routing and failover.

Base URL `https://api.trustedrouter.com/v1`, protocol `openai_chat_completions`.

Two deliberate omissions:

- **No `account` connector.** `https://api.trustedrouter.com/v1/credits` exists but requires auth, and I could not verify the response shape, so a guessed JSONPath meter mapping would ship a broken balance readout. `account` is optional in `ProviderPreset` and several presets (anthropic, deepseek, bailian, code0, fenno…) omit it. Happy to add it in a follow-up once the shape is confirmed.
- **No `officialApiKeyPatterns`.** TrustedRouter keys are not on a documented fixed prefix, and a wrong pattern would flag valid keys as unsafe.

No icon entry in `providerPresetIconUrls` either — that map is `Record<string, string>` rather than exhaustive, so the preset works without one. Glad to add the asset if you'd like it.

Verified: `tsc --noEmit` clean. `npm run test:core` has one failure, `RequestLogStore bounded heap regression`, which reproduces identically on unmodified `main` (checked by stashing this change and re-running) — it's a memory-bounded observability test, unrelated to presets.
