### PR TITLE
fix(ui): keep hand-written provider fields when saving from the dialog

### DIFF
--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -25,7 +25,7 @@ import {
   persistLanguagePreference, PluginInstallCandidate, PluginMarketplaceEntry, PluginRoutingConfigTarget, PluginSettingsDraft, presetCapabilitiesFromDraft,
   probeProviderCandidates, probeProviderDeepLinkPayload, profileAgentLabel, profileAgentOptionsForRuntime, profileDraftWithDetectedAppPath, profileEnvRowsForAgent, ProfileConfig, ProfileOpenSurface, ProfileRuntimeStatus, profileConfigFromDraft, providerAccountApiKeySafetyIssue,
   profileOpenCommandFallback, profileOpenSurfaces, ProviderAccountSnapshot, providerApiKeySafetyIssue, ProviderConnectivityCheckReport, ProviderDeepLinkPayload, ProviderDeepLinkRequest, providerIdentitySafetyIssue, providerProbeCandidates,
-  providerAutoFetchKnownModelsForSave, providerBaseUrl, providerCapabilitiesForProtocols, providerCapabilitiesForSave, providerConnectivityApiKeyFromDraft, providerConnectivityProviderPlugins, providerGlobalBaseUrlForProbe, providerProbeCandidatesApiKeySafetyIssue, providerProbeHasSupportedProtocol, providerProbeInputKey, providerProtocolOptions, providerSelectableProtocolsFromProbe, ProxyNetworkSnapshot,
+  providerAutoFetchKnownModelsForSave, providerBaseUrl, providerCapabilitiesForProtocols, providerCapabilitiesForSave, providerConnectivityApiKeyFromDraft, providerConnectivityProviderPlugins, providerGlobalBaseUrlForProbe, providerManualFieldsForSave, providerProbeCandidatesApiKeySafetyIssue, providerProbeHasSupportedProtocol, providerProbeInputKey, providerProtocolOptions, providerSelectableProtocolsFromProbe, ProxyNetworkSnapshot,
   ProxyStatus, readLanguagePreference, RequestLogListFilter, RequestLogPage, ResolvedLanguage,
   ResolvedTheme, resolvePluginInstallPlan, resolveProviderDeepLinkCatalogModels, removeLocalAgentProviderPluginsForProvider, RouterRule, routingRuleFromDraft, SettingsPageId,
   setProviderPresets, splitLines, translateAppErrorMessage, translateText, TrayBalanceProgressConfig, TrayWidgetConfig,
@@ -1709,6 +1709,7 @@ function App() {
       nextBaseUrl: baseUrl
     });
     const provider: GatewayProviderConfig = {
+      ...providerManualFieldsForSave(existingProvider),
       api_base_url: normalizeProviderBaseUrl(baseUrl),
       api_key: primaryApiKey,
       autoFetchModels: providerDraft.autoFetchModels || undefined,

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -1993,6 +1993,47 @@ export function providerCapabilitiesForSave(
   );
 }
 
+export type ProviderManualFields = Pick<
+  GatewayProviderConfig,
+  "billing" | "extraBody" | "extraHeaders" | "provider" | "transformer"
+>;
+
+/**
+ * Provider fields the setup dialog cannot edit.
+ *
+ * Saving rebuilds the provider from the dialog draft, so a field the form does
+ * not know about is dropped unless it is carried over explicitly. These fields
+ * only ever come from a hand-written config, and losing them is silent: the
+ * provider keeps working, just without the upstream body, headers or
+ * transformers it was configured with.
+ *
+ * The legacy `apiKey` / `apikey` / `baseUrl` / `baseurl` aliases are deliberately
+ * not carried over — the form writes the canonical `api_key` / `api_base_url`,
+ * and a stale alias would shadow the value the user just typed.
+ */
+export function providerManualFieldsForSave(
+  existingProvider: GatewayProviderConfig | undefined
+): ProviderManualFields {
+  if (!existingProvider) {
+    return {};
+  }
+  const preserved: ProviderManualFields = {
+    billing: existingProvider.billing,
+    extraBody: existingProvider.extraBody,
+    extraHeaders: existingProvider.extraHeaders,
+    provider: existingProvider.provider,
+    transformer: existingProvider.transformer
+  };
+  // Keep the saved provider free of keys it never had, so an unrelated edit does
+  // not show up as a config change.
+  for (const field of Object.keys(preserved) as Array<keyof ProviderManualFields>) {
+    if (preserved[field] === undefined) {
+      delete preserved[field];
+    }
+  }
+  return preserved;
+}
+
 export function providerGlobalBaseUrlForProbe(
   inputBaseUrl: string,
   _probe: GatewayProviderProbeResult | undefined,

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -1976,6 +1976,47 @@ export function providerCapabilitiesForSave(
   );
 }
 
+export type ProviderManualFields = Pick<
+  GatewayProviderConfig,
+  "billing" | "extraBody" | "extraHeaders" | "provider" | "transformer"
+>;
+
+/**
+ * Provider fields the setup dialog cannot edit.
+ *
+ * Saving rebuilds the provider from the dialog draft, so a field the form does
+ * not know about is dropped unless it is carried over explicitly. These fields
+ * only ever come from a hand-written config, and losing them is silent: the
+ * provider keeps working, just without the upstream body, headers or
+ * transformers it was configured with.
+ *
+ * The legacy `apiKey` / `apikey` / `baseUrl` / `baseurl` aliases are deliberately
+ * not carried over — the form writes the canonical `api_key` / `api_base_url`,
+ * and a stale alias would shadow the value the user just typed.
+ */
+export function providerManualFieldsForSave(
+  existingProvider: GatewayProviderConfig | undefined
+): ProviderManualFields {
+  if (!existingProvider) {
+    return {};
+  }
+  const preserved: ProviderManualFields = {
+    billing: existingProvider.billing,
+    extraBody: existingProvider.extraBody,
+    extraHeaders: existingProvider.extraHeaders,
+    provider: existingProvider.provider,
+    transformer: existingProvider.transformer
+  };
+  // Keep the saved provider free of keys it never had, so an unrelated edit does
+  // not show up as a config change.
+  for (const field of Object.keys(preserved) as Array<keyof ProviderManualFields>) {
+    if (preserved[field] === undefined) {
+      delete preserved[field];
+    }
+  }
+  return preserved;
+}
+
 export function providerGlobalBaseUrlForProbe(
   inputBaseUrl: string,
   _probe: GatewayProviderProbeResult | undefined,

--- a/packages/ui/test/integration/providers.test.ts
+++ b/packages/ui/test/integration/providers.test.ts
@@ -31,6 +31,7 @@ import {
   parseProviderAccountDraft,
   providerBrowserConnectorFromDraft,
   providerGlobalBaseUrlForProbe,
+  providerManualFieldsForSave,
   providerPresetIconUrls,
   providerProtocolOptions,
   providerProbeCandidates,
@@ -142,6 +143,54 @@ test("provider save keeps explicit secondary media origins when the base URL is 
   assert.deepEqual(
     providerCapabilitiesForSave(current, media, "https://chat.example/v1/", "https://chat.example/v1"),
     [...current, ...media]
+  );
+});
+
+test("provider save keeps hand-written fields the dialog cannot edit", () => {
+  const existing = {
+    api_base_url: "https://example.test/v1",
+    api_key: "sk-old",
+    billing: { currency: "USD" },
+    extraBody: { default: { reasoning_effort: "high" } },
+    extraHeaders: { "x-tenant": "acme" },
+    models: ["model-a"],
+    name: "example",
+    provider: "openai",
+    transformer: { use: ["openrouter"] },
+    type: "openai_chat_completions"
+  };
+
+  assert.deepEqual(providerManualFieldsForSave(existing), {
+    billing: existing.billing,
+    extraBody: existing.extraBody,
+    extraHeaders: existing.extraHeaders,
+    provider: existing.provider,
+    transformer: existing.transformer
+  });
+});
+
+test("provider save drops legacy credential aliases so the edited values win", () => {
+  const existing = {
+    apiKey: "sk-legacy",
+    apikey: "sk-legacy",
+    baseUrl: "https://legacy.test/v1",
+    baseurl: "https://legacy.test/v1",
+    models: ["model-a"],
+    name: "example"
+  };
+
+  const preserved = providerManualFieldsForSave(existing) as Record<string, unknown>;
+
+  for (const alias of ["apiKey", "apikey", "baseUrl", "baseurl"]) {
+    assert.equal(alias in preserved, false, `${alias} must not survive a dialog save`);
+  }
+});
+
+test("provider save does not invent keys the provider never had", () => {
+  assert.deepEqual(providerManualFieldsForSave(undefined), {});
+  assert.deepEqual(
+    providerManualFieldsForSave({ models: ["model-a"], name: "example" }),
+    {}
   );
 });
 

--- a/tests/e2e/cli-web-runtime.ts
+++ b/tests/e2e/cli-web-runtime.ts
@@ -1,0 +1,142 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import type { Readable } from "node:stream";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+const projectRoot = path.resolve(__dirname, "..", "..");
+const cliPath = path.join(projectRoot, "packages", "cli", "dist", "main", "cli.js");
+const host = "127.0.0.1";
+const startupTimeoutMs = 10_000;
+const shutdownTimeoutMs = 5_000;
+
+export type CliWebChild = ChildProcessByStdio<null, Readable, Readable>;
+
+export type CliWebRuntime = {
+  baseUrl: string;
+  child: CliWebChild;
+  testHome: string;
+  token: string;
+};
+
+export async function startCliWebServer(authToken: string): Promise<CliWebRuntime> {
+  const port = await findAvailablePort();
+  const testHome = mkdtempSync(path.join(os.tmpdir(), "ccr-playwright-home-"));
+  const child = spawn(process.execPath, [
+    cliPath,
+    "serve",
+    "--no-gateway",
+    "--host",
+    host,
+    "--port",
+    String(port),
+    "--no-open"
+  ], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      CCR_INTERNAL_APP_DATA_DIR: path.join(testHome, "app-data"),
+      CCR_INTERNAL_HOME_DIR: testHome,
+      CCR_INTERNAL_USER_DATA_DIR: path.join(testHome, "user-data"),
+      CCR_WEB_AUTH_TOKEN: authToken,
+      HOME: testHome
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const service = await new Promise<{ baseUrl: string; token: string }>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`CCR web service did not start within ${startupTimeoutMs}ms.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, startupTimeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout.off("data", onStdout);
+      child.off("exit", onExit);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`CCR web service exited during startup code=${code ?? "null"} signal=${signal ?? "null"}.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    };
+    const onStdout = () => {
+      const match = stdout.match(/CCR web management is running at (http:\/\/[^\s]+)/);
+      if (!match) {
+        return;
+      }
+      cleanup();
+      const url = new URL(match[1]);
+      resolve({
+        baseUrl: `${url.protocol}//${url.host}`,
+        token: url.searchParams.get("ccr_web_token") ?? ""
+      });
+    };
+
+    child.on("exit", onExit);
+    child.stdout.on("data", onStdout);
+  });
+
+  if (!service.token) {
+    await stopCliWebServer(child);
+    rmSync(testHome, { force: true, recursive: true });
+    throw new Error("CCR web service started without a web auth token.");
+  }
+
+  return {
+    ...service,
+    child,
+    testHome
+  };
+}
+
+export async function stopCliWebServer(child: CliWebChild): Promise<void> {
+  if (child.exitCode !== null) {
+    return;
+  }
+
+  child.kill("SIGINT");
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve();
+    }, shutdownTimeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+export async function disposeCliWebRuntime(runtime: CliWebRuntime): Promise<void> {
+  await stopCliWebServer(runtime.child);
+  rmSync(runtime.testHome, { force: true, recursive: true });
+}
+
+async function findAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : undefined;
+      server.close(() => {
+        if (!port) {
+          reject(new Error("Failed to allocate a local test port."));
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}

--- a/tests/e2e/cli-web.spec.ts
+++ b/tests/e2e/cli-web.spec.ts
@@ -1,39 +1,19 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-import { spawn, type ChildProcessByStdio } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
-import type { Readable } from "node:stream";
-import net from "node:net";
-import os from "node:os";
-import path from "node:path";
+import { disposeCliWebRuntime, startCliWebServer, type CliWebRuntime } from "./cli-web-runtime";
 
-const projectRoot = path.resolve(__dirname, "..", "..");
-const cliPath = path.join(projectRoot, "packages", "cli", "dist", "main", "cli.js");
-const host = "127.0.0.1";
 const cliWebAuthToken = "playwright-cli-web-auth-token";
-const startupTimeoutMs = 10_000;
-const shutdownTimeoutMs = 5_000;
-
-type CliWebRuntime = {
-  baseUrl: string;
-  child: CliWebChild;
-  testHome: string;
-  token: string;
-};
-
-type CliWebChild = ChildProcessByStdio<null, Readable, Readable>;
 
 let runtime: CliWebRuntime | undefined;
 
 test.beforeAll(async () => {
-  runtime = await startCliWebServer();
+  runtime = await startCliWebServer(cliWebAuthToken);
 });
 
 test.afterAll(async () => {
   if (!runtime) {
     return;
   }
-  await stopCliWebServer(runtime.child);
-  rmSync(runtime.testHome, { force: true, recursive: true });
+  await disposeCliWebRuntime(runtime);
   runtime = undefined;
 });
 
@@ -104,122 +84,6 @@ async function expectStaticAsset(
   expect(response.status()).toBe(200);
   expect(response.headers()["content-type"]).toContain(expectedContentType);
   expect(Number(response.headers()["content-length"] ?? "0")).toBeGreaterThan(0);
-}
-
-async function startCliWebServer(): Promise<CliWebRuntime> {
-  const port = await findAvailablePort();
-  const testHome = mkdtempSync(path.join(os.tmpdir(), "ccr-playwright-home-"));
-  const child = spawn(process.execPath, [
-    cliPath,
-    "serve",
-    "--no-gateway",
-    "--host",
-    host,
-    "--port",
-    String(port),
-    "--no-open"
-  ], {
-    cwd: projectRoot,
-    env: {
-      ...process.env,
-      CCR_INTERNAL_APP_DATA_DIR: path.join(testHome, "app-data"),
-      CCR_INTERNAL_HOME_DIR: testHome,
-      CCR_INTERNAL_USER_DATA_DIR: path.join(testHome, "user-data"),
-      CCR_WEB_AUTH_TOKEN: cliWebAuthToken,
-      HOME: testHome
-    },
-    stdio: ["ignore", "pipe", "pipe"]
-  });
-
-  let stdout = "";
-  let stderr = "";
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  child.stdout.on("data", (chunk) => {
-    stdout += chunk;
-  });
-  child.stderr.on("data", (chunk) => {
-    stderr += chunk;
-  });
-
-  const service = await new Promise<{ baseUrl: string; token: string }>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error(`CCR web service did not start within ${startupTimeoutMs}ms.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
-    }, startupTimeoutMs);
-
-    const cleanup = () => {
-      clearTimeout(timer);
-      child.stdout.off("data", onStdout);
-      child.off("exit", onExit);
-    };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      reject(new Error(`CCR web service exited during startup code=${code ?? "null"} signal=${signal ?? "null"}.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
-    };
-    const onStdout = () => {
-      const match = stdout.match(/CCR web management is running at (http:\/\/[^\s]+)/);
-      if (!match) {
-        return;
-      }
-      cleanup();
-      const url = new URL(match[1]);
-      resolve({
-        baseUrl: `${url.protocol}//${url.host}`,
-        token: url.searchParams.get("ccr_web_token") ?? ""
-      });
-    };
-
-    child.on("exit", onExit);
-    child.stdout.on("data", onStdout);
-  });
-
-  if (!service.token) {
-    await stopCliWebServer(child);
-    rmSync(testHome, { force: true, recursive: true });
-    throw new Error("CCR web service started without a web auth token.");
-  }
-
-  return {
-    ...service,
-    child,
-    testHome
-  };
-}
-
-async function stopCliWebServer(child: CliWebChild): Promise<void> {
-  if (child.exitCode !== null) {
-    return;
-  }
-
-  child.kill("SIGINT");
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-      resolve();
-    }, shutdownTimeoutMs);
-    child.once("exit", () => {
-      clearTimeout(timer);
-      resolve();
-    });
-  });
-}
-
-async function findAvailablePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.on("error", reject);
-    server.listen(0, host, () => {
-      const address = server.address();
-      const port = typeof address === "object" && address ? address.port : undefined;
-      server.close(() => {
-        if (!port) {
-          reject(new Error("Failed to allocate a local test port."));
-          return;
-        }
-        resolve(port);
-      });
-    });
-  });
 }
 
 function requireRuntime(): CliWebRuntime {

--- a/tests/e2e/provider-edit.spec.ts
+++ b/tests/e2e/provider-edit.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test, type Page } from "@playwright/test";
 import { disposeCliWebRuntime, startCliWebServer, type CliWebRuntime } from "./cli-web-runtime";
 
+// The web UI defaults to the system language, and this suite asserts strings
+// that are localized ("Providers" nav, the "Edit <name>" provider button
+// aria-label). Pin the context to English so the spec is independent of the
+// host's locale instead of hard-coding dual-language selectors.
+test.use({ locale: "en-US" });
+
 const cliWebAuthToken = "playwright-provider-edit-token";
 
 // A provider shaped like a hand-written config entry: the dialog renders none of

--- a/tests/e2e/provider-edit.spec.ts
+++ b/tests/e2e/provider-edit.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test, type Page } from "@playwright/test";
+import { disposeCliWebRuntime, startCliWebServer, type CliWebRuntime } from "./cli-web-runtime";
+
+const cliWebAuthToken = "playwright-provider-edit-token";
+
+// A provider shaped like a hand-written config entry: the dialog renders none of
+// extraBody, extraHeaders or transformer, so saving must not drop them.
+const configOnlyProvider = {
+  api_base_url: "http://127.0.0.1:9/v1",
+  api_key: "sk-config-only",
+  extraBody: { default: { reasoning_effort: "high" } },
+  extraHeaders: { "x-tenant": "acme" },
+  models: ["config-only-model"],
+  name: "config-only",
+  transformer: { use: ["openrouter"] },
+  type: "openai_chat_completions"
+};
+
+let runtime: CliWebRuntime | undefined;
+
+test.beforeAll(async () => {
+  runtime = await startCliWebServer(cliWebAuthToken);
+});
+
+test.afterAll(async () => {
+  if (!runtime) {
+    return;
+  }
+  await disposeCliWebRuntime(runtime);
+  runtime = undefined;
+});
+
+test("keeps config-only provider fields when the provider is saved from the dialog", async ({ page }) => {
+  const current = requireRuntime();
+
+  await page.goto(`${current.baseUrl}/?ccr_web_token=${current.token}`);
+  await waitForBridge(page);
+  await page.evaluate(async (provider) => {
+    const config = await window.ccr!.getConfig();
+    config.Providers = [provider];
+    await window.ccr!.saveConfig(config);
+    await window.ccr!.setOnboardingFinished?.();
+  }, configOnlyProvider);
+
+  await page.reload();
+  await waitForBridge(page);
+
+  await page.getByRole("button", { name: "Providers", exact: true }).click();
+  const editButton = page.locator(`button[aria-label="Edit ${configOnlyProvider.name}"]:visible`).first();
+  await editButton.click();
+
+  const saveButton = page.getByRole("button", { name: /^(Save|保存)$/ });
+  await expect(saveButton).toBeEnabled();
+  await saveButton.click();
+  await expect(saveButton).toBeHidden();
+
+  await expect.poll(async () => page.evaluate(async () => {
+    const config = await window.ccr!.getConfig();
+    const provider = config.Providers[0];
+    return {
+      extraBody: provider?.extraBody,
+      extraHeaders: provider?.extraHeaders,
+      transformer: provider?.transformer
+    };
+  })).toEqual({
+    extraBody: configOnlyProvider.extraBody,
+    extraHeaders: configOnlyProvider.extraHeaders,
+    transformer: configOnlyProvider.transformer
+  });
+});
+
+async function waitForBridge(page: Page): Promise<void> {
+  await page.waitForFunction(() => Boolean(window.ccr?.getConfig), undefined, { timeout: 20_000 });
+}
+
+function requireRuntime(): CliWebRuntime {
+  if (!runtime) {
+    throw new Error("CLI web runtime was not started.");
+  }
+  return runtime;
+}


### PR DESCRIPTION
## Problem

Editing a provider in the web UI silently deletes every provider field the setup dialog does not render.

`saveProvider` in `packages/ui/src/pages/home/App.tsx` builds a fresh `GatewayProviderConfig` from the dialog draft and then replaces the stored entry outright:

```ts
const provider: GatewayProviderConfig = {
  api_base_url: normalizeProviderBaseUrl(baseUrl),
  api_key: primaryApiKey,
  // ...only the fields the form knows about
};
// ...
config.Providers[providerEditIndex] = provider;
```

`GatewayProviderConfig` also carries `extraBody`, `extraHeaders`, `transformer`, `billing` and the legacy `provider` protocol alias. The backend handles all of them fine — `parseProviders` keeps them, `runtime-topology` forwards them, and the gateway reads `extraBody.default` / `extraBody.byModel[model]` — but the dialog has no field for them, so they are dropped on the next save. `enabled` is already hand-preserved from `existingProvider` on the line above, so the precedent for carrying a field over is there; the others were just missed.

The failure is silent and easy to miss:

```json
{
  "name": "sglang-think",
  "type": "openai_chat_completions",
  "api_base_url": "http://…/v1",
  "models": ["…"],
  "extraBody": { "default": { "reasoning_effort": "high" } }
}
```

Open this provider in the UI, change nothing meaningful — re-type the base URL, tick a model — and save. `extraBody` is gone. No error, no warning, and the UI looks identical because it never displayed the field in the first place. Requests keep succeeding, just without reasoning. The same applies to a `transformer` chain or `extraHeaders` needed by an upstream.

Only the dialog save path is affected. `setProviderEnabled`, the model-metadata editors and the other provider mutations all spread the existing provider and are fine.

## Fix

Carry the unmanaged fields over from the existing provider on edit, via a small pure helper next to the existing `providerCapabilitiesForSave`:

```ts
const provider: GatewayProviderConfig = {
  ...providerManualFieldsForSave(existingProvider),
  api_base_url: normalizeProviderBaseUrl(baseUrl),
  // ...
};
```

The spread comes first so every field the form does manage still wins.

Two deliberate choices:

- The legacy `apiKey` / `apikey` / `baseUrl` / `baseurl` aliases are **not** carried over. The form writes the canonical `api_key` / `api_base_url`, and a surviving alias would shadow the value the user just typed. This is why the fix is an explicit allowlist rather than `{ ...existingProvider, ... }`.
- The helper omits keys the provider never had, so an unrelated edit does not add `undefined`-valued keys to the config draft.

## Tests

Three cases added to `packages/ui/test/integration/providers.test.ts`, alongside the existing `providerCapabilitiesForSave` save-path tests: hand-written fields survive an edit, legacy credential aliases do not, and nothing is invented for a provider that never had these fields.

`npm run test:ui` (183 passing), `npm run test:architecture` and `npm run typecheck` are green.

## Follow-up, not in this PR

This restores the fields but still leaves them uneditable from the UI — `extraBody` and friends remain config-file-only, and a user has no way to see that their provider carries them. An "Advanced" JSON section in the provider dialog would close that gap; happy to open a separate PR if that direction is welcome.
