### PR TITLE
Normalize usage token conventions per source

### DIFF
--- a/packages/core/src/observability/request-log-store.ts
+++ b/packages/core/src/observability/request-log-store.ts
@@ -533,11 +533,19 @@ export class RequestLogStore {
     const responseError = normalizeFilterValue(input.error) ??
       detectSseError(responseBodyText, headerValue(responseHeaders, "content-type"));
     const bodyUsage = extractUsageFromBody(responseBodyText);
-    const usage: UsageSnapshot = normalizeUsageInputTokens(mergeUsageSnapshots(extractUsageFromBillingHeaders(input.responseHeaders), bodyUsage), {
-      path: input.path,
-      providerProtocol: input.providerProtocol,
-      usageHint: bodyUsage
-    }) ?? {};
+    // Each source carries its own cache-inclusion convention; normalize before
+    // merging (see UsageConventionSource).
+    const usage: UsageSnapshot = mergeUsageSnapshots(
+      normalizeUsageInputTokens(extractUsageFromBillingHeaders(input.responseHeaders), {
+        path: input.path,
+        providerProtocol: input.providerProtocol,
+        source: "providerBilling"
+      }),
+      normalizeUsageInputTokens(bodyUsage, {
+        path: input.path,
+        source: "responseBody"
+      })
+    ) ?? {};
     const route = splitRequestLogRouteSelector(input.fallbackModel);
     const bodyModel = requestLogRequestedModel(input.requestBody, input.path);
     const requestModel = normalizeFilterValue(input.model) ?? bodyModel;
@@ -868,10 +876,20 @@ export class RequestLogStore {
       const bodyUsage = input.responseBodyText === undefined
         ? undefined
         : extractUsageFromBody(input.responseBodyText);
-      const usage: UsageSnapshot = normalizeUsageInputTokens<UsageSnapshot>(mergeUsageSnapshots(extractUsageFromBillingHeaders(responseHeaders), bodyUsage), {
-        path: usagePath,
-        usageHint: bodyUsage
-      }) ?? {};
+      // As in record(), each source is normalized under its own convention.
+      // Raw-trace updates carry no provider protocol — it is not part of the
+      // gateway's raw-trace sync contract — so the billing headers fall back to
+      // the request path, which is only a proxy for the upstream's convention.
+      const usage: UsageSnapshot = mergeUsageSnapshots(
+        normalizeUsageInputTokens(extractUsageFromBillingHeaders(responseHeaders), {
+          path: usagePath,
+          source: "providerBilling"
+        }),
+        normalizeUsageInputTokens<UsageSnapshot>(bodyUsage, {
+          path: usagePath,
+          source: "responseBody"
+        })
+      ) ?? {};
       if (hasUsageNumbers(usage)) {
         const inputTokens = normalizeCount(usage.inputTokens);
         const outputTokens = normalizeCount(usage.outputTokens);

--- a/packages/core/src/usage/billing-sync.ts
+++ b/packages/core/src/usage/billing-sync.ts
@@ -166,8 +166,11 @@ export class GatewayBillingSynchronizer {
       outputTokens: numberValue(usage.output_tokens),
       totalTokens: numberValue(usage.total_tokens)
     }, {
+      // The gateway's own billing event, so these are the upstream provider's
+      // counters in the upstream's convention.
       path,
-      providerProtocol
+      providerProtocol,
+      source: "providerBilling"
     });
     const reportedCost = finiteNumber(cost.total);
     const input: UsageEventInput = {

--- a/packages/core/src/usage/normalization.ts
+++ b/packages/core/src/usage/normalization.ts
@@ -7,13 +7,25 @@ export type UsageTokenAccounting = {
   inputTokens?: number;
 };
 
+/**
+ * Which artefact the counts were read from. The two disagree whenever the
+ * gateway translates between formats — an Anthropic response served from an
+ * OpenAI upstream carries billing headers in the upstream's cache-inclusive
+ * convention next to a body in Anthropic's cache-exclusive one — so each has
+ * to be normalized under its own rule before the two are merged.
+ */
+export type UsageConventionSource = "providerBilling" | "responseBody";
+
+export type UsageNormalizationOptions = {
+  path?: string;
+  providerProtocol?: GatewayProviderProtocol;
+  source?: UsageConventionSource;
+  usageHint?: UsageTokenAccounting;
+};
+
 export function normalizeUsageInputTokens<T extends UsageTokenAccounting>(
   usage: T | undefined,
-  options: {
-    path?: string;
-    providerProtocol?: GatewayProviderProtocol;
-    usageHint?: UsageTokenAccounting;
-  } = {}
+  options: UsageNormalizationOptions = {}
 ): T | undefined {
   if (!usage) {
     return undefined;
@@ -37,12 +49,26 @@ export function normalizeUsageInputTokens<T extends UsageTokenAccounting>(
 
 function inputIncludesCacheTokens(
   usage: UsageTokenAccounting,
-  options: {
-    path?: string;
-    providerProtocol?: GatewayProviderProtocol;
-    usageHint?: UsageTokenAccounting;
-  }
+  options: UsageNormalizationOptions
 ): boolean | undefined {
+  if (options.source === "responseBody") {
+    // A body describes its own wire format, and the field names we parsed are
+    // the direct evidence of it. The upstream protocol is deliberately not
+    // consulted: it describes what the gateway talked to, not what it emitted,
+    // and reading a translated body under the upstream's rule subtracts the
+    // cached prefix a second time — clamping input tokens to zero on any turn
+    // where the cache hit exceeds the new input, which is most of them.
+    if (usage.inputIncludesCacheTokens !== undefined) {
+      return usage.inputIncludesCacheTokens;
+    }
+    if (options.usageHint?.inputIncludesCacheTokens !== undefined) {
+      return options.usageHint.inputIncludesCacheTokens;
+    }
+    return inputIncludesCacheTokensForPath(options.path);
+  }
+
+  // Billing headers and billing events restate the upstream provider's own
+  // counters verbatim, so the upstream protocol governs them.
   const protocolValue = inputIncludesCacheTokensForProtocol(options.providerProtocol);
   if (protocolValue !== undefined) {
     return protocolValue;

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -220,11 +220,20 @@ export class UsageStore {
   async recordCapture(input: UsageCaptureInput): Promise<void> {
     const headersUsage = extractUsageFromBillingHeaders(input.responseHeaders);
     const bodyUsage = extractUsageFromBody(input.bodyText);
-    const usage = normalizeUsageInputTokens(mergeUsageSnapshots(headersUsage, bodyUsage), {
-      path: input.path,
-      providerProtocol: input.providerProtocol,
-      usageHint: bodyUsage
-    });
+    // Normalize each source under its own convention before merging them: on a
+    // translated response the billing headers and the body state input tokens
+    // differently, and one shared rule is wrong for one of them.
+    const usage = mergeUsageSnapshots(
+      normalizeUsageInputTokens(headersUsage, {
+        path: input.path,
+        providerProtocol: input.providerProtocol,
+        source: "providerBilling"
+      }),
+      normalizeUsageInputTokens(bodyUsage, {
+        path: input.path,
+        source: "responseBody"
+      })
+    );
     const fallbackAttribution = resolveUsageModelAttribution(input.config, input.fallbackModel);
     const responseAttribution = resolveUsageResponseModelAttribution(input.config, bodyUsage?.model);
     const route = splitRouteSelector(input.fallbackModel);

--- a/packages/core/test/unit/usage/usage-normalization.test.mjs
+++ b/packages/core/test/unit/usage/usage-normalization.test.mjs
@@ -38,6 +38,96 @@ test("normalizeUsageInputTokens keeps Anthropic input tokens unchanged", () => {
   });
 });
 
+test("normalizeUsageInputTokens ignores the upstream protocol for a translated body", () => {
+  // Anthropic response served from an OpenAI upstream: the body already excludes
+  // the cached prefix, so the upstream's cache-inclusive rule must not apply.
+  const usage = normalizeUsageInputTokens(
+    {
+      cacheReadTokens: 3584,
+      inputIncludesCacheTokens: false,
+      inputTokens: 250,
+      outputTokens: 40
+    },
+    {
+      path: "/v1/messages",
+      providerProtocol: "openai_chat_completions",
+      source: "responseBody"
+    }
+  );
+
+  assert.equal(usage?.inputTokens, 250);
+});
+
+test("normalizeUsageInputTokens does not clamp a translated body to zero", () => {
+  // The failure this guards against: subtracting an already-excluded cached
+  // prefix drives input tokens negative, and the clamp reports it as 0.
+  const usage = normalizeUsageInputTokens(
+    {
+      cacheReadTokens: 260608,
+      inputIncludesCacheTokens: false,
+      inputTokens: 1888
+    },
+    {
+      path: "/v1/messages",
+      providerProtocol: "openai_chat_completions",
+      source: "responseBody"
+    }
+  );
+
+  assert.equal(usage?.inputTokens, 1888);
+});
+
+test("normalizeUsageInputTokens subtracts on billing headers from the same response", () => {
+  // Same response, other source: the gateway restates the upstream's own
+  // counters, which do include the cached prefix.
+  const usage = normalizeUsageInputTokens(
+    {
+      cacheReadTokens: 3584,
+      inputTokens: 3834,
+      outputTokens: 40
+    },
+    {
+      path: "/v1/messages",
+      providerProtocol: "openai_chat_completions",
+      source: "providerBilling"
+    }
+  );
+
+  assert.equal(usage?.inputTokens, 250);
+});
+
+test("normalizeUsageInputTokens still subtracts for a same-format body", () => {
+  // No translation: an OpenAI body from an OpenAI upstream is cache-inclusive,
+  // and the body's own fields say so.
+  const usage = normalizeUsageInputTokens(
+    {
+      cacheReadTokens: 20,
+      inputIncludesCacheTokens: true,
+      inputTokens: 100
+    },
+    { path: "/v1/chat/completions", source: "responseBody" }
+  );
+
+  assert.equal(usage?.inputTokens, 80);
+});
+
+test("normalizeUsageInputTokens uses the path when a body declares no convention", () => {
+  assert.equal(
+    normalizeUsageInputTokens(
+      { cacheReadTokens: 8, inputTokens: 50 },
+      { path: "/v1/messages", source: "responseBody" }
+    )?.inputTokens,
+    50
+  );
+  assert.equal(
+    normalizeUsageInputTokens(
+      { cacheReadTokens: 8, inputTokens: 50 },
+      { path: "/v1/chat/completions", source: "responseBody" }
+    )?.inputTokens,
+    42
+  );
+});
+
 test("normalizeUsageInputTokens falls back to path and usage hints", () => {
   assert.equal(
     normalizeUsageInputTokens(


### PR DESCRIPTION
## Problem

`normalizeUsageInputTokens` decides whether `input_tokens` already includes the cached prefix, and it asks the **upstream provider protocol** first. Both usage call sites merge the billing headers and the response body into a single snapshot and then normalize that merge once — but on a translated response the two sources use different conventions:

| Source | Convention |
| --- | --- |
| `x-gateway-billing-*` headers | The upstream provider's own counters, passed through verbatim — cache-**inclusive** for OpenAI-compatible upstreams |
| Response body | Whatever the gateway emitted — an Anthropic body is cache-**exclusive** regardless of what it was translated from |

So an Anthropic response served from an OpenAI-compatible upstream has the body's already-excluded prefix subtracted a second time.

Non-streaming responses escape by luck: the headers win the merge and *are* inclusive, so the subtraction is exactly right. Streaming responses carry **no billing headers at all**, leaving the body alone to be over-subtracted and then clamped by `Math.max(0, …)`.

## Impact

Ledger only — client-facing usage is not affected, so context sizing and gateway billing stay correct. But on a long cached conversation the recorded `input_tokens` is `0` on nearly every turn, and `buildTotals` then derives `promptTokens == cacheTokens`, pinning the dashboard cache ratio at 100%.

Measured on a deployment fronting an OpenAI-compatible upstream, replaying captured response bodies from `request_logs`:

- 391 of 394 `/v1/messages` turns were subtracted twice; 387 clamped to `0`
- 58% of real new-input tokens lost
- cache ratio reported 99.15%, by construction rather than measurement

## Fix

Tag each source with a `UsageConventionSource` and normalize the two separately before merging.

Reordering the precedence instead is **not** sufficient — it moves the defect onto the non-streaming path, which depends on the headers being reduced. That is why this splits the decision rather than rearranging it.

Raw-trace updates carry no provider protocol (it is not part of the raw-trace sync contract), so their billing headers keep falling back to the request path; only the body side changes there.

## Tests

Five cases added to `usage-normalization.test.mjs`, including the translated-body regression and the clamp-to-zero symptom. The three existing cases are unchanged and still pass.

`npm run test:core`: 584 tests, 579 pass, 3 fail. The 3 failures are pre-existing on `main` (bundled-plugin permission defaults / Claude Design plugin config) and unrelated — unpatched `main` gives 579 tests, 574 pass, the same 3 failures.