### PR TITLE
fix(fusion-vision): normalize bare-base64 imageUrl before forwarding

### DIFF
--- a/packages/core/src/mcp/fusion-vision-mcp.ts
+++ b/packages/core/src/mcp/fusion-vision-mcp.ts
@@ -757,7 +757,15 @@ async function buildImageParts(args: Record<string, unknown>, detail: "auto" | "
 
 async function imageInputToUrl(input: { base64?: string; mimeType?: string; path?: string; url?: string }): Promise<string | undefined> {
   if (input.url) {
-    return input.url;
+    const url = input.url.trim();
+    if (!url.startsWith("data:") && !/^https?:\/\//i.test(url)) {
+      // The virtual-model tool loop emits images as bare base64 in imageUrl.
+      // Strict OpenAI-compatible gateways reject that as an invalid URL (HTTP
+      // 400) while lenient ones silently accept it. Normalize to a data: URI
+      // the way the imageBase64 field already does.
+      return toDataUrl(url, input.mimeType || "image/png");
+    }
+    return url;
   }
   if (input.base64) {
     return toDataUrl(input.base64, input.mimeType || "image/png");


### PR DESCRIPTION
## What

The virtual-model tool loop hands images to `vision_understand` as a **bare base64 string** in the `imageUrl` argument. `imageInputToUrl` forwarded it verbatim, so strict OpenAI-compatible vision gateways reject the whole request:

- `gateway.theturbo.ai` → HTTP 400 "invalid URL"
- lenient gateways (e.g. maasapi anispark) happen to accept it, which masks the bug

Real-world evidence: a deployment pointed at a strict gateway hit 4× 400 during boot probing and another 400 mid-session (each ~6s wasted before the gateway refused, then a retry).

## Fix

Normalize a non-http(s), non-`data:` `imageUrl` as bare base64 in `imageInputToUrl`, reusing `toDataUrl` — the exact path the `imageBase64` field already takes. Doing it at the MCP boundary covers every source of the argument (loop-emitted and client-issued tool calls) and keeps the tool input schema unchanged.

## Notes

- `data:`-URL input and http(s) input are untouched.
- Bare base64 and its normalized `data:` URI carry identical payload bytes, so any code keying on the post-comma payload is unaffected.

## Testing

- Strict gateway: bare-base64 call previously 400, now 200 (verified against gateway.theturbo.ai).
- Lenient gateway: unchanged.