### PR TITLE
Forward session id as prompt_cache_key on openai_responses

### DIFF
--- a/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
+++ b/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
@@ -1,0 +1,104 @@
+import { isRecord, stringValue } from "@ccr/core/gateway/internal/value";
+
+type HeaderValue = string | string[] | undefined;
+
+type UpstreamRequest = {
+  body?: unknown;
+  bodyEncoding?: "bytes" | "form" | "json" | "none" | "text";
+  headers?: Record<string, string>;
+  method?: string;
+  url: string;
+};
+
+export type ResponsesSessionAffinityInput = {
+  request?: {
+    body?: unknown;
+    headers?: Record<string, HeaderValue>;
+  };
+  targetProviderConfig?: {
+    type?: string;
+  };
+  upstreamRequest: UpstreamRequest;
+};
+
+const sessionIdHeaderNames = ["x-claude-code-session-id", "x-claude-session-id"];
+
+/**
+ * Copies the Claude Code session identity onto outbound OpenAI Responses
+ * bodies. The protocol conversion emits neither `prompt_cache_key` nor
+ * `metadata.user_id`, so multi-channel Responses upstreams that pin sessions
+ * on body fields hash each turn onto a different channel and the next hop
+ * rejects channel-bound `encrypted_content` continuations. A caller-supplied
+ * non-empty `prompt_cache_key` always wins; other protocols and non-JSON
+ * bodies pass through untouched.
+ */
+export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInput): UpstreamRequest {
+  const upstreamRequest = input.upstreamRequest;
+  const providerType = input.targetProviderConfig?.type?.trim().toLowerCase();
+  if (providerType !== "openai_responses") {
+    return upstreamRequest;
+  }
+  const body = upstreamRequest.body;
+  if ((upstreamRequest.bodyEncoding ?? "json") !== "json" || !isRecord(body)) {
+    return upstreamRequest;
+  }
+
+  const inboundUserId = inboundMetadataUserId(input.request?.body);
+  const changes: Record<string, unknown> = {};
+  if (!stringValue(body.prompt_cache_key)) {
+    const sessionKey = resolveResponsesSessionKey(input.request?.headers, inboundUserId);
+    if (sessionKey) {
+      changes.prompt_cache_key = sessionKey;
+    }
+  }
+  if (inboundUserId && body.metadata === undefined) {
+    changes.metadata = { user_id: inboundUserId };
+  }
+  if (Object.keys(changes).length === 0) {
+    return upstreamRequest;
+  }
+  return {
+    ...upstreamRequest,
+    body: { ...body, ...changes }
+  };
+}
+
+/**
+ * First non-empty of the Claude Code session headers (case-insensitive),
+ * falling back to the inbound Anthropic `metadata.user_id`.
+ */
+export function resolveResponsesSessionKey(
+  headers: Record<string, HeaderValue> | undefined,
+  inboundUserId: string | undefined
+): string | undefined {
+  for (const name of sessionIdHeaderNames) {
+    const value = readHeaderValue(headers, name);
+    if (value) {
+      return value;
+    }
+  }
+  return inboundUserId;
+}
+
+function inboundMetadataUserId(body: unknown): string | undefined {
+  if (!isRecord(body) || !isRecord(body.metadata)) {
+    return undefined;
+  }
+  return stringValue(body.metadata.user_id);
+}
+
+function readHeaderValue(headers: Record<string, HeaderValue> | undefined, name: string): string | undefined {
+  for (const [headerName, headerValue] of Object.entries(headers ?? {})) {
+    if (headerName.trim().toLowerCase() !== name) {
+      continue;
+    }
+    const values = Array.isArray(headerValue) ? headerValue : [headerValue];
+    for (const value of values) {
+      const normalized = stringValue(value);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
+++ b/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
@@ -1,3 +1,6 @@
+import { applyResponsesSessionAffinity } from "@ccr/core/gateway/core-runtime/responses-session-affinity";
+import type { ResponsesSessionAffinityInput } from "@ccr/core/gateway/core-runtime/responses-session-affinity";
+
 type UpstreamRequest = {
   body: unknown;
   bodyEncoding?: "bytes" | "form" | "json" | "none" | "text";
@@ -194,6 +197,14 @@ export function createGatewayPlugin() {
             headers: mergeUpstreamProviderHeaders(input.request?.headers, input.upstreamRequest.headers),
             url: rewriteUpstreamProviderUrl(input.upstreamRequest.url, input.targetProviderConfig, input.config)
           }
+        };
+      }
+    }, {
+      key: "ccr-responses-session-affinity",
+      transformRequest(input: ResponsesSessionAffinityInput) {
+        return {
+          ok: true as const,
+          value: applyResponsesSessionAffinity(input)
         };
       }
     }]

--- a/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
+++ b/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyResponsesSessionAffinity, resolveResponsesSessionKey } from "@ccr/core/gateway/core-runtime/responses-session-affinity.ts";
+import { createGatewayPlugin } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
+
+function responsesInput(overrides = {}) {
+  return {
+    request: {
+      body: {
+        messages: [{ content: "hello", role: "user" }],
+        metadata: { user_id: "user_abc123_account__session_11112222" },
+        model: "claude-sonnet-4-5"
+      },
+      headers: {
+        "x-claude-code-session-id": "session-1111-2222"
+      }
+    },
+    targetProviderConfig: {
+      name: "multi-channel::openai_responses",
+      type: "openai_responses"
+    },
+    upstreamRequest: {
+      body: {
+        input: [],
+        instructions: "system prompt",
+        max_output_tokens: 32000,
+        model: "gpt-5.1-codex",
+        stream: true
+      },
+      bodyEncoding: "json",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      url: "https://provider.example/v1/responses"
+    },
+    ...overrides
+  };
+}
+
+test("openai_responses bodies gain prompt_cache_key from the Claude Code session header", () => {
+  const input = responsesInput();
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result.body.prompt_cache_key, "session-1111-2222");
+  assert.equal(result.body.model, "gpt-5.1-codex");
+  assert.equal(input.upstreamRequest.body.prompt_cache_key, undefined);
+});
+
+test("inbound metadata.user_id is carried onto the outbound Responses body", () => {
+  const result = applyResponsesSessionAffinity(responsesInput());
+
+  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+});
+
+test("caller-supplied prompt_cache_key is never overwritten", () => {
+  const input = responsesInput();
+  input.upstreamRequest.body.prompt_cache_key = "caller-key";
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result.body.prompt_cache_key, "caller-key");
+});
+
+test("empty prompt_cache_key is treated as missing", () => {
+  const input = responsesInput();
+  input.upstreamRequest.body.prompt_cache_key = "  ";
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result.body.prompt_cache_key, "session-1111-2222");
+});
+
+test("session headers resolve case-insensitively and prefer x-claude-code-session-id", () => {
+  const input = responsesInput();
+  input.request.headers = {
+    "X-Claude-Code-Session-ID": "code-session",
+    "x-claude-session-id": "legacy-session"
+  };
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result.body.prompt_cache_key, "code-session");
+});
+
+test("x-claude-session-id and inbound metadata.user_id are fallback key sources", () => {
+  assert.equal(
+    resolveResponsesSessionKey({ "x-claude-session-id": "legacy-session" }, "metadata-user"),
+    "legacy-session"
+  );
+  assert.equal(resolveResponsesSessionKey({}, "metadata-user"), "metadata-user");
+  assert.equal(resolveResponsesSessionKey(undefined, undefined), undefined);
+});
+
+test("non-Responses providers and non-JSON bodies pass through untouched", () => {
+  const chatInput = responsesInput({
+    targetProviderConfig: { type: "openai_chat_completions" }
+  });
+  assert.equal(applyResponsesSessionAffinity(chatInput), chatInput.upstreamRequest);
+
+  const bytesInput = responsesInput();
+  bytesInput.upstreamRequest = {
+    ...bytesInput.upstreamRequest,
+    body: Buffer.from("{}"),
+    bodyEncoding: "bytes"
+  };
+  assert.equal(applyResponsesSessionAffinity(bytesInput), bytesInput.upstreamRequest);
+});
+
+test("requests without any session key source pass through untouched", () => {
+  const input = responsesInput({
+    request: {
+      body: { messages: [] },
+      headers: { "content-type": "application/json" }
+    }
+  });
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result, input.upstreamRequest);
+});
+
+test("outbound metadata supplied by the caller is preserved", () => {
+  const input = responsesInput();
+  input.upstreamRequest.body.metadata = { user_id: "caller-user" };
+  input.upstreamRequest.body.prompt_cache_key = "caller-key";
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result, input.upstreamRequest);
+});
+
+test("gateway boundary plugin registers the session affinity hook", async () => {
+  const hooks = createGatewayPlugin().providerHooks;
+  const affinityHook = hooks.find((hook) => hook.key === "ccr-responses-session-affinity");
+  assert.ok(affinityHook);
+
+  const input = responsesInput();
+  const result = await affinityHook.transformRequest(input);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.body.prompt_cache_key, "session-1111-2222");
+});


### PR DESCRIPTION
When CCR translates Claude Code traffic to an `openai_responses` provider behind a multi-channel upstream, each turn is hashed onto a different channel because the outbound body carries no session-stable field, and the next continuation fails with `400 invalid_encrypted_content`.

This change fills `prompt_cache_key` on outbound `openai_responses` JSON bodies from the first non-empty of `x-claude-code-session-id`, `x-claude-session-id`, or the inbound Anthropic `metadata.user_id`, and it also carries `metadata.user_id` onto the outbound body when the converter left it out. A caller-supplied non-empty `prompt_cache_key` always wins, headers are matched case-insensitively, and other protocols and non-JSON bodies pass through untouched.

The logic lives in a new `ccr-responses-session-affinity` hook registered by the existing gateway boundary plugin, so it applies the same key on the first turn and every continuation without touching the protocol conversion itself.

Unit tests in `packages/core/test/unit/gateway/responses-session-affinity.test.mjs` cover the header sources and their precedence, the no-overwrite rule for caller-supplied keys, empty keys treated as missing, the `metadata.user_id` carry-over, pass-through for non-Responses providers and non-JSON bodies, and the hook wiring through `createGatewayPlugin`. `npm run typecheck`, the core unit suite, and the architecture suite pass.

Fixes #1688
