### PR TITLE
fix: preserve provider account meters during local agent import

### DIFF
--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -55,10 +55,10 @@ const percentLimitMapping = (id: string, label: string, path: string, window: st
 const claudeCodeAccountMapping: ProviderAccountMappingConfig = {
   meters: [
     percentLimitMapping("claude_five_hour_quota", "5h quota", "$.five_hour", "5h"),
-    percentLimitMapping("claude_seven_day_quota", "7d quota", "$.seven_day", "7d"),
-    percentLimitMapping("claude_oauth_apps_quota", "OAuth apps quota", "$.seven_day_oauth_apps", "7d"),
-    percentLimitMapping("claude_opus_quota", "Opus quota", "$.seven_day_opus", "7d"),
-    percentLimitMapping("claude_sonnet_quota", "Sonnet quota", "$.seven_day_sonnet", "7d"),
+    percentLimitMapping("claude_seven_day_quota", "7d quota", "$.seven_day", "weekly"),
+    percentLimitMapping("claude_oauth_apps_quota", "OAuth apps quota", "$.seven_day_oauth_apps", "weekly"),
+    percentLimitMapping("claude_opus_quota", "Opus quota", "$.seven_day_opus", "weekly"),
+    percentLimitMapping("claude_sonnet_quota", "Sonnet quota", "$.seven_day_sonnet", "weekly"),
     {
       id: "claude_extra_usage",
       kind: "quota",

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -20,6 +20,7 @@ import type {
   ProviderAccountConfig,
   ProviderAccountConnectorConfig,
   ProviderAccountHttpJsonConnectorConfig,
+  ProviderAccountMappedMeterConfig,
   ProviderAccountStandardConnectorConfig,
   ProviderAccountWebContentJsonConnectorConfig,
   ProviderCredentialConfig,
@@ -1215,7 +1216,7 @@ export function createProviderAccountDraftFromConfig(account: ProviderAccountCon
       accountRefreshIntervalMs: account.refreshIntervalMs ? String(account.refreshIntervalMs) : ""
     };
   }
-  if (jsonConnector.parser) {
+  if (jsonConnector.parser || flatDraftDropsMeters(jsonConnector.mapping.meters)) {
     return {
       ...base,
       accountConnectorsText: JSON.stringify(connectors, null, 2),
@@ -1257,6 +1258,22 @@ export function createProviderAccountDraftFromConfig(account: ProviderAccountCon
     usageSubscriptionResetPath: stringValue(subscriptionMeter?.resetAt) || "",
     usageSubscriptionUnit: stringValue(subscriptionMeter?.unit) || "tokens"
   };
+}
+
+function isBalanceDraftMeter(meter: ProviderAccountMappedMeterConfig): boolean {
+  return meter.kind === "balance" || meter.id === "balance";
+}
+
+function isSubscriptionDraftMeter(meter: ProviderAccountMappedMeterConfig): boolean {
+  return meter.kind === "subscription" || meter.id === "subscription" || meter.kind === "quota" || meter.kind === "tokens" || meter.kind === "time_window";
+}
+
+function flatDraftDropsMeters(meters: ProviderAccountMappedMeterConfig[]): boolean {
+  const balanceMeters = meters.filter(isBalanceDraftMeter);
+  const subscriptionMeters = meters.filter((meter) => !isBalanceDraftMeter(meter) && isSubscriptionDraftMeter(meter));
+  return balanceMeters.length > 1
+    || subscriptionMeters.length > 1
+    || balanceMeters.length + subscriptionMeters.length !== meters.length;
 }
 
 function mappedStringDraftValue(value: string | string[] | undefined): string {


### PR DESCRIPTION
## Problem

Importing a local agent provider through the UI silently drops most of its account meters. For Claude Code, the core returns an account config with 7 meters, but only 2 survive into the persisted config.

The "Account Balance" widget therefore only ever shows the 5-hour window for Claude subscriptions. The weekly, Opus, Sonnet, OAuth-apps and extra-usage meters are fetched correctly from the API but never make it into the config.

## Root cause

The import button calls `importLocalAgentProvider`, which correctly returns the full 7-meter mapping from `claude-code.ts`. The UI then round-trips that config through the flat Add Provider form draft:

1. `createProviderAccountDraftFromConfig` (`packages/ui/src/pages/home/shared/providers.ts:1196`) flattens the connector into draft fields. The draft can only represent **one** balance meter and **one** subscription meter, so it picks the first of each (line 1229) and discards the rest.
2. On save, `providerJsonConnectorDraftPartsFromDraft` (line 1294) rebuilds the connector from those flat fields, emitting two hardcoded meters: `id: "balance"` and `id: "subscription"` (line 1335).

The surviving quota meter is whichever came first in the list, which is the 5 hour one.

A clear fingerprint of this round-trip: the persisted connector contains `"method": "GET"`, but `claudeCodeProviderAccountConfig()` in core never sets a `method` field. It is added by the draft builder, confirming the stored object was rebuilt by the UI rather than passed through from core.

Providers using a `parser` (e.g. `kimi-code-usages`) are unaffected, because they already take the `raw` branch and build their meters at runtime. That is why Kimi correctly shows both its 5h and weekly quotas.

## Fix

`createProviderAccountDraftFromConfig` already bailed out to `raw` mode, which preserves connectors verbatim, when a connector uses a `parser`. This extends that same guard to also bail out when the mapping contains meters the flat draft cannot represent:

```ts
if (jsonConnector.parser || flatDraftDropsMeters(jsonConnector.mapping.meters)) {
```

`flatDraftDropsMeters` compares what the draft can hold (at most one balance and one subscription meter) against what the mapping actually has. The two helper predicates reuse the exact criteria already used for meter selection, so the "does it fit" check matches what the flattening would do.

This reuses the existing `raw` path rather than introducing a new mode, keeping the change small and leaving the form untouched.

A second change in `claude-code.ts`: the weekly Claude meters used `window: "7d"`, but `providerAccountMeterWindowRank` (`packages/ui/src/pages/home/components/dashboard.tsx:4029`) only recognises the literal string `"weekly"` for rank 1. With `"7d"` they fell through to rank 4, behind even the `monthly` extra-usage meter. Switching them to `"weekly"` makes the weekly quota show up as the secondary meter, matching how Z.ai and Zhipu presets already label theirs.

The two changes are in one commit because neither is useful alone: preserving the meters without the window fix ranks the weekly quota poorly, and the window fix alone is inert while the meter is dropped before persistence.

## Testing

- `npm run typecheck` passes.
- `npm run test:ui` shows 4 failures, all pre-existing on a clean `upstream/main` checkout (`AgentAnalysisView` ×2, `OverviewView`, `TrayStatusStrip`) and unrelated to this change.
- Verified the guard against real mappings: the 7-meter Claude config now takes the `raw` path, while `balance`+`subscription`, single-meter, and empty mappings keep the existing flat behaviour, so providers that worked before are unchanged.

## Note for existing users

Providers imported before this fix already have the flattened 2-meter config stored in `config.sqlite`. They need to be removed and re-imported to pick up the full mapping.