### PR TITLE
fix(gateway): strip Anthropic thinking content blocks for openai upstreams

### DIFF
--- a/packages/core/src/gateway/upstream/executor.ts
+++ b/packages/core/src/gateway/upstream/executor.ts
@@ -789,15 +789,56 @@ function usageAwareOpenAiChatAttemptBody(input: {
 }
 
 
-function stripUnsupportedOpenAiRequestParameters(body: Buffer | undefined): Buffer | undefined {
+export function stripUnsupportedOpenAiRequestParameters(body: Buffer | undefined): Buffer | undefined {
   const parsedBody = parseJsonObjectSafe(body);
-  if (!parsedBody || (!("thinking" in parsedBody) && !("reasoning_split" in parsedBody))) {
+  if (!parsedBody) {
     return body;
   }
   const next = { ...parsedBody };
-  delete next.thinking;
-  delete next.reasoning_split;
-  return serializeJsonBody(next);
+  let changed = false;
+  if ("thinking" in next || "reasoning_split" in next) {
+    delete next.thinking;
+    delete next.reasoning_split;
+    changed = true;
+  }
+  if (stripThinkingContentBlocks(next.messages)) {
+    changed = true;
+  }
+  return changed ? serializeJsonBody(next) : body;
+}
+
+/**
+ * OpenAI chat/responses upstreams reject Anthropic `thinking` content blocks in message
+ * history (HTTP 400). Remove them in place from each message's content array. Returns true
+ * when any block was removed. Non-array content (string content, already-OpenAI bodies) is
+ * left untouched.
+ */
+function stripThinkingContentBlocks(messages: unknown): boolean {
+  if (!Array.isArray(messages)) {
+    return false;
+  }
+  let changed = false;
+  for (const message of messages) {
+    if (!isRecord(message)) {
+      continue;
+    }
+    const content = message.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    const filtered = content.filter((block) => {
+      if (!isRecord(block)) {
+        return true;
+      }
+      const type = stringValue(block.type);
+      return type !== "thinking" && type !== "redacted_thinking";
+    });
+    if (filtered.length !== content.length) {
+      message.content = filtered;
+      changed = true;
+    }
+  }
+  return changed;
 }
 
 

--- a/packages/core/test/unit/gateway/upstream/executor.test.mjs
+++ b/packages/core/test/unit/gateway/upstream/executor.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { stripUnsupportedOpenAiRequestParameters } from "@ccr/core/gateway/upstream/executor.ts";
+
+function toJsonBuffer(value) {
+  return Buffer.from(JSON.stringify(value), "utf8");
+}
+
+function parseOutput(buffer) {
+  return JSON.parse(buffer.toString("utf8"));
+}
+
+test("strips Anthropic thinking and redacted_thinking content blocks from message history", () => {
+  const body = {
+    model: "claude-sonnet-5",
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal reasoning" },
+          { type: "text", text: "visible answer" }
+        ]
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "continue" }
+        ]
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "redacted" },
+          { type: "tool_use", id: "t1", name: "x", input: {} }
+        ]
+      }
+    ]
+  };
+
+  const output = parseOutput(stripUnsupportedOpenAiRequestParameters(toJsonBuffer(body)));
+  assert.deepEqual(output.messages[0].content, [{ type: "text", text: "visible answer" }]);
+  assert.deepEqual(output.messages[1].content, [{ type: "text", text: "continue" }]);
+  assert.deepEqual(output.messages[2].content, [{ type: "tool_use", id: "t1", name: "x", input: {} }]);
+  assert.equal(output.model, "claude-sonnet-5");
+});
+
+test("still removes top-level thinking and reasoning_split parameters", () => {
+  const body = {
+    thinking: { type: "enabled", budget_tokens: 1024 },
+    reasoning_split: "disabled",
+    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }]
+  };
+
+  const output = parseOutput(stripUnsupportedOpenAiRequestParameters(toJsonBuffer(body)));
+  assert.equal("thinking" in output, false);
+  assert.equal("reasoning_split" in output, false);
+});
+
+test("returns the original buffer unchanged when there is nothing to strip", () => {
+  const body = {
+    messages: [{ role: "user", content: "plain string content" }]
+  };
+  const input = toJsonBuffer(body);
+  assert.equal(stripUnsupportedOpenAiRequestParameters(input), input);
+});
+
+test("leaves OpenAI-style string content untouched", () => {
+  const body = {
+    messages: [
+      { role: "system", content: "you are a helper" },
+      { role: "user", content: "hello" }
+    ]
+  };
+  const output = parseOutput(stripUnsupportedOpenAiRequestParameters(toJsonBuffer(body)));
+  assert.equal(output.messages[0].content, "you are a helper");
+  assert.equal(output.messages[1].content, "hello");
+});


### PR DESCRIPTION
## Summary

OpenAI chat/responses upstreams reject Anthropic `thinking` and `redacted_thinking` content blocks in message history with HTTP 400. Previously `stripUnsupportedOpenAiRequestParameters` only removed top-level `thinking`/`reasoning_split` fields; it now also strips `type: "thinking"` / `type: "redacted_thinking"` blocks from each message's `content` array before forwarding to OpenAI targets.

Fixes #1686

## Changes

- `packages/core/src/gateway/upstream/executor.ts` — extend `stripUnsupportedOpenAiRequestParameters` to also strip thinking content blocks from `messages[].content[]`; export the function for unit testing. Non-array (string) content is left untouched.
- `packages/core/test/unit/gateway/upstream/executor.test.mjs` — 4 unit tests covering thinking/redacted_thinking stripping, the top-level `thinking`/`reasoning_split` regression, no-op passthrough when there is nothing to strip, and OpenAI-style string content.

## Testing

- 4/4 new unit tests pass.
- Full core suite: no regressions introduced (599 tests; the only 3 failures are pre-existing claude-design plugin path issues in the local environment, unrelated to this change).
