### PR TITLE
fix(gateway): translate request body across cross-protocol fallback

### DIFF
--- a/packages/core/src/gateway/upstream/body-translate.ts
+++ b/packages/core/src/gateway/upstream/body-translate.ts
@@ -1,0 +1,398 @@
+import type { GatewayProviderProtocol } from "@ccr/core/contracts/app";
+import { parseJsonObjectSafe, serializeJsonBody } from "@ccr/core/gateway/http/body";
+import { isRecord, stringValue } from "@ccr/core/gateway/internal/value";
+
+/**
+ * Cross-protocol fallback body translation (issue #1615).
+ *
+ * When a request arrives on one protocol (e.g. `/v1/messages`, Anthropic) but the
+ * fallback target resolves to a provider speaking a different protocol (e.g.
+ * `openai_chat_completions`), the body is currently forwarded unchanged with only the
+ * `model` field rewritten — the upstream rejects it with HTTP 400. These helpers translate
+ * the request body between the Anthropic messages format and the OpenAI chat completions
+ * format so a cross-protocol fallback actually works.
+ *
+ * Only the protocol pair that covers the common fallback scenarios is implemented
+ * (`anthropic_messages` <-> `openai_chat_completions`). Other pairs (openai_responses,
+ * gemini, ...) fall through unchanged. Translation is defensive: any structure it cannot
+ * map is carried over or dropped conservatively, and it never throws — on failure the
+ * original body is returned so the fallback degrades to today's behavior instead of crashing.
+ */
+
+export function translateBodyForProtocol(
+  body: Buffer | undefined,
+  clientProtocol: GatewayProviderProtocol | undefined,
+  targetProtocol: GatewayProviderProtocol | undefined
+): Buffer | undefined {
+  if (!body || !clientProtocol || !targetProtocol || clientProtocol === targetProtocol) {
+    return body;
+  }
+  try {
+    const parsedBody = parseJsonObjectSafe(body);
+    if (!parsedBody) {
+      return body;
+    }
+    let translated: Record<string, unknown> | undefined;
+    if (clientProtocol === "anthropic_messages" && targetProtocol === "openai_chat_completions") {
+      translated = anthropicToOpenAiChat(parsedBody);
+    } else if (clientProtocol === "openai_chat_completions" && targetProtocol === "anthropic_messages") {
+      translated = openAiChatToAnthropic(parsedBody);
+    }
+    return translated ? serializeJsonBody(translated) : body;
+  } catch {
+    // Never let a translation failure break a fallback attempt.
+    return body;
+  }
+}
+
+function anthropicToOpenAiChat(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  // Copy everything through and only replace the fields whose shape differs between
+  // protocols. This preserves incidental fields (stream, stream_options, temperature,
+  // max_tokens, ...) that callers may rely on even when the body is not a canonical
+  // Anthropic request (e.g. already-OpenAI-shaped bodies arriving via /v1/messages).
+  const next: Record<string, unknown> = { ...body };
+  delete next.system;
+  delete next.messages;
+  delete next.stop_sequences;
+  delete next.tools;
+
+  const messages: unknown[] = [];
+  if (body.system !== undefined) {
+    const systemText = contentToText(body.system);
+    if (systemText !== undefined) {
+      messages.push({ role: "system", content: systemText });
+    }
+  }
+  if (Array.isArray(body.messages)) {
+    for (const message of body.messages) {
+      const converted = anthropicMessageToOpenAi(message);
+      if (converted) {
+        messages.push(converted);
+      }
+    }
+  }
+  if (Array.isArray(body.messages)) {
+    next.messages = messages;
+  }
+  if (Array.isArray(body.stop_sequences)) {
+    next.stop = body.stop_sequences;
+  }
+  const tools = anthropicToolsToOpenAi(body.tools);
+  if (tools) {
+    next.tools = tools;
+  }
+  return next;
+}
+
+function anthropicMessageToOpenAi(message: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(message)) {
+    return undefined;
+  }
+  const role = stringValue(message.role);
+  if (role === "user") {
+    const content = message.content;
+    // Anthropic tool results travel inside user messages; OpenAI uses a dedicated "tool"
+    // role. A tool_result is emitted as its own OpenAI tool message.
+    const toolResults = anthropicToolResultsToOpenAi(content);
+    if (toolResults.length > 0) {
+      return toolResults[0];
+    }
+    const text = contentToText(content);
+    const openAi: Record<string, unknown> = { role: "user" };
+    if (text !== undefined) {
+      openAi.content = text;
+    } else {
+      const blocks = anthropicUserBlocksToOpenAi(content);
+      if (blocks) {
+        openAi.content = blocks;
+      } else if (typeof content === "string") {
+        openAi.content = content;
+      }
+    }
+    return openAi;
+  }
+  if (role === "assistant") {
+    const openAi: Record<string, unknown> = { role: "assistant" };
+    const content = message.content;
+    const text = contentToText(content);
+    if (text !== undefined) {
+      openAi.content = text;
+    }
+    const toolCalls = anthropicToolUseToOpenAi(content);
+    if (toolCalls.length > 0) {
+      openAi.tool_calls = toolCalls;
+    }
+    return openAi;
+  }
+  return undefined;
+}
+
+function anthropicToolResultsToOpenAi(content: unknown): unknown[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const messages: unknown[] = [];
+  for (const block of content) {
+    if (isRecord(block) && block.type === "tool_result" && stringValue(block.tool_use_id)) {
+      messages.push({
+        role: "tool",
+        tool_call_id: stringValue(block.tool_use_id),
+        content: contentToText(block.content) ?? ""
+      });
+    }
+  }
+  return messages;
+}
+
+function anthropicUserBlocksToOpenAi(content: unknown): unknown[] | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const blocks: unknown[] = [];
+  let hasContent = false;
+  for (const block of content) {
+    if (!isRecord(block)) {
+      continue;
+    }
+    if (block.type === "image" && isRecord(block.source)) {
+      const imageUrl = anthropicImageToDataUrl(block.source);
+      if (imageUrl) {
+        blocks.push({ type: "image_url", image_url: { url: imageUrl } });
+        hasContent = true;
+      }
+    }
+  }
+  return hasContent ? blocks : undefined;
+}
+
+function anthropicToolUseToOpenAi(content: unknown): unknown[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const calls: unknown[] = [];
+  for (const block of content) {
+    if (isRecord(block) && block.type === "tool_use") {
+      calls.push({
+        id: stringValue(block.id),
+        type: "function",
+        function: {
+          name: stringValue(block.name),
+          arguments: JSON.stringify(block.input ?? {})
+        }
+      });
+    }
+  }
+  return calls;
+}
+
+function anthropicToolsToOpenAi(tools: unknown): unknown[] | undefined {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return undefined;
+  }
+  const converted: unknown[] = [];
+  for (const tool of tools) {
+    if (!isRecord(tool) || !stringValue(tool.name)) {
+      continue;
+    }
+    converted.push({
+      type: "function",
+      function: {
+        name: stringValue(tool.name),
+        description: stringValue(tool.description),
+        parameters: tool.input_schema ?? { type: "object", properties: {} }
+      }
+    });
+  }
+  return converted.length > 0 ? converted : undefined;
+}
+
+function openAiChatToAnthropic(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  // Copy everything through and only replace fields whose shape differs between protocols.
+  const next: Record<string, unknown> = { ...body };
+  delete next.messages;
+  delete next.stop;
+  delete next.tools;
+
+  const messages: unknown[] = [];
+  if (Array.isArray(body.messages)) {
+    let pendingSystem: string | undefined;
+    for (const message of body.messages) {
+      if (!isRecord(message)) {
+        continue;
+      }
+      const role = stringValue(message.role);
+      if (role === "system") {
+        pendingSystem = pendingSystem ?? contentToText(message.content);
+        continue;
+      }
+      const anthropic = openAiMessageToAnthropic(message);
+      if (anthropic) {
+        messages.push(anthropic);
+      }
+    }
+    if (pendingSystem !== undefined) {
+      next.system = pendingSystem;
+    }
+  }
+  if (Array.isArray(body.messages)) {
+    next.messages = messages;
+  }
+  if (Array.isArray(body.stop)) {
+    next.stop_sequences = body.stop;
+  }
+  const tools = openAiToolsToAnthropic(body.tools);
+  if (tools) {
+    next.tools = tools;
+  }
+  return next;
+}
+
+function openAiMessageToAnthropic(message: Record<string, unknown>): Record<string, unknown> | undefined {
+  const role = stringValue(message.role);
+  const content = message.content;
+
+  if (role === "user") {
+    const anthropic: Record<string, unknown> = { role: "user" };
+    if (typeof content === "string") {
+      anthropic.content = [{ type: "text", text: content }];
+    } else if (Array.isArray(content)) {
+      const blocks: unknown[] = [];
+      for (const block of content) {
+        if (isRecord(block)) {
+          if (block.type === "text") {
+            blocks.push({ type: "text", text: stringValue(block.text) ?? "" });
+          } else if (block.type === "image_url" && isRecord(block.image_url)) {
+            const source = dataUrlToAnthropicImage(stringValue(block.image_url.url));
+            if (source) {
+              blocks.push({ type: "image", source });
+            }
+          }
+        }
+      }
+      if (blocks.length > 0) {
+        anthropic.content = blocks;
+      }
+    }
+    return anthropic;
+  }
+
+  if (role === "assistant") {
+    const anthropic: Record<string, unknown> = { role: "assistant" };
+    const blocks: unknown[] = [];
+    if (typeof content === "string" && content) {
+      blocks.push({ type: "text", text: content });
+    } else if (Array.isArray(content)) {
+      for (const block of content) {
+        if (isRecord(block) && block.type === "text" && stringValue(block.text)) {
+          blocks.push({ type: "text", text: stringValue(block.text) });
+        }
+      }
+    }
+    if (Array.isArray(message.tool_calls)) {
+      for (const call of message.tool_calls) {
+        if (isRecord(call) && isRecord(call.function)) {
+          blocks.push({
+            type: "tool_use",
+            id: stringValue(call.id),
+            name: stringValue(call.function.name),
+            input: parseArguments(stringValue(call.function.arguments))
+          });
+        }
+      }
+    }
+    if (blocks.length > 0) {
+      anthropic.content = blocks;
+    }
+    return anthropic;
+  }
+
+  if (role === "tool") {
+    return {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: stringValue(message.tool_call_id),
+        content: contentToText(content) ?? ""
+      }]
+    };
+  }
+
+  return undefined;
+}
+
+function openAiToolsToAnthropic(tools: unknown): unknown[] | undefined {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return undefined;
+  }
+  const converted: unknown[] = [];
+  for (const tool of tools) {
+    if (!isRecord(tool)) {
+      continue;
+    }
+    const fn = isRecord(tool.function) ? tool.function : tool;
+    if (!stringValue(fn.name)) {
+      continue;
+    }
+    converted.push({
+      name: stringValue(fn.name),
+      description: stringValue(fn.description),
+      input_schema: fn.parameters ?? { type: "object", properties: {} }
+    });
+  }
+  return converted.length > 0 ? converted : undefined;
+}
+
+function contentToText(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (isRecord(block) && block.type === "text") {
+        const text = stringValue(block.text);
+        if (text) {
+          parts.push(text);
+        }
+      }
+    }
+    return parts.length > 0 ? parts.join("\n") : undefined;
+  }
+  return undefined;
+}
+
+function anthropicImageToDataUrl(source: Record<string, unknown>): string | undefined {
+  const type = stringValue(source.type);
+  const mediaType = stringValue(source.media_type);
+  const data = stringValue(source.data);
+  if (type === "base64" && mediaType && data) {
+    return `data:${mediaType};base64,${data}`;
+  }
+  if (type === "url" && stringValue(source.url)) {
+    return stringValue(source.url);
+  }
+  return undefined;
+}
+
+function dataUrlToAnthropicImage(url: string | undefined): Record<string, unknown> | undefined {
+  if (!url) {
+    return undefined;
+  }
+  const match = /^data:([^;]+);base64,(.+)$/.exec(url);
+  if (match) {
+    return { type: "base64", media_type: match[1], data: match[2] };
+  }
+  return { type: "url", url };
+}
+
+function parseArguments(raw: string | undefined): Record<string, unknown> {
+  if (!raw) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/core/src/gateway/upstream/executor.ts
+++ b/packages/core/src/gateway/upstream/executor.ts
@@ -16,6 +16,7 @@ import { isLocalClaudeCodeOauthProviderPlugin, mergeAnthropicBetaValues } from "
 import { abortSignalMessage, formatError, omitLocalObservabilityHeaders, shouldSendBody, withCoreGatewayAuthHeader } from "@ccr/core/gateway/http/io";
 import { parseJsonObjectSafe, releaseJsonObject, serializeJsonBody, serializeJsonBodyWithModel } from "@ccr/core/gateway/http/body";
 import { resolveGatewayPublicModelId } from "@ccr/core/gateway/features/model-discovery";
+import { translateBodyForProtocol } from "@ccr/core/gateway/upstream/body-translate";
 import { activeProviderCredentials, findProviderByPublicOrInternalName, findProviderCredentialBySlug, normalizedProviderCapabilities, parseProviderCredentialInternalName, providerCapabilityForClientProtocol, providerCapabilityInternalName, providerCapabilityNameMatches, providerCredentialInternalName, providerCredentialPriority, providerCredentialRuntimeId, providerCredentialSlug, providerProtocolForClientProtocol, sanitizeHeaderValue } from "@ccr/core/providers/runtime-topology";
 import { delay } from "@ccr/core/gateway/internal/clock";
 import { retryDelayAfterNetworkError, retryDelayAfterStatus, shouldFallbackAfterStatus } from "@ccr/core/gateway/upstream/retry-policy";
@@ -590,12 +591,20 @@ function prepareUpstreamCredentialAttempt(input: {
   const normalizedBody = normalizeConfiguredProviderModelBody(input.attempt.body, input.config);
   const target = resolvePlannedProviderCredentialRoutingTarget(input.attempt, input.path) ??
     resolveProviderCredentialRoutingTarget(input.config, input.headers, input.path, input.attempt.body);
-  const attemptBody = (body: Buffer | undefined) => usageAwareOpenAiChatAttemptBody({
-    body,
-    config: input.config,
-    path: input.path,
-    target
-  });
+  const clientProtocol = requestProtocolForPath(input.path);
+  const targetProtocol = target?.protocol;
+  const attemptBody = (body: Buffer | undefined) => {
+    // Cross-protocol fallback (#1615): translate the body from the client protocol to the
+    // target provider protocol before any OpenAI-specific sanitization. No-op when both
+    // protocols match or the pair is unsupported.
+    const translated = translateBodyForProtocol(body, clientProtocol, targetProtocol);
+    return usageAwareOpenAiChatAttemptBody({
+      body: translated,
+      config: input.config,
+      path: input.path,
+      target
+    });
+  };
   if (!target) {
     const body = normalizedBody?.body ?? input.attempt.body;
     return {

--- a/packages/core/test/unit/gateway/upstream/body-translate.test.mjs
+++ b/packages/core/test/unit/gateway/upstream/body-translate.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { translateBodyForProtocol } from "@ccr/core/gateway/upstream/body-translate.ts";
+
+function toJsonBuffer(value) {
+  return Buffer.from(JSON.stringify(value), "utf8");
+}
+
+function parseOutput(buffer) {
+  return JSON.parse(buffer.toString("utf8"));
+}
+
+test("translates Anthropic messages -> OpenAI chat completions", () => {
+  const anthropic = {
+    model: "claude-sonnet-5",
+    system: "You are a helpful assistant.",
+    messages: [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "let me look" },
+          { type: "tool_use", id: "t1", name: "search", input: { q: "x" } }
+        ]
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "results" }] }
+    ],
+    max_tokens: 4096,
+    temperature: 0.5,
+    stop_sequences: ["\n\n"],
+    tools: [{ name: "search", description: "Search the web", input_schema: { type: "object", properties: { q: { type: "string" } } } }],
+    stream: true
+  };
+
+  const out = parseOutput(translateBodyForProtocol(toJsonBuffer(anthropic), "anthropic_messages", "openai_chat_completions"));
+
+  assert.equal(out.model, "claude-sonnet-5");
+  assert.deepEqual(out.messages[0], { role: "system", content: "You are a helpful assistant." });
+  assert.deepEqual(out.messages[1], { role: "user", content: "hi" });
+  assert.equal(out.messages[2].role, "assistant");
+  assert.equal(out.messages[2].content, "let me look");
+  assert.deepEqual(out.messages[2].tool_calls, [
+    { id: "t1", type: "function", function: { name: "search", arguments: JSON.stringify({ q: "x" }) } }
+  ]);
+  assert.deepEqual(out.messages[3], { role: "tool", tool_call_id: "t1", content: "results" });
+  assert.deepEqual(out.stop, ["\n\n"]);
+  assert.deepEqual(out.tools, [
+    { type: "function", function: { name: "search", description: "Search the web", parameters: { type: "object", properties: { q: { type: "string" } } } } }
+  ]);
+  assert.equal(out.max_tokens, 4096);
+  assert.equal(out.temperature, 0.5);
+  assert.equal(out.stream, true);
+});
+
+test("translates OpenAI chat completions -> Anthropic messages", () => {
+  const openAi = {
+    model: "gpt-4o",
+    messages: [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: "let me look",
+        tool_calls: [{ id: "t1", type: "function", function: { name: "search", arguments: JSON.stringify({ q: "x" }) } }]
+      },
+      { role: "tool", tool_call_id: "t1", content: "results" }
+    ],
+    max_tokens: 4096,
+    temperature: 0.5,
+    stop: ["\n\n"],
+    tools: [{ type: "function", function: { name: "search", description: "Search the web", parameters: { type: "object", properties: { q: { type: "string" } } } } }],
+    stream: true
+  };
+
+  const out = parseOutput(translateBodyForProtocol(toJsonBuffer(openAi), "openai_chat_completions", "anthropic_messages"));
+
+  assert.equal(out.model, "gpt-4o");
+  assert.equal(out.system, "You are a helpful assistant.");
+  assert.deepEqual(out.messages[0], { role: "user", content: [{ type: "text", text: "hi" }] });
+  assert.equal(out.messages[1].role, "assistant");
+  assert.deepEqual(out.messages[1].content, [{ type: "text", text: "let me look" }, { type: "tool_use", id: "t1", name: "search", input: { q: "x" } }]);
+  assert.deepEqual(out.messages[2], { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "results" }] });
+  assert.deepEqual(out.stop_sequences, ["\n\n"]);
+  assert.deepEqual(out.tools, [
+    { name: "search", description: "Search the web", input_schema: { type: "object", properties: { q: { type: "string" } } } }
+  ]);
+});
+
+test("returns the original body when protocols match", () => {
+  const body = toJsonBuffer({ model: "x", messages: [{ role: "user", content: "hi" }] });
+  assert.equal(translateBodyForProtocol(body, "anthropic_messages", "anthropic_messages"), body);
+});
+
+test("returns the original body for unsupported protocol pairs", () => {
+  const body = toJsonBuffer({ model: "x", messages: [] });
+  assert.equal(translateBodyForProtocol(body, "anthropic_messages", "gemini_generate_content"), body);
+});
+
+test("returns the original body when either protocol is missing", () => {
+  const body = toJsonBuffer({ model: "x", messages: [] });
+  assert.equal(translateBodyForProtocol(body, "anthropic_messages", undefined), body);
+  assert.equal(translateBodyForProtocol(body, undefined, "openai_chat_completions"), body);
+});
+
+test("preserves incidental fields (stream_options) through Anthropic -> OpenAI translation", () => {
+  const body = {
+    model: "deepseek-v4-flash",
+    messages: [],
+    stream: true,
+    stream_options: { extra_flag: "keep" }
+  };
+  const out = parseOutput(translateBodyForProtocol(toJsonBuffer(body), "anthropic_messages", "openai_chat_completions"));
+  assert.deepEqual(out.stream_options, { extra_flag: "keep" });
+  assert.deepEqual(out.messages, []);
+  assert.equal(out.stream, true);
+  assert.equal(out.model, "deepseek-v4-flash");
+});


### PR DESCRIPTION
## Summary

When a request arrives on one protocol (e.g. `/v1/messages`, Anthropic) but the fallback target resolves to a provider speaking a different protocol (e.g. `openai_chat_completions`), the body was forwarded unchanged with only the `model` field rewritten, causing HTTP 400 upstream.

This PR adds a defensive Anthropic <-> OpenAI chat request-body translation, applied per fallback attempt before forwarding, keyed by the resolved target provider protocol.

Fixes #1615

## Changes

- `packages/core/src/gateway/upstream/body-translate.ts` (new) — `translateBodyForProtocol` plus the Anthropic <-> OpenAI chat translators. Covers the system prompt, text content, tool_use/tool_result, tool definitions, stop/stop_sequences, and sampling params. Unsupported protocol pairs and any translation failure return the original body, so a fallback attempt degrades to today's behavior instead of breaking.
- `packages/core/src/gateway/upstream/executor.ts` — in `prepareUpstreamCredentialAttempt`, translate the body from the client protocol to the resolved target provider protocol before OpenAI-specific sanitization.
- `packages/core/test/unit/gateway/upstream/body-translate.test.mjs` — 6 unit tests (both translation directions, no-op on matching/unsupported/missing protocols, and preservation of incidental fields such as `stream_options`).

## Testing

- 6/6 new unit tests pass.
- `router-builtins.test.js`: 78/78 pass — no regression.
- Full core suite: no regressions introduced (the only failures are pre-existing claude-design plugin path issues in the local environment, unrelated to this change).
