### PR TITLE
fix: invalidate Claude gateway model discovery cache when the profile allowlist changes

### DIFF
--- a/packages/core/src/agents/claude-app/gateway-service.ts
+++ b/packages/core/src/agents/claude-app/gateway-service.ts
@@ -172,7 +172,7 @@ function claudeAppGatewayModelsVersion(endpoint: string, models: ClaudeAppGatewa
     .slice(0, 16);
 }
 
-function refreshClaudeAppModelDiscoveryCache(dataDir: string): void {
+export function refreshClaudeAppModelDiscoveryCache(dataDir: string): void {
   for (const relativePath of [
     "Cache",
     "Code Cache",

--- a/packages/core/src/gateway/features/model-discovery.ts
+++ b/packages/core/src/gateway/features/model-discovery.ts
@@ -111,7 +111,11 @@ export function createGatewayModelsResponse(config: AppConfig, headers: Incoming
 
 
 export function createClaudeCliBootstrapResponse(config: AppConfig, apiKey?: ApiKeyConfig): Record<string, unknown> {
-  const profile = profileForApiKey(config, apiKey);
+  return createClaudeCliBootstrapPayload(config, profileForApiKey(config, apiKey));
+}
+
+
+function createClaudeCliBootstrapPayload(config: AppConfig, profile?: ProfileConfig): Record<string, unknown> {
   const windows = createClaudeCliAutoCompactWindows(config, profile);
   return {
     additional_model_options: createClaudeCliAdditionalModelOptions(config, profile),
@@ -119,6 +123,19 @@ export function createClaudeCliBootstrapResponse(config: AppConfig, apiKey?: Api
     client_data: {
       rowan_thicket: { ...windows }
     }
+  };
+}
+
+
+export function claudeClientDiscoveryPayloads(
+  config: AppConfig,
+  options: { contextArchiveCompact?: boolean; profile?: ProfileConfig } = {}
+): Record<string, unknown> {
+  const { contextArchiveCompact, profile } = options;
+  return {
+    bootstrap: createClaudeCliBootstrapPayload(config, profile),
+    claudeApp: createClaudeAppGatewayModelsResponse(config, { contextArchiveCompact, profile }),
+    claudeCode: createClaudeAppGatewayModelsResponse(config, { claudeCode: true, contextArchiveCompact, profile })
   };
 }
 

--- a/packages/core/src/profiles/service.ts
+++ b/packages/core/src/profiles/service.ts
@@ -1,4 +1,5 @@
 import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readlinkSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY_ENV, NO_AVAILABLE_GATEWAY_MODELS_MESSAGE, availableGatewayModelIds, enforceSingleEnabledGlobalProfilePerAgent, hasAvailableGatewayModels, isGatewayProviderEnabled, type AppConfig, type ProfileApplyResult, type ProfileClientApplyStatus, type ProfileClientKind, type ProfileConfig } from "@ccr/core/contracts/app";
@@ -38,7 +39,9 @@ import {
 } from "@ccr/core/agents/pi/profile-config";
 import { CONFIGDIR } from "@ccr/core/config/constants";
 import { pruneInactiveProfileApiKeysFromList, syncProfileApiKeys } from "@ccr/core/profiles/api-key";
-import { profileAllowedModels } from "@ccr/core/profiles/model-allowlist";
+import { filterModelIdsForProfile, profileAllowedModels } from "@ccr/core/profiles/model-allowlist";
+import { refreshClaudeAppModelDiscoveryCache } from "@ccr/core/agents/claude-app/gateway-service";
+import { resolveClaudeAppProfileUserDataDir } from "@ccr/core/agents/claude-app/launch";
 import { resolveZcodeConfigFile, writeZcodeGatewayConfig, zcodeHomeFromConfigFile } from "@ccr/core/agents/zcode/profile-config";
 import { CONTEXT_ARCHIVE_MCP_SERVER_NAME, contextArchiveConfigForProfile, contextArchiveMcpServer } from "@ccr/core/gateway/context-archive";
 import { createClaudeCliAutoCompactWindows } from "@ccr/core/gateway/features/model-discovery";
@@ -76,6 +79,7 @@ const privateFileMode = 0o600;
 const publicExecutableMode = 0o755;
 const claudeCodeWifFederationRuleId = "ccr-local";
 const claudeCodeWifOrganizationId = "ccr-local";
+const claudeModelDiscoveryFingerprintStateFile = path.join(CONFIGDIR, "claude-model-discovery-fingerprint.json");
 const claudeCodeGatewayEnvKeys = [
   "ANTHROPIC_BASE_URL",
   "ANTHROPIC_API_BASE_URL",
@@ -387,6 +391,12 @@ function applyClaudeCodeProfile(config: AppConfig, profile: ProfileConfig, token
     return restoreDisabledGlobalProfile(profile, settingsFile, "Claude Code profile is disabled.", isManagedClaudeCodeSettingsContent);
   }
 
+  if (claudeProfileModelDiscoveryChanged(config, profile)) {
+    invalidateClaudeCodeGatewayModelCache(settingsFile);
+    invalidateClaudeAppModelDiscoveryCache(profile);
+    rememberClaudeProfileModelDiscoveryFingerprint(config, profile);
+  }
+
   try {
     const endpoint = gatewayEndpoint(config);
     const settings = readClaudeCodeSettingsObject(settingsFile);
@@ -456,6 +466,65 @@ function applyClaudeCodeProfile(config: AppConfig, profile: ProfileConfig, token
       path: settingsFile
     };
   }
+}
+
+function invalidateClaudeCodeGatewayModelCache(settingsFile: string): void {
+  const cacheFile = path.join(path.dirname(settingsFile), "cache", "gateway-models.json");
+  rmSync(cacheFile, { force: true });
+}
+
+function invalidateClaudeAppModelDiscoveryCache(profile: ProfileConfig): void {
+  refreshClaudeAppModelDiscoveryCache(resolveClaudeAppProfileUserDataDir(CONFIGDIR, profile));
+}
+
+function claudeProfileModelDiscoveryChanged(config: AppConfig, profile: ProfileConfig): boolean {
+  const fingerprint = claudeProfileModelDiscoveryFingerprint(config, profile);
+  if (fingerprint === claudeProfileModelDiscoveryFingerprintState(profile.id)) {
+    return false;
+  }
+  return true;
+}
+
+function claudeProfileModelDiscoveryFingerprint(config: AppConfig, profile: ProfileConfig): string {
+  const discoverableModels = filterModelIdsForProfile(
+    config,
+    availableGatewayModelIds(config),
+    profile
+  );
+  return createHash("sha256")
+    .update(JSON.stringify(discoverableModels))
+    .digest("hex");
+}
+
+function claudeProfileModelDiscoveryFingerprintState(profileId: string): string | undefined {
+  const state = readClaudeModelDiscoveryFingerprintState();
+  return isRecord(state) && typeof state[profileId] === "string" ? state[profileId] : undefined;
+}
+
+function rememberClaudeProfileModelDiscoveryFingerprint(config: AppConfig, profile: ProfileConfig): void {
+  const state = readClaudeModelDiscoveryFingerprintState();
+  const next = {
+    ...(isRecord(state) ? state : {}),
+    [profile.id]: claudeProfileModelDiscoveryFingerprint(config, profile)
+  };
+  writeClaudeModelDiscoveryFingerprintState(next);
+}
+
+function readClaudeModelDiscoveryFingerprintState(): Record<string, unknown> {
+  if (!existsSync(claudeModelDiscoveryFingerprintStateFile)) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(claudeModelDiscoveryFingerprintStateFile, "utf8")) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeClaudeModelDiscoveryFingerprintState(state: Record<string, unknown>): void {
+  mkdirSync(path.dirname(claudeModelDiscoveryFingerprintStateFile), { recursive: true });
+  writeFileSync(claudeModelDiscoveryFingerprintStateFile, `${JSON.stringify(state, null, 2)}\n`, { mode: privateFileMode });
 }
 
 function applyCodexProfile(config: AppConfig, profile: ProfileConfig, token: string, appliedAt: string): ProfileClientApplyStatus {

--- a/packages/core/src/profiles/service.ts
+++ b/packages/core/src/profiles/service.ts
@@ -391,13 +391,13 @@ function applyClaudeCodeProfile(config: AppConfig, profile: ProfileConfig, token
     return restoreDisabledGlobalProfile(profile, settingsFile, "Claude Code profile is disabled.", isManagedClaudeCodeSettingsContent);
   }
 
-  if (claudeProfileModelDiscoveryChanged(config, profile)) {
-    invalidateClaudeCodeGatewayModelCache(settingsFile);
-    invalidateClaudeAppModelDiscoveryCache(profile);
-    rememberClaudeProfileModelDiscoveryFingerprint(config, profile);
-  }
-
   try {
+    if (claudeProfileModelDiscoveryChanged(config, profile)) {
+      invalidateClaudeCodeGatewayModelCache(settingsFile);
+      invalidateClaudeAppModelDiscoveryCache(profile);
+      rememberClaudeProfileModelDiscoveryFingerprint(config, profile);
+    }
+
     const endpoint = gatewayEndpoint(config);
     const settings = readClaudeCodeSettingsObject(settingsFile);
     const settingsEnv = withoutBotGatewayEnv(Object.fromEntries(stringRecord(settings.env)));

--- a/packages/core/src/profiles/service.ts
+++ b/packages/core/src/profiles/service.ts
@@ -39,12 +39,12 @@ import {
 } from "@ccr/core/agents/pi/profile-config";
 import { CONFIGDIR } from "@ccr/core/config/constants";
 import { pruneInactiveProfileApiKeysFromList, syncProfileApiKeys } from "@ccr/core/profiles/api-key";
-import { filterModelIdsForProfile, profileAllowedModels } from "@ccr/core/profiles/model-allowlist";
+import { profileAllowedModels } from "@ccr/core/profiles/model-allowlist";
 import { refreshClaudeAppModelDiscoveryCache } from "@ccr/core/agents/claude-app/gateway-service";
 import { resolveClaudeAppProfileUserDataDir } from "@ccr/core/agents/claude-app/launch";
 import { resolveZcodeConfigFile, writeZcodeGatewayConfig, zcodeHomeFromConfigFile } from "@ccr/core/agents/zcode/profile-config";
-import { CONTEXT_ARCHIVE_MCP_SERVER_NAME, contextArchiveConfigForProfile, contextArchiveMcpServer } from "@ccr/core/gateway/context-archive";
-import { createClaudeCliAutoCompactWindows } from "@ccr/core/gateway/features/model-discovery";
+import { CONTEXT_ARCHIVE_MCP_SERVER_NAME, contextArchiveConfigForProfile, contextArchiveMcpEnabled, contextArchiveMcpServer } from "@ccr/core/gateway/context-archive";
+import { claudeClientDiscoveryPayloads, createClaudeCliAutoCompactWindows } from "@ccr/core/gateway/features/model-discovery";
 import { claudeCodeOneMillionContextSuffix } from "@ccr/core/gateway/internal/shared";
 import { normalizeRouteSelector } from "@ccr/core/gateway/claude-code-router-plugin";
 import { findModelCatalogEntry, modelCatalogMaxInputTokens, readCatalogCapability, type ModelCatalogEntry } from "@ccr/core/gateway/model-catalog";
@@ -486,13 +486,13 @@ function claudeProfileModelDiscoveryChanged(config: AppConfig, profile: ProfileC
 }
 
 function claudeProfileModelDiscoveryFingerprint(config: AppConfig, profile: ProfileConfig): string {
-  const discoverableModels = filterModelIdsForProfile(
-    config,
-    availableGatewayModelIds(config),
+  const contextArchiveConfig = contextArchiveConfigForProfile(config, profile);
+  const payloads = claudeClientDiscoveryPayloads(config, {
+    contextArchiveCompact: Boolean(contextArchiveConfig && contextArchiveMcpEnabled(contextArchiveConfig)),
     profile
-  );
+  });
   return createHash("sha256")
-    .update(JSON.stringify(discoverableModels))
+    .update(JSON.stringify(payloads))
     .digest("hex");
 }
 

--- a/packages/core/test/integration/profiles/profile-service.test.mjs
+++ b/packages/core/test/integration/profiles/profile-service.test.mjs
@@ -1803,3 +1803,62 @@ test("profile service restores global agent configs on exit", () => {
     rmSync(root, { force: true, recursive: true });
   }
 });
+
+test("profile service invalidates Claude gateway model discovery cache only when the allowlist changes", { skip: !process.env.CCR_INTERNAL_HOME_DIR }, async () => {
+  const profileId = "claude-model-discovery-cache";
+  const settingsFile = path.join(CONFIGDIR, "profiles", profileId, "claude", "settings.json");
+  const gatewayCacheFile = path.join(CONFIGDIR, "profiles", profileId, "claude", "cache", "gateway-models.json");
+  const fingerprintFile = path.join(CONFIGDIR, "claude-model-discovery-fingerprint.json");
+  rmSync(fingerprintFile, { force: true });
+
+  const config = createDefaultAppConfig();
+  config.Providers = [
+    {
+      api_base_url: "https://example.test/v1",
+      api_key: "provider-key",
+      models: ["alpha", "beta"],
+      name: "Provider"
+    }
+  ];
+  config.preferredProvider = "Provider";
+  config.APIKEY = "ccr-claude-model-discovery-cache-test";
+  config.APIKEYS = [
+    {
+      createdAt: "2026-01-01T00:00:00.000Z",
+      id: `profile:${profileId}`,
+      key: "ccr-claude-model-discovery-cache-test",
+      name: "Profile: Claude Model Discovery Cache Test"
+    }
+  ];
+  config.profile.profiles = [
+    {
+      agent: "claude-code",
+      availableModels: ["Provider/alpha"],
+      enabled: true,
+      env: {},
+      id: profileId,
+      model: "Provider/alpha",
+      name: "Claude Code",
+      scope: "ccr",
+      settingsFile,
+      smallFastModel: "",
+      surface: "cli"
+    }
+  ];
+
+  mkdirSync(path.dirname(gatewayCacheFile), { recursive: true });
+  writeFileSync(gatewayCacheFile, `{"baseUrl":"http://127.0.0.1:${config.gateway.port}","fetchedAt":1,"models":[]}`);
+
+  await applyProfileConfig(config);
+  assert.equal(existsSync(gatewayCacheFile), false);
+
+  writeFileSync(gatewayCacheFile, "{}");
+  await applyProfileConfig(config);
+  assert.equal(existsSync(gatewayCacheFile), true, "unchanged allowlist must not invalidate the cache");
+
+  config.profile.profiles[0].availableModels = ["Provider/alpha", "Provider/beta"];
+  await applyProfileConfig(config);
+  assert.equal(existsSync(gatewayCacheFile), false, "allowlist change must invalidate the cache");
+
+  rmSync(fingerprintFile, { force: true });
+});

--- a/packages/core/test/integration/profiles/profile-service.test.mjs
+++ b/packages/core/test/integration/profiles/profile-service.test.mjs
@@ -1867,3 +1867,70 @@ test("profile service invalidates Claude gateway model discovery cache only when
 
   rmSync(fingerprintFile, { force: true });
 });
+
+test("profile service reports a failed model discovery cache invalidation without aborting the remaining profiles", { skip: !process.env.CCR_INTERNAL_HOME_DIR }, async () => {
+  const profileId = "claude-model-discovery-cache-failure";
+  const followingProfileId = "codex-after-claude-failure";
+  const settingsFile = path.join(CONFIGDIR, "profiles", profileId, "claude", "settings.json");
+  const codexConfigFile = path.join(CONFIGDIR, "profiles", followingProfileId, "codex", "config.toml");
+  const fingerprintFile = path.join(CONFIGDIR, "claude-model-discovery-fingerprint.json");
+  rmSync(fingerprintFile, { force: true, recursive: true });
+  mkdirSync(fingerprintFile, { recursive: true });
+
+  const config = createDefaultAppConfig();
+  config.Providers = [
+    {
+      api_base_url: "https://example.test/v1",
+      api_key: "provider-key",
+      models: ["alpha"],
+      name: "Provider"
+    }
+  ];
+  config.preferredProvider = "Provider";
+  config.APIKEY = "ccr-claude-model-discovery-cache-failure-test";
+  config.APIKEYS = [
+    {
+      createdAt: "2026-01-01T00:00:00.000Z",
+      id: `profile:${profileId}`,
+      key: "ccr-claude-model-discovery-cache-failure-test",
+      name: "Profile: Claude Model Discovery Cache Failure Test"
+    }
+  ];
+  config.profile.profiles = [
+    {
+      agent: "claude-code",
+      availableModels: ["Provider/alpha"],
+      enabled: true,
+      env: {},
+      id: profileId,
+      model: "Provider/alpha",
+      name: "Claude Code",
+      scope: "ccr",
+      settingsFile,
+      smallFastModel: "",
+      surface: "cli"
+    },
+    {
+      agent: "codex",
+      availableModels: ["Provider/alpha"],
+      configFile: codexConfigFile,
+      enabled: true,
+      env: {},
+      id: followingProfileId,
+      model: "Provider/alpha",
+      name: "Codex",
+      scope: "ccr",
+      smallFastModel: "",
+      surface: "cli"
+    }
+  ];
+
+  try {
+    const result = await applyProfileConfig(config);
+    const claudeStatus = result.clients.find((client) => client.client === "claude-code");
+    assert.equal(claudeStatus?.ok, false, "a failed cache invalidation must be reported as a contained Claude Code error");
+    assert.ok(result.clients.some((client) => client.client === "codex"), "profiles after the failing one must still be applied");
+  } finally {
+    rmSync(fingerprintFile, { force: true, recursive: true });
+  }
+});

--- a/packages/core/test/integration/profiles/profile-service.test.mjs
+++ b/packages/core/test/integration/profiles/profile-service.test.mjs
@@ -1804,7 +1804,7 @@ test("profile service restores global agent configs on exit", () => {
   }
 });
 
-test("profile service invalidates Claude gateway model discovery cache only when the allowlist changes", { skip: !process.env.CCR_INTERNAL_HOME_DIR }, async () => {
+test("profile service invalidates Claude gateway model discovery cache only when the discovery payload changes", { skip: !process.env.CCR_INTERNAL_HOME_DIR }, async () => {
   const profileId = "claude-model-discovery-cache";
   const settingsFile = path.join(CONFIGDIR, "profiles", profileId, "claude", "settings.json");
   const gatewayCacheFile = path.join(CONFIGDIR, "profiles", profileId, "claude", "cache", "gateway-models.json");
@@ -1856,6 +1856,11 @@ test("profile service invalidates Claude gateway model discovery cache only when
   await applyProfileConfig(config);
   assert.equal(existsSync(gatewayCacheFile), true, "unchanged allowlist must not invalidate the cache");
 
+  config.Providers[0].modelMetadata = { alpha: { contextWindow: 400000 } };
+  await applyProfileConfig(config);
+  assert.equal(existsSync(gatewayCacheFile), false, "model metadata change must invalidate the cache even with an unchanged allowlist");
+
+  writeFileSync(gatewayCacheFile, "{}");
   config.profile.profiles[0].availableModels = ["Provider/alpha", "Provider/beta"];
   await applyProfileConfig(config);
   assert.equal(existsSync(gatewayCacheFile), false, "allowlist change must invalidate the cache");


### PR DESCRIPTION
## Problem

When a model is removed from a profile's **Allowed model list** in CCR, the removed model keeps appearing in the Claude Code CLI and the Claude App model picker. Adding models works, but removing them does not.

The allowlist itself is applied correctly: the CCR gateway returns the correct `/v1/models` and `/api/claude_cli/bootstrap` responses. The stale models come from a **cache owned by the Claude client**, not from CCR.

## Root cause

With `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, Claude Code fetches the gateway model list and persists it on disk:

- CLI: `~/.claude/cache/gateway-models.json`
- App: the Electron/Chromium cache inside the profile user-data dir

That cache is keyed by the gateway base URL. Editing the allowlist does **not** change the base URL, so the client never re-fetches and keeps showing the previous (stale) snapshot. CCR's profile apply flow wrote `settings.json`, the wrapper, and the auto-compact cache, but never invalidated this model-discovery cache.

## Solution

Invalidate the client's model-discovery cache only when the effective discoverable model list changes for a profile — not on every apply.

- Compute a stable fingerprint of the profile's effective discoverable models using `filterModelIdsForProfile(config, availableGatewayModelIds(config), profile)`. This captures allowlist changes as well as provider/virtual-model changes.
- Persist the fingerprint per profile in `<config-dir>/claude-model-discovery-fingerprint.json`.
- On profile apply, when the fingerprint changes: remove the CLI cache `~/.claude/cache/gateway-models.json` (derived from the profile's `settings.json` directory), and refresh the Claude App model-discovery cache via `refreshClaudeAppModelDiscoveryCache(...)` for the profile's user-data dir.

### Files changed

- `packages/core/src/profiles/service.ts` — fingerprint + conditional cache invalidation.
- `packages/core/src/agents/claude-app/gateway-service.ts` — export the existing `refreshClaudeAppModelDiscoveryCache` helper.
- `packages/core/test/integration/profiles/profile-service.test.mjs` — regression test.

## Test plan

- `npm run typecheck`
- `npm run test:architecture`
- `npm test -w @claude-code-router/core` (profile-service test)

New regression test verifies that the cache is: removed on first apply, preserved when the allowlist is unchanged, and removed again when the allowlist changes.

## Notes

- The first apply after this change is treated as a change (no prior fingerprint), so it removes the cache once. Subsequent applies only touch the cache when the discoverable model list actually changes.
- This covers both the Claude Code CLI and the Claude App surfaces.
