### PR TITLE
fix: skip session affinity body fields for Codex Responses upstreams

### DIFF
--- a/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
+++ b/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
@@ -16,12 +16,15 @@ export type ResponsesSessionAffinityInput = {
     headers?: Record<string, HeaderValue>;
   };
   targetProviderConfig?: {
+    baseurl?: string;
+    name?: string;
     type?: string;
   };
   upstreamRequest: UpstreamRequest;
 };
 
 const sessionIdHeaderNames = ["x-claude-code-session-id", "x-claude-session-id"];
+const codexUpstreamUrlMarkers = ["chatgpt.com/backend-api/codex", "/backend-api/codex"];
 
 /**
  * Copies the Claude Code session identity onto outbound OpenAI Responses
@@ -30,12 +33,16 @@ const sessionIdHeaderNames = ["x-claude-code-session-id", "x-claude-session-id"]
  * on body fields hash each turn onto a different channel and the next hop
  * rejects channel-bound `encrypted_content` continuations. A caller-supplied
  * non-empty `prompt_cache_key` always wins; other protocols and non-JSON
- * bodies pass through untouched.
+ * bodies pass through untouched. Codex upstreams reject unknown body fields
+ * with `400 Unsupported parameter`, so affinity is skipped for them.
  */
 export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInput): UpstreamRequest {
   const upstreamRequest = input.upstreamRequest;
   const providerType = input.targetProviderConfig?.type?.trim().toLowerCase();
   if (providerType !== "openai_responses") {
+    return upstreamRequest;
+  }
+  if (isCodexResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)) {
     return upstreamRequest;
   }
   const body = upstreamRequest.body;
@@ -78,6 +85,22 @@ export function resolveResponsesSessionKey(
     }
   }
   return inboundUserId;
+}
+
+/**
+ * Codex backend detection: the outbound URL is authoritative (it carries the
+ * final rewritten base), with the configured provider base URL as a fallback
+ * for requests that bypass URL rewriting.
+ */
+export function isCodexResponsesUpstream(
+  upstreamUrl: string,
+  providerConfig?: { baseurl?: string }
+): boolean {
+  const candidates = [upstreamUrl, providerConfig?.baseurl];
+  return candidates.some((candidate) => {
+    const normalized = candidate?.trim().toLowerCase();
+    return Boolean(normalized && codexUpstreamUrlMarkers.some((marker) => normalized.includes(marker)));
+  });
 }
 
 function inboundMetadataUserId(body: unknown): string | undefined {

--- a/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
+++ b/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { applyResponsesSessionAffinity, resolveResponsesSessionKey } from "@ccr/core/gateway/core-runtime/responses-session-affinity.ts";
+import { applyResponsesSessionAffinity, isCodexResponsesUpstream, resolveResponsesSessionKey } from "@ccr/core/gateway/core-runtime/responses-session-affinity.ts";
 import { createGatewayPlugin } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
 
 function responsesInput(overrides = {}) {
@@ -89,6 +89,41 @@ test("x-claude-session-id and inbound metadata.user_id are fallback key sources"
   );
   assert.equal(resolveResponsesSessionKey({}, "metadata-user"), "metadata-user");
   assert.equal(resolveResponsesSessionKey(undefined, undefined), undefined);
+});
+
+test("codex upstreams receive neither prompt_cache_key nor metadata", () => {
+  const input = responsesInput({
+    targetProviderConfig: {
+      name: "codex-api::openai_responses",
+      type: "openai_responses"
+    }
+  });
+  input.upstreamRequest.url = "https://chatgpt.com/backend-api/codex/responses";
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result, input.upstreamRequest);
+  assert.equal(result.body.prompt_cache_key, undefined);
+  assert.equal(result.body.metadata, undefined);
+});
+
+test("non-codex openai_responses upstreams keep the affinity injection", () => {
+  const input = responsesInput();
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result.body.prompt_cache_key, "session-1111-2222");
+  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+});
+
+test("isCodexResponsesUpstream matches the outbound url and provider baseurl", () => {
+  assert.equal(isCodexResponsesUpstream("https://chatgpt.com/backend-api/codex/responses"), true);
+  assert.equal(isCodexResponsesUpstream("https://api.openai.com/v1/responses"), false);
+  assert.equal(
+    isCodexResponsesUpstream("https://api.openai.com/v1/responses", { baseurl: "https://chatgpt.com/backend-api/codex" }),
+    true
+  );
+  assert.equal(isCodexResponsesUpstream("https://mirror.example/backend-api/codex/responses"), true);
 });
 
 test("non-Responses providers and non-JSON bodies pass through untouched", () => {


### PR DESCRIPTION
Summary

Requests routed to OpenAI Responses upstreams that use the ChatGPT/Codex backend fail with `400 Unsupported parameter: metadata`. This happens because CCR injects session-affinity body fields (`metadata.user_id` and `prompt_cache_key`) into every outbound `/v1/responses` request, and the Codex backend rejects unknown parameters. After this change, the session affinity hook detects Codex upstreams by URL and skips the injection for them, while keeping the existing behavior for every other upstream (including the public OpenAI API).

## The problem

When Claude Code talks to the gateway, it sends its requests in Anthropic format and includes a `metadata.user_id` field identifying the user and session. The protocol conversion to OpenAI Responses drops this field, which is correct for the public API, but it also means multi-channel Responses upstreams cannot pin a conversation to a specific channel.

To fix that channel-pinning problem, the gateway ships a provider plugin (`ccr-responses-session-affinity`, in `packages/core/src/gateway/core-runtime/responses-session-affinity.ts`) that copies two fields onto the outbound Responses body when they are absent:

- `prompt_cache_key`: taken from the Claude Code session header, so consecutive turns of the same session hash onto the same upstream channel.
- `metadata.user_id`: carried over from the inbound Anthropic body.

This works fine against `api.openai.com/v1/responses`, which accepts both fields. It breaks against the Codex backend (`chatgpt.com/backend-api/codex/responses`), which serves a different, stricter contract: any parameter outside its schema is rejected with `400 Unsupported parameter: <field>`. Since these injections happen on essentially every Claude Code request, all traffic routed to a Codex provider fails on the first hop, and with no fallback target configured the client receives:

```json
{
  "error": {
    "message": "All target providers failed.",
    "target_provider_names": ["codex-api::openai_responses"],
    "attempts": [
      {
        "provider_name": "codex-api::openai_responses",
        "stage": "upstream_response",
        "status": 400,
        "details": { "detail": "Unsupported parameter: metadata" }
      }
    ]
  }
}
```

The same reasoning applies to `prompt_cache_key`: even though the reported error names `metadata` first, the Codex schema is strict as a whole, so injecting only one of the fields would just move the failure to the next unsupported parameter.

## The fix

In `packages/core/src/gateway/core-runtime/responses-session-affinity.ts`:

1. New exported helper `isCodexResponsesUpstream(url, providerConfig)` returns true when the outbound URL or the provider base URL contains a Codex backend marker (`chatgpt.com/backend-api/codex`).
2. `applyResponsesSessionAffinity` now returns the upstream request untouched when the target is a Codex Responses upstream, skipping both injected fields.

No configuration changes, no migration, no UI changes. Existing providers pointing at the Codex backend are picked up automatically on the next gateway start.

## Testing

- New unit tests in `packages/core/test/unit/gateway/responses-session-affinity.test.mjs` cover:
  - A Codex upstream receiving neither `prompt_cache_key` nor `metadata`.
  - Non-Codex `openai_responses` upstreams keeping the injection (no regression).
  - `isCodexResponsesUpstream` matching the outbound URL and provider base URL, including mirrored paths.
- `npm run typecheck` passes; the full core suite shows no new failures compared to the baseline branch