### PR TITLE
feat: respect profile Entry mode when syncing the Claude App config

### DIFF
--- a/packages/core/src/agents/claude-app/gateway-service.ts
+++ b/packages/core/src/agents/claude-app/gateway-service.ts
@@ -24,6 +24,9 @@ const claudeAppGatewayModelRouteOptions: ClaudeAppGatewayModelRouteOptions = {
   supportsOneMillionContext: (model) => Boolean(findModelCatalogEntry(model)?.limits?.supports1MContext)
 };
 
+export const NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE =
+  "No enabled claude-code profile can open the Claude App. Set a profile's Entry mode to App or Auto to configure the Claude App for CCR.";
+
 type ClaudeAppGatewayConfig = {
   authentication: {
     disableClaudeAiSignIn: true;
@@ -81,7 +84,19 @@ export type ClaudeAppGatewaySyncResult = {
   result: ClaudeAppGatewayApplyResult;
 };
 
+export function hasClaudeAppEntryProfile(config: Pick<AppConfig, "profile">): boolean {
+  return config.profile.profiles.some((profile) => profile.enabled && profile.agent === "claude-code" && profile.surface !== "cli");
+}
+
 export async function syncClaudeAppGatewayConfig(config: AppConfig): Promise<ClaudeAppGatewaySyncResult> {
+  if (!hasClaudeAppEntryProfile(config)) {
+    restoreClaudeAppGatewayConfig();
+    return {
+      config,
+      configChanged: false,
+      result: skippedClaudeAppGatewayResult(config, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE)
+    };
+  }
   if (!hasAvailableGatewayModels(config)) {
     return {
       config,
@@ -106,7 +121,10 @@ export async function syncClaudeAppGatewayConfig(config: AppConfig): Promise<Cla
   };
 }
 
-function skippedClaudeAppGatewayResult(config: AppConfig): ClaudeAppGatewayApplyResult {
+function skippedClaudeAppGatewayResult(
+  config: AppConfig,
+  message: string = NO_AVAILABLE_GATEWAY_MODELS_MESSAGE
+): ClaudeAppGatewayApplyResult {
   const paths = getClaudeAppGatewayPaths();
   return {
     apiKeyGenerated: false,
@@ -114,7 +132,7 @@ function skippedClaudeAppGatewayResult(config: AppConfig): ClaudeAppGatewayApply
     configLibraryFile: paths.configLibraryFile,
     dataDir: paths.dataDir,
     endpoint: gatewayEndpoint(config),
-    message: NO_AVAILABLE_GATEWAY_MODELS_MESSAGE,
+    message,
     model: "",
     requiresRestart: false
   };

--- a/packages/core/test/unit/agents/claude-app-gateway-sync.test.mjs
+++ b/packages/core/test/unit/agents/claude-app-gateway-sync.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const testRoot = path.join(
+  process.env.CCR_INTERNAL_HOME_DIR || os.tmpdir(),
+  `claude-app-gateway-sync-${process.pid}`
+);
+process.env.CCR_INTERNAL_HOME_DIR = path.join(testRoot, "home");
+process.env.CCR_INTERNAL_APP_DATA_DIR = path.join(testRoot, "app-data");
+process.env.CCR_INTERNAL_USER_DATA_DIR = path.join(testRoot, "user-data");
+
+async function loadModules() {
+  const {
+    NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE,
+    hasClaudeAppEntryProfile,
+    syncClaudeAppGatewayConfig
+  } = await import("@ccr/core/agents/claude-app/gateway-service.ts");
+  const { CONFIGDIR } = await import("@ccr/core/config/constants.ts");
+  return {
+    BACKUP_FILE: path.join(CONFIGDIR, "claude-app-gateway-backup.json"),
+    NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE,
+    hasClaudeAppEntryProfile,
+    syncClaudeAppGatewayConfig
+  };
+}
+
+test("sync skips and restores the backup when no enabled claude-code profile opens the app", async () => {
+  const { BACKUP_FILE, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE, hasClaudeAppEntryProfile, syncClaudeAppGatewayConfig } = await loadModules();
+  seedGatewayBackup(BACKUP_FILE);
+  const synced = await syncClaudeAppGatewayConfig(createConfig({
+    profile: {
+      profiles: [claudeCodeProfile({ surface: "cli" })]
+    }
+  }));
+
+  assert.equal(hasClaudeAppEntryProfile(synced.config), false);
+  assert.equal(synced.configChanged, false);
+  assert.equal(synced.result.message, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE);
+  assert.equal(existsSync(BACKUP_FILE), false);
+  const libraryConfig = JSON.parse(readFileSync(claudeAppPaths().configLibraryFile, "utf8"));
+  assert.equal(libraryConfig.inferenceProvider, "original");
+  assert.equal(readFileSync(claudeAppPaths().rootConfigFile, "utf8"), '{"deploymentMode":"native"}');
+  cleanup(BACKUP_FILE);
+});
+
+test("sync skips and restores the backup when the only claude-code profile is disabled", async () => {
+  const { BACKUP_FILE, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE, hasClaudeAppEntryProfile, syncClaudeAppGatewayConfig } = await loadModules();
+  seedGatewayBackup(BACKUP_FILE);
+  const synced = await syncClaudeAppGatewayConfig(createConfig({
+    profile: {
+      profiles: [claudeCodeProfile({ enabled: false })]
+    }
+  }));
+
+  assert.equal(hasClaudeAppEntryProfile(synced.config), false);
+  assert.equal(synced.result.message, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE);
+  assert.equal(existsSync(BACKUP_FILE), false);
+  assert.equal(existsSync(claudeAppPaths().configLibraryFile), true);
+  cleanup(BACKUP_FILE);
+});
+
+test("sync skips when only a claude-design profile is enabled", async () => {
+  const { BACKUP_FILE, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE, hasClaudeAppEntryProfile, syncClaudeAppGatewayConfig } = await loadModules();
+  seedGatewayBackup(BACKUP_FILE);
+  const synced = await syncClaudeAppGatewayConfig(createConfig({
+    profile: {
+      profiles: [{
+        agent: "claude-design",
+        enabled: true,
+        id: "design",
+        model: "test-model",
+        name: "design"
+      }]
+    }
+  }));
+
+  assert.equal(hasClaudeAppEntryProfile(synced.config), false);
+  assert.equal(synced.result.message, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE);
+  assert.equal(existsSync(BACKUP_FILE), false);
+  cleanup(BACKUP_FILE);
+});
+
+test("sync with a cli-only profile restores missing files as absent", async () => {
+  const { BACKUP_FILE, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE, syncClaudeAppGatewayConfig } = await loadModules();
+  seedGatewayBackupWithoutExistingFiles(BACKUP_FILE);
+  const synced = await syncClaudeAppGatewayConfig(createConfig({
+    profile: {
+      profiles: [claudeCodeProfile({ surface: "cli" })]
+    }
+  }));
+
+  assert.equal(synced.result.message, NO_CLAUDE_APP_ENTRY_PROFILE_MESSAGE);
+  assert.equal(existsSync(claudeAppPaths().rootConfigFile), false);
+  assert.equal(existsSync(claudeAppPaths().metaFile), false);
+  assert.equal(existsSync(claudeAppPaths().configLibraryFile), false);
+  cleanup(BACKUP_FILE);
+});
+
+test("sync applies the gateway config for auto, app, and unset surfaces", async () => {
+  const { BACKUP_FILE, hasClaudeAppEntryProfile, syncClaudeAppGatewayConfig } = await loadModules();
+  for (const surface of ["auto", "app", undefined]) {
+    const synced = await syncClaudeAppGatewayConfig(createConfig({
+      profile: {
+        profiles: [claudeCodeProfile({ surface })]
+      }
+    }));
+
+    assert.equal(hasClaudeAppEntryProfile(synced.config), true);
+    assert.equal(synced.configChanged, false);
+    const libraryConfig = JSON.parse(readFileSync(claudeAppPaths().configLibraryFile, "utf8"));
+    assert.equal(libraryConfig.inferenceProvider, "gateway");
+    assert.equal(libraryConfig.inferenceGatewayApiKey, "existing-test-key");
+    cleanup(BACKUP_FILE);
+  }
+});
+
+test("sync applies the gateway config regardless of profile scope", async () => {
+  const { BACKUP_FILE, hasClaudeAppEntryProfile, syncClaudeAppGatewayConfig } = await loadModules();
+  for (const scope of ["ccr", "global", "custom"]) {
+    const synced = await syncClaudeAppGatewayConfig(createConfig({
+      profile: {
+        profiles: [claudeCodeProfile({ scope, surface: "auto" })]
+      }
+    }));
+
+    assert.equal(hasClaudeAppEntryProfile(synced.config), true);
+    const libraryConfig = JSON.parse(readFileSync(claudeAppPaths().configLibraryFile, "utf8"));
+    assert.equal(libraryConfig.inferenceProvider, "gateway");
+    cleanup(BACKUP_FILE);
+  }
+});
+
+function claudeCodeProfile(overrides = {}) {
+  return {
+    agent: "claude-code",
+    enabled: true,
+    id: "p1",
+    model: "test-model",
+    name: "claude-code",
+    ...overrides
+  };
+}
+
+function claudeAppPaths() {
+  const dataDir = path.join(testRoot, "app-data", "Claude-3p");
+  return {
+    configLibraryFile: path.join(dataDir, "configLibrary", "8f69f2f1-3275-4ad8-9317-4aa7e972f311.json"),
+    dataDir,
+    metaFile: path.join(dataDir, "configLibrary", "_meta.json"),
+    rootConfigFile: path.join(dataDir, "claude_desktop_config.json")
+  };
+}
+
+function seedGatewayBackup(backupFile) {
+  writeJsonFile(backupFile, {
+    configLibraryFile: { content: '{"inferenceProvider":"original"}', exists: true },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    metaFile: { content: "{}", exists: true },
+    rootConfigFile: { content: '{"deploymentMode":"native"}', exists: true },
+    version: 1
+  });
+}
+
+function seedGatewayBackupWithoutExistingFiles(backupFile) {
+  writeJsonFile(backupFile, {
+    configLibraryFile: { exists: false },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    metaFile: { exists: false },
+    rootConfigFile: { exists: false },
+    version: 1
+  });
+}
+
+function writeJsonFile(file, value) {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify(value));
+}
+
+function cleanup(backupFile) {
+  rmSync(claudeAppPaths().dataDir, { force: true, recursive: true });
+  if (backupFile) {
+    rmSync(backupFile, { force: true });
+  }
+}
+
+function createConfig(overrides = {}) {
+  return {
+    APIKEY: "existing-test-key",
+    APIKEYS: [],
+    HOST: "0.0.0.0",
+    PORT: 3456,
+    Providers: [{
+      models: ["test-model"],
+      name: "test-provider"
+    }],
+    gateway: {
+      enabled: true,
+      host: "0.0.0.0",
+      port: 3456
+    },
+    profile: {
+      profiles: []
+    },
+    virtualModelProfiles: [],
+    ...overrides
+  };
+}


### PR DESCRIPTION
Closes #1712

CCR rewrites the Claude desktop app config on every save, gateway start/restart, and startup, ignoring each profile's Entry mode. With a claude-code profile set to "CLI only", the app still gets pointed at the CCR gateway until the service stops.

Now `syncClaudeAppGatewayConfig` first checks whether any enabled claude-code profile can open the app (`hasClaudeAppEntryProfile`). If none can, it restores the existing backup immediately via `restoreClaudeAppGatewayConfig` and skips. Explicit "Open in App" is unaffected: that path calls `applyClaudeAppGatewayConfig` directly.

Only `claude-code` profiles count (claude-design never reads the Claude-3p config), filtered by `enabled` alone to match `findProfileForOpen`.

Side effects for CLI-only setups: `gateway.enabled` is no longer forced back to true on every save, and no "Claude App" API key is auto-minted anymore.

All changes in `packages/core/src/agents/claude-app/gateway-service.ts`; every call site inherits the behavior untouched.

## Testing

New unit tests in `packages/core/test/unit/agents/claude-app-gateway-sync.test.mjs`: skip + backup restore for `surface: "cli"`, disabled profile, claude-design-only; restore of absent files; apply for `auto`/`app`/unset surfaces and any scope.

`npm run typecheck` clean; architecture tests pass.
