### PR TITLE
fix(gateway): opt OpenAI Responses tools out of implicit strict mode

### DIFF
--- a/packages/core/src/gateway/core-runtime/responses-tool-strictness.ts
+++ b/packages/core/src/gateway/core-runtime/responses-tool-strictness.ts
@@ -9,6 +9,8 @@ type UpstreamRequest = {
 };
 
 export type ResponsesToolStrictnessInput = {
+  sourceAdapterKey?: string;
+  sourceProvider?: string;
   targetProviderConfig?: {
     type?: string;
   };
@@ -18,12 +20,19 @@ export type ResponsesToolStrictnessInput = {
 /**
  * OpenAI Responses treats omitted `strict` as "try to make this schema strict".
  * Claude Code tools leave `strict` unset, so optional fields get forced on.
+ * Only converted Anthropic/Claude Code requests are stamped. Native
+ * `/v1/responses` pass-through keeps omitted `strict` as API semantics.
  * Explicit boolean strictness is left alone. Other protocols pass through.
  */
 export function applyResponsesToolStrictness(input: ResponsesToolStrictnessInput): UpstreamRequest {
   const upstreamRequest = input.upstreamRequest;
   const providerType = input.targetProviderConfig?.type?.trim().toLowerCase();
   if (providerType !== "openai_responses") {
+    return upstreamRequest;
+  }
+  const sourceKey = input.sourceAdapterKey?.trim().toLowerCase();
+  const sourceProvider = input.sourceProvider?.trim().toLowerCase();
+  if (sourceKey !== "anthropic_messages" && sourceProvider !== "anthropic") {
     return upstreamRequest;
   }
   const body = upstreamRequest.body;

--- a/packages/core/src/gateway/core-runtime/responses-tool-strictness.ts
+++ b/packages/core/src/gateway/core-runtime/responses-tool-strictness.ts
@@ -1,0 +1,80 @@
+import { isRecord } from "@ccr/core/gateway/internal/value";
+
+type UpstreamRequest = {
+  body?: unknown;
+  bodyEncoding?: "bytes" | "form" | "json" | "none" | "text";
+  headers?: Record<string, string>;
+  method?: string;
+  url: string;
+};
+
+export type ResponsesToolStrictnessInput = {
+  targetProviderConfig?: {
+    type?: string;
+  };
+  upstreamRequest: UpstreamRequest;
+};
+
+/**
+ * OpenAI Responses treats omitted `strict` as "try to make this schema strict".
+ * Claude Code tools leave `strict` unset, so optional fields get forced on.
+ * Explicit boolean strictness is left alone. Other protocols pass through.
+ */
+export function applyResponsesToolStrictness(input: ResponsesToolStrictnessInput): UpstreamRequest {
+  const upstreamRequest = input.upstreamRequest;
+  const providerType = input.targetProviderConfig?.type?.trim().toLowerCase();
+  if (providerType !== "openai_responses") {
+    return upstreamRequest;
+  }
+  const body = upstreamRequest.body;
+  if ((upstreamRequest.bodyEncoding ?? "json") !== "json" || !isRecord(body) || !Array.isArray(body.tools)) {
+    return upstreamRequest;
+  }
+
+  const tools = stampTools(body.tools);
+  if (tools === body.tools) {
+    return upstreamRequest;
+  }
+  return {
+    ...upstreamRequest,
+    body: {
+      ...body,
+      tools
+    }
+  };
+}
+
+function stampTools(tools: unknown[]): unknown[] {
+  let changed = false;
+  const next = tools.map((tool) => {
+    const stamped = stampTool(tool);
+    if (stamped !== tool) {
+      changed = true;
+    }
+    return stamped;
+  });
+  return changed ? next : tools;
+}
+
+function stampTool(tool: unknown): unknown {
+  if (!isRecord(tool)) {
+    return tool;
+  }
+  if (tool.type === "namespace" && Array.isArray(tool.tools)) {
+    const nested = stampTools(tool.tools);
+    if (nested === tool.tools) {
+      return tool;
+    }
+    return {
+      ...tool,
+      tools: nested
+    };
+  }
+  if (tool.type !== "function" || typeof tool.strict === "boolean") {
+    return tool;
+  }
+  return {
+    ...tool,
+    strict: false
+  };
+}

--- a/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
+++ b/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
@@ -1,5 +1,7 @@
 import { applyResponsesSessionAffinity } from "@ccr/core/gateway/core-runtime/responses-session-affinity";
 import type { ResponsesSessionAffinityInput } from "@ccr/core/gateway/core-runtime/responses-session-affinity";
+import { applyResponsesToolStrictness } from "@ccr/core/gateway/core-runtime/responses-tool-strictness";
+import type { ResponsesToolStrictnessInput } from "@ccr/core/gateway/core-runtime/responses-tool-strictness";
 
 type UpstreamRequest = {
   body: unknown;
@@ -205,6 +207,14 @@ export function createGatewayPlugin() {
         return {
           ok: true as const,
           value: applyResponsesSessionAffinity(input)
+        };
+      }
+    }, {
+      key: "ccr-responses-tool-strictness",
+      transformRequest(input: ResponsesToolStrictnessInput) {
+        return {
+          ok: true as const,
+          value: applyResponsesToolStrictness(input)
         };
       }
     }]

--- a/packages/core/test/unit/gateway/responses-tool-strictness.test.mjs
+++ b/packages/core/test/unit/gateway/responses-tool-strictness.test.mjs
@@ -42,6 +42,8 @@ function readTool(overrides = {}) {
 
 function responsesInput(overrides = {}) {
   return {
+    sourceAdapterKey: "anthropic_messages",
+    sourceProvider: "anthropic",
     targetProviderConfig: {
       name: "multi-channel::openai_responses",
       type: "openai_responses"
@@ -145,6 +147,49 @@ test("requests without tools pass through untouched", () => {
   const result = applyResponsesToolStrictness(input);
 
   assert.equal(result, input.upstreamRequest);
+});
+
+test("native Responses requests leave omitted strict unchanged", () => {
+  const tool = monitorTool();
+  const body = {
+    input: [],
+    model: "gpt-5.1-codex",
+    stream: true,
+    tools: [tool]
+  };
+
+  const input = responsesInput({
+    sourceAdapterKey: undefined,
+    sourceProvider: undefined,
+    request: {
+      body,
+      headers: { "content-type": "application/json" }
+    },
+    upstreamRequest: {
+      body,
+      bodyEncoding: "json",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      url: "https://provider.example/v1/responses"
+    }
+  });
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result, input.upstreamRequest);
+  assert.equal(result.body.tools[0].strict, undefined);
+});
+
+test("Chat Completions conversions leave omitted strict unchanged", () => {
+  const input = responsesInput({
+    sourceAdapterKey: "openai_chat",
+    sourceProvider: "openai"
+  });
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result, input.upstreamRequest);
+  assert.equal(result.body.tools[0].strict, undefined);
 });
 
 test("gateway boundary plugin registers the tool strictness hook", async () => {

--- a/packages/core/test/unit/gateway/responses-tool-strictness.test.mjs
+++ b/packages/core/test/unit/gateway/responses-tool-strictness.test.mjs
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyResponsesToolStrictness } from "@ccr/core/gateway/core-runtime/responses-tool-strictness.ts";
+import { createGatewayPlugin } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
+
+function monitorTool(overrides = {}) {
+  return {
+    type: "function",
+    name: "Monitor",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["description", "timeout_ms", "persistent"],
+      properties: {
+        command: { type: "string" },
+        description: { type: "string" },
+        persistent: { type: "boolean" },
+        timeout_ms: { type: "number" },
+        ws: { type: "object" }
+      }
+    },
+    ...overrides
+  };
+}
+
+function readTool(overrides = {}) {
+  return {
+    type: "function",
+    name: "Read",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["file_path"],
+      properties: {
+        file_path: { type: "string" },
+        pages: { type: "string" }
+      }
+    },
+    ...overrides
+  };
+}
+
+function responsesInput(overrides = {}) {
+  return {
+    targetProviderConfig: {
+      name: "multi-channel::openai_responses",
+      type: "openai_responses"
+    },
+    upstreamRequest: {
+      body: {
+        input: [],
+        model: "gpt-5.1-codex",
+        stream: true,
+        tools: [monitorTool()]
+      },
+      bodyEncoding: "json",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      url: "https://provider.example/v1/responses"
+    },
+    ...overrides
+  };
+}
+
+test("omitted strict on a Monitor-shaped tool becomes false", () => {
+  const input = responsesInput();
+  const originalTool = input.upstreamRequest.body.tools[0];
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result.body.tools[0].strict, false);
+  assert.equal(originalTool.strict, undefined);
+  assert.notEqual(result, input.upstreamRequest);
+  assert.notEqual(result.body, input.upstreamRequest.body);
+  assert.notEqual(result.body.tools, input.upstreamRequest.body.tools);
+});
+
+test("omitted strict on a Read-shaped tool becomes false", () => {
+  const input = responsesInput();
+  input.upstreamRequest.body.tools = [readTool()];
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result.body.tools[0].strict, false);
+  assert.equal(result.body.tools[0].name, "Read");
+});
+
+test("explicit strict true and false are unchanged", () => {
+  const input = responsesInput();
+  input.upstreamRequest.body.tools = [monitorTool({ strict: true }), readTool({ strict: false })];
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result, input.upstreamRequest);
+  assert.equal(result.body.tools[0].strict, true);
+  assert.equal(result.body.tools[1].strict, false);
+});
+
+test("namespace nested function tools with omitted strict become false", () => {
+  const nested = monitorTool();
+  const input = responsesInput();
+  input.upstreamRequest.body.tools = [{
+    type: "namespace",
+    name: "local",
+    tools: [nested]
+  }];
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result.body.tools[0].tools[0].strict, false);
+  assert.equal(nested.strict, undefined);
+  assert.equal(result.body.tools[0].name, "local");
+});
+
+test("non-function tools are left untouched", () => {
+  const searchTool = { type: "tool_search", execution: "client", parameters: { type: "object" } };
+  const input = responsesInput();
+  input.upstreamRequest.body.tools = [searchTool];
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result, input.upstreamRequest);
+  assert.equal("strict" in result.body.tools[0], false);
+});
+
+test("non-Responses providers and non-JSON bodies pass through untouched", () => {
+  const chatInput = responsesInput({
+    targetProviderConfig: { type: "openai_chat_completions" }
+  });
+  assert.equal(applyResponsesToolStrictness(chatInput), chatInput.upstreamRequest);
+
+  const bytesInput = responsesInput();
+  bytesInput.upstreamRequest = {
+    ...bytesInput.upstreamRequest,
+    body: Buffer.from("{}"),
+    bodyEncoding: "bytes"
+  };
+  assert.equal(applyResponsesToolStrictness(bytesInput), bytesInput.upstreamRequest);
+});
+
+test("requests without tools pass through untouched", () => {
+  const input = responsesInput();
+  delete input.upstreamRequest.body.tools;
+
+  const result = applyResponsesToolStrictness(input);
+
+  assert.equal(result, input.upstreamRequest);
+});
+
+test("gateway boundary plugin registers the tool strictness hook", async () => {
+  const hooks = createGatewayPlugin().providerHooks;
+  assert.equal(hooks[0].key, "ccr-upstream-header-sanitizer");
+  assert.ok(hooks.some((hook) => hook.key === "ccr-responses-session-affinity"));
+  const strictnessHook = hooks.find((hook) => hook.key === "ccr-responses-tool-strictness");
+  assert.ok(strictnessHook);
+
+  const input = responsesInput();
+  const result = await strictnessHook.transformRequest(input);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.body.tools[0].strict, false);
+});


### PR DESCRIPTION
## Summary

OpenAI Responses treats omitted `strict` as an attempt to make the tool schema strict. Claude Code tools do not set `strict`, so optional fields (Monitor `command`/`ws`, Read `pages`) get forced on and Claude Code rejects Monitor with `exactly one of command or ws`.

This stamps `strict: false` on outbound Responses function tools that do not already have a boolean `strict`, using the existing CCR provider-hook path.

Closes #1722

## Changes

- Add `applyResponsesToolStrictness` and register it as `ccr-responses-tool-strictness` next to session affinity.
- Leave explicit `strict: true`/`false`, non-function tools, Chat Completions, and non-JSON bodies unchanged.
- Recurse into `type: namespace` nested function tools.

## Test plan

- `node --test .test-dist/core/test/gateway/responses-tool-strictness.test.js`: 8 passed, 0 failed.
- `npm run typecheck`: exit 0.
- `npm run test:core`: new tests passed. Three bundled-plugin tests failed on this machine; the same three fail on `main` without this change (`known bundled plugins without persisted permissions...`, Claude Design split-plugin migration, Claude Design runtime plugin config).
- No live Claude Code Codex session (usage-limited; not in this PR's scope).