### PR TITLE
fix(providers): drop Anthropic metadata on Codex and Grok CLI Responses

### DIFF
--- a/packages/core/src/agents/local-providers/codex.ts
+++ b/packages/core/src/agents/local-providers/codex.ts
@@ -614,7 +614,7 @@ function codexOauthPlugin(suffix: string, providerName = providerNamePlaceholder
 
 function codexBackendRequestTransform(): Record<string, unknown> {
   return {
-    bodyRemove: ["max_output_tokens"]
+    bodyRemove: ["max_output_tokens", "metadata"]
   };
 }
 

--- a/packages/core/src/agents/local-providers/grok.ts
+++ b/packages/core/src/agents/local-providers/grok.ts
@@ -651,6 +651,7 @@ function grokOauthPlugin(suffix: string, token: string, providerName?: string): 
   return {
     ...bearerAuthPlugin(suffix, token, {}, providerName),
     request: {
+      bodyRemove: ["metadata"],
       headers: {
         "x-grok-client-identifier": "xai-grok-cli",
         "x-grok-client-version": grokClientVersion(),

--- a/packages/core/src/gateway/core-runtime/config-compiler.ts
+++ b/packages/core/src/gateway/core-runtime/config-compiler.ts
@@ -568,6 +568,7 @@ async function withGrokOauthRuntimeDefaults(providerPlugins: unknown[]): Promise
           ...currentBodyRemove
             .map((value) => stringValue(value))
             .filter((value): value is string => Boolean(value)),
+          "metadata",
           "external_web_access"
         ]),
         headers: {
@@ -813,7 +814,7 @@ function withCodexBackendRequestTransform(request: unknown): Record<string, unkn
     : [];
   return {
     ...currentRequest,
-    bodyRemove: uniqueStrings([...bodyRemove, "max_output_tokens", "stop"])
+    bodyRemove: uniqueStrings([...bodyRemove, "max_output_tokens", "stop", "metadata"])
   };
 }
 

--- a/packages/core/src/gateway/core-runtime/local-agent-auth-provider-hook.ts
+++ b/packages/core/src/gateway/core-runtime/local-agent-auth-provider-hook.ts
@@ -420,7 +420,8 @@ const grokSupportedResponsesToolTypes = new Set([
 ]);
 
 const grokUnsupportedResponsesOptions = new Set([
-  "external_web_access"
+  "external_web_access",
+  "metadata"
 ]);
 
 function uniqueStrings(values: string[]): string[] {

--- a/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
+++ b/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
@@ -36,11 +36,10 @@ const grokCliUpstreamUrlMarkers = ["cli-chat-proxy.grok.com"];
  * non-empty `prompt_cache_key` always wins; other protocols and non-JSON
  * bodies pass through untouched.
  *
- * Strict subscription proxies (Codex CLI, Grok CLI) reject unknown body
- * fields with 400, so affinity is skipped for them. Anthropic `metadata` is
- * only copied onto the public OpenAI Responses API, which documents that
- * field; every other openai_responses preset would otherwise inherit Claude
- * Code's `metadata.user_id` and fail the same way.
+ * Codex backends reject unknown body fields (`400 Unsupported parameter`),
+ * so affinity is skipped for them. Grok CLI's chat-proxy rejects
+ * `metadata` (`Argument not supported: metadata`) but accepts
+ * `prompt_cache_key`, so only the metadata copy is skipped there.
  */
 export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInput): UpstreamRequest {
   const upstreamRequest = input.upstreamRequest;
@@ -48,7 +47,7 @@ export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInp
   if (providerType !== "openai_responses") {
     return upstreamRequest;
   }
-  if (isStrictResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)) {
+  if (isCodexResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)) {
     return upstreamRequest;
   }
   const body = upstreamRequest.body;
@@ -67,7 +66,7 @@ export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInp
   if (
     inboundUserId &&
     body.metadata === undefined &&
-    isOfficialOpenAIResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)
+    !isGrokCliResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)
   ) {
     changes.metadata = { user_id: inboundUserId };
   }
@@ -111,10 +110,7 @@ export function isCodexResponsesUpstream(
   );
 }
 
-/**
- * Grok CLI chat-proxy: same strict Responses contract as Codex. Unknown
- * fields such as `metadata` return `Argument not supported`.
- */
+/** Grok CLI chat-proxy. Rejects `metadata`; accepts `prompt_cache_key`. */
 export function isGrokCliResponsesUpstream(
   upstreamUrl: string,
   providerConfig?: { baseurl?: string }
@@ -124,40 +120,10 @@ export function isGrokCliResponsesUpstream(
   );
 }
 
-export function isStrictResponsesUpstream(
-  upstreamUrl: string,
-  providerConfig?: { baseurl?: string }
-): boolean {
-  return isCodexResponsesUpstream(upstreamUrl, providerConfig) ||
-    isGrokCliResponsesUpstream(upstreamUrl, providerConfig);
-}
-
-/**
- * Public OpenAI Responses (`api.openai.com`) is the documented home of
- * `metadata`. Claude Code's Anthropic `user_id` is only replayed there.
- */
-export function isOfficialOpenAIResponsesUpstream(
-  upstreamUrl: string,
-  providerConfig?: { baseurl?: string }
-): boolean {
-  return urlCandidates(upstreamUrl, providerConfig).some((normalized) => {
-    const host = hostnameFromCandidate(normalized);
-    return host === "api.openai.com" || host.endsWith(".api.openai.com");
-  });
-}
-
 function urlCandidates(upstreamUrl: string, providerConfig?: { baseurl?: string }): string[] {
   return [upstreamUrl, providerConfig?.baseurl]
     .map((candidate) => candidate?.trim().toLowerCase())
     .filter((candidate): candidate is string => Boolean(candidate));
-}
-
-function hostnameFromCandidate(candidate: string): string {
-  try {
-    return new URL(candidate.includes("://") ? candidate : `https://${candidate}`).hostname;
-  } catch {
-    return "";
-  }
 }
 
 function inboundMetadataUserId(body: unknown): string | undefined {

--- a/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
+++ b/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
@@ -25,7 +25,6 @@ export type ResponsesSessionAffinityInput = {
 
 const sessionIdHeaderNames = ["x-claude-code-session-id", "x-claude-session-id"];
 const codexUpstreamUrlMarkers = ["chatgpt.com/backend-api/codex", "/backend-api/codex"];
-const grokCliUpstreamUrlMarkers = ["cli-chat-proxy.grok.com"];
 
 /**
  * Copies the Claude Code session identity onto outbound OpenAI Responses
@@ -36,10 +35,11 @@ const grokCliUpstreamUrlMarkers = ["cli-chat-proxy.grok.com"];
  * non-empty `prompt_cache_key` always wins; other protocols and non-JSON
  * bodies pass through untouched.
  *
- * Codex backends reject unknown body fields (`400 Unsupported parameter`),
- * so affinity is skipped for them. Grok CLI's chat-proxy rejects
- * `metadata` (`Argument not supported: metadata`) but accepts
- * `prompt_cache_key`, so only the metadata copy is skipped there.
+ * Codex backends reject unknown body fields, so affinity is skipped for
+ * them. Anthropic `metadata` is only copied onto the public OpenAI
+ * Responses API (`api.openai.com`), which documents that field. Other
+ * openai_responses proxies (Grok CLI, custom endpoints, …) inherit Claude
+ * Code's `user_id` and 400 if they do not implement it.
  */
 export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInput): UpstreamRequest {
   const upstreamRequest = input.upstreamRequest;
@@ -66,7 +66,7 @@ export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInp
   if (
     inboundUserId &&
     body.metadata === undefined &&
-    !isGrokCliResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)
+    isOfficialOpenAIResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)
   ) {
     changes.metadata = { user_id: inboundUserId };
   }
@@ -110,20 +110,32 @@ export function isCodexResponsesUpstream(
   );
 }
 
-/** Grok CLI chat-proxy. Rejects `metadata`; accepts `prompt_cache_key`. */
-export function isGrokCliResponsesUpstream(
+/**
+ * Public OpenAI Responses (`api.openai.com`) is the documented home of
+ * `metadata`. Claude Code's Anthropic `user_id` is only replayed there.
+ */
+export function isOfficialOpenAIResponsesUpstream(
   upstreamUrl: string,
   providerConfig?: { baseurl?: string }
 ): boolean {
-  return urlCandidates(upstreamUrl, providerConfig).some((normalized) =>
-    grokCliUpstreamUrlMarkers.some((marker) => normalized.includes(marker))
-  );
+  return urlCandidates(upstreamUrl, providerConfig).some((normalized) => {
+    const host = hostnameFromCandidate(normalized);
+    return host === "api.openai.com" || host.endsWith(".api.openai.com");
+  });
 }
 
 function urlCandidates(upstreamUrl: string, providerConfig?: { baseurl?: string }): string[] {
   return [upstreamUrl, providerConfig?.baseurl]
     .map((candidate) => candidate?.trim().toLowerCase())
     .filter((candidate): candidate is string => Boolean(candidate));
+}
+
+function hostnameFromCandidate(candidate: string): string {
+  try {
+    return new URL(candidate.includes("://") ? candidate : `https://${candidate}`).hostname;
+  } catch {
+    return "";
+  }
 }
 
 function inboundMetadataUserId(body: unknown): string | undefined {

--- a/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
+++ b/packages/core/src/gateway/core-runtime/responses-session-affinity.ts
@@ -25,6 +25,7 @@ export type ResponsesSessionAffinityInput = {
 
 const sessionIdHeaderNames = ["x-claude-code-session-id", "x-claude-session-id"];
 const codexUpstreamUrlMarkers = ["chatgpt.com/backend-api/codex", "/backend-api/codex"];
+const grokCliUpstreamUrlMarkers = ["cli-chat-proxy.grok.com"];
 
 /**
  * Copies the Claude Code session identity onto outbound OpenAI Responses
@@ -33,8 +34,13 @@ const codexUpstreamUrlMarkers = ["chatgpt.com/backend-api/codex", "/backend-api/
  * on body fields hash each turn onto a different channel and the next hop
  * rejects channel-bound `encrypted_content` continuations. A caller-supplied
  * non-empty `prompt_cache_key` always wins; other protocols and non-JSON
- * bodies pass through untouched. Codex upstreams reject unknown body fields
- * with `400 Unsupported parameter`, so affinity is skipped for them.
+ * bodies pass through untouched.
+ *
+ * Strict subscription proxies (Codex CLI, Grok CLI) reject unknown body
+ * fields with 400, so affinity is skipped for them. Anthropic `metadata` is
+ * only copied onto the public OpenAI Responses API, which documents that
+ * field; every other openai_responses preset would otherwise inherit Claude
+ * Code's `metadata.user_id` and fail the same way.
  */
 export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInput): UpstreamRequest {
   const upstreamRequest = input.upstreamRequest;
@@ -42,7 +48,7 @@ export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInp
   if (providerType !== "openai_responses") {
     return upstreamRequest;
   }
-  if (isCodexResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)) {
+  if (isStrictResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)) {
     return upstreamRequest;
   }
   const body = upstreamRequest.body;
@@ -58,7 +64,11 @@ export function applyResponsesSessionAffinity(input: ResponsesSessionAffinityInp
       changes.prompt_cache_key = sessionKey;
     }
   }
-  if (inboundUserId && body.metadata === undefined) {
+  if (
+    inboundUserId &&
+    body.metadata === undefined &&
+    isOfficialOpenAIResponsesUpstream(upstreamRequest.url, input.targetProviderConfig)
+  ) {
     changes.metadata = { user_id: inboundUserId };
   }
   if (Object.keys(changes).length === 0) {
@@ -96,11 +106,58 @@ export function isCodexResponsesUpstream(
   upstreamUrl: string,
   providerConfig?: { baseurl?: string }
 ): boolean {
-  const candidates = [upstreamUrl, providerConfig?.baseurl];
-  return candidates.some((candidate) => {
-    const normalized = candidate?.trim().toLowerCase();
-    return Boolean(normalized && codexUpstreamUrlMarkers.some((marker) => normalized.includes(marker)));
+  return urlCandidates(upstreamUrl, providerConfig).some((normalized) =>
+    codexUpstreamUrlMarkers.some((marker) => normalized.includes(marker))
+  );
+}
+
+/**
+ * Grok CLI chat-proxy: same strict Responses contract as Codex. Unknown
+ * fields such as `metadata` return `Argument not supported`.
+ */
+export function isGrokCliResponsesUpstream(
+  upstreamUrl: string,
+  providerConfig?: { baseurl?: string }
+): boolean {
+  return urlCandidates(upstreamUrl, providerConfig).some((normalized) =>
+    grokCliUpstreamUrlMarkers.some((marker) => normalized.includes(marker))
+  );
+}
+
+export function isStrictResponsesUpstream(
+  upstreamUrl: string,
+  providerConfig?: { baseurl?: string }
+): boolean {
+  return isCodexResponsesUpstream(upstreamUrl, providerConfig) ||
+    isGrokCliResponsesUpstream(upstreamUrl, providerConfig);
+}
+
+/**
+ * Public OpenAI Responses (`api.openai.com`) is the documented home of
+ * `metadata`. Claude Code's Anthropic `user_id` is only replayed there.
+ */
+export function isOfficialOpenAIResponsesUpstream(
+  upstreamUrl: string,
+  providerConfig?: { baseurl?: string }
+): boolean {
+  return urlCandidates(upstreamUrl, providerConfig).some((normalized) => {
+    const host = hostnameFromCandidate(normalized);
+    return host === "api.openai.com" || host.endsWith(".api.openai.com");
   });
+}
+
+function urlCandidates(upstreamUrl: string, providerConfig?: { baseurl?: string }): string[] {
+  return [upstreamUrl, providerConfig?.baseurl]
+    .map((candidate) => candidate?.trim().toLowerCase())
+    .filter((candidate): candidate is string => Boolean(candidate));
+}
+
+function hostnameFromCandidate(candidate: string): string {
+  try {
+    return new URL(candidate.includes("://") ? candidate : `https://${candidate}`).hostname;
+  } catch {
+    return "";
+  }
 }
 
 function inboundMetadataUserId(body: unknown): string | undefined {

--- a/packages/core/src/providers/probe.ts
+++ b/packages/core/src/providers/probe.ts
@@ -1166,7 +1166,7 @@ function withCodexProbeBackendRequestTransform(requestTransform: Record<string, 
   const bodyRemove = readStringArray(requestTransform.bodyRemove);
   return {
     ...requestTransform,
-    bodyRemove: uniqueStrings([...bodyRemove, "max_output_tokens", "stop"])
+    bodyRemove: uniqueStrings([...bodyRemove, "max_output_tokens", "stop", "metadata"])
   };
 }
 

--- a/packages/core/test/unit/gateway/gateway-billing-sync.test.mjs
+++ b/packages/core/test/unit/gateway/gateway-billing-sync.test.mjs
@@ -63,5 +63,5 @@ test("Codex OAuth providers remove unsupported Responses request fields", async 
   );
   const plugin = compiled.providerPlugins.find((item) => item.key === "ccr-local-agent-codex-oauth-test");
 
-  assert.deepEqual(plugin.request.bodyRemove, ["custom-field", "max_output_tokens", "stop"]);
+  assert.deepEqual(plugin.request.bodyRemove, ["custom-field", "max_output_tokens", "stop", "metadata"]);
 });

--- a/packages/core/test/unit/gateway/local-agent-auth-provider-hook.test.mjs
+++ b/packages/core/test/unit/gateway/local-agent-auth-provider-hook.test.mjs
@@ -49,6 +49,7 @@ test("Grok local agent auth hook refreshes live login state before authenticatin
     const upstreamRequest = {
       body: {
         external_web_access: true,
+        metadata: { user_id: "ccr-test" },
         input: [
           { type: "custom_tool_call", call_id: "call_patch", name: "apply_patch", input: patch },
           { type: "custom_tool_call_output", call_id: "call_patch", output: "Success" }
@@ -89,6 +90,7 @@ test("Grok local agent auth hook refreshes live login state before authenticatin
     assert.equal(requestResult.value.headers["x-grok-client-version"], "0.2.93");
     assert.equal(requestResult.value.headers["x-grok-model-override"], "grok-4.5");
     assert.equal(requestResult.value.body.external_web_access, undefined);
+    assert.equal(requestResult.value.body.metadata, undefined);
     assert.deepEqual(requestResult.value.body.tools.map((tool) => tool.type), ["function", "function"]);
     assert.equal(requestResult.value.body.tools[1].name, virtualApplyPatchToolName);
     assert.equal(requestResult.value.body.tools.some((tool) => tool.type === "custom" || tool.type === "namespace"), false);
@@ -222,7 +224,6 @@ test("core gateway config removes Grok unsupported Responses options through dec
       refresh_token: "grok-refresh-token"
     });
     const plugin = grokOauthProviderPlugin();
-    plugin.request.bodyRemove = ["metadata"];
 
     const config = createDefaultAppConfig();
     config.providerPlugins = [plugin];

--- a/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
+++ b/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import {
   applyResponsesSessionAffinity,
   isCodexResponsesUpstream,
-  isGrokCliResponsesUpstream,
+  isOfficialOpenAIResponsesUpstream,
   resolveResponsesSessionKey
 } from "@ccr/core/gateway/core-runtime/responses-session-affinity.ts";
 import { createGatewayPlugin } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
@@ -51,10 +51,17 @@ test("openai_responses bodies gain prompt_cache_key from the Claude Code session
   assert.equal(input.upstreamRequest.body.prompt_cache_key, undefined);
 });
 
-test("inbound metadata.user_id is carried onto the outbound Responses body", () => {
-  const result = applyResponsesSessionAffinity(responsesInput());
+test("inbound metadata.user_id is carried only onto the public OpenAI Responses API", () => {
+  const official = responsesInput();
+  official.upstreamRequest.url = "https://api.openai.com/v1/responses";
 
-  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+  const officialResult = applyResponsesSessionAffinity(official);
+  assert.deepEqual(officialResult.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+  assert.equal(officialResult.body.prompt_cache_key, "session-1111-2222");
+
+  const genericResult = applyResponsesSessionAffinity(responsesInput());
+  assert.equal(genericResult.body.metadata, undefined);
+  assert.equal(genericResult.body.prompt_cache_key, "session-1111-2222");
 });
 
 test("caller-supplied prompt_cache_key is never overwritten", () => {
@@ -112,28 +119,19 @@ test("codex upstreams receive neither prompt_cache_key nor metadata", () => {
   assert.equal(result.body.metadata, undefined);
 });
 
-test("grok CLI upstreams keep prompt_cache_key and omit Anthropic metadata", () => {
-  const input = responsesInput({
-    targetProviderConfig: {
-      name: "grok-cli-api::openai_responses",
-      type: "openai_responses"
-    }
-  });
-  input.upstreamRequest.url = "https://cli-chat-proxy.grok.com/v1/responses";
+test("non-OpenAI openai_responses upstreams keep prompt_cache_key without Anthropic metadata", () => {
+  for (const url of [
+    "https://provider.example/v1/responses",
+    "https://cli-chat-proxy.grok.com/v1/responses"
+  ]) {
+    const input = responsesInput();
+    input.upstreamRequest.url = url;
 
-  const result = applyResponsesSessionAffinity(input);
+    const result = applyResponsesSessionAffinity(input);
 
-  assert.equal(result.body.prompt_cache_key, "session-1111-2222");
-  assert.equal(result.body.metadata, undefined);
-});
-
-test("non-codex openai_responses upstreams keep the affinity injection", () => {
-  const input = responsesInput();
-
-  const result = applyResponsesSessionAffinity(input);
-
-  assert.equal(result.body.prompt_cache_key, "session-1111-2222");
-  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+    assert.equal(result.body.prompt_cache_key, "session-1111-2222");
+    assert.equal(result.body.metadata, undefined);
+  }
 });
 
 test("isCodexResponsesUpstream matches the outbound url and provider baseurl", () => {
@@ -146,13 +144,11 @@ test("isCodexResponsesUpstream matches the outbound url and provider baseurl", (
   assert.equal(isCodexResponsesUpstream("https://mirror.example/backend-api/codex/responses"), true);
 });
 
-test("isGrokCliResponsesUpstream matches the Grok CLI chat proxy", () => {
-  assert.equal(isGrokCliResponsesUpstream("https://cli-chat-proxy.grok.com/v1/responses"), true);
-  assert.equal(isGrokCliResponsesUpstream("https://api.openai.com/v1/responses"), false);
-  assert.equal(
-    isGrokCliResponsesUpstream("https://api.openai.com/v1/responses", { baseurl: "https://cli-chat-proxy.grok.com/v1" }),
-    true
-  );
+test("isOfficialOpenAIResponsesUpstream matches api.openai.com only", () => {
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://api.openai.com/v1/responses"), true);
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://chatgpt.com/backend-api/codex/responses"), false);
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://cli-chat-proxy.grok.com/v1/responses"), false);
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://provider.example/v1/responses"), false);
 });
 
 test("non-Responses providers and non-JSON bodies pass through untouched", () => {

--- a/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
+++ b/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
@@ -4,7 +4,6 @@ import {
   applyResponsesSessionAffinity,
   isCodexResponsesUpstream,
   isGrokCliResponsesUpstream,
-  isOfficialOpenAIResponsesUpstream,
   resolveResponsesSessionKey
 } from "@ccr/core/gateway/core-runtime/responses-session-affinity.ts";
 import { createGatewayPlugin } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
@@ -52,16 +51,10 @@ test("openai_responses bodies gain prompt_cache_key from the Claude Code session
   assert.equal(input.upstreamRequest.body.prompt_cache_key, undefined);
 });
 
-test("inbound metadata.user_id is carried only onto the public OpenAI Responses API", () => {
-  const official = responsesInput();
-  official.upstreamRequest.url = "https://api.openai.com/v1/responses";
+test("inbound metadata.user_id is carried onto the outbound Responses body", () => {
+  const result = applyResponsesSessionAffinity(responsesInput());
 
-  const officialResult = applyResponsesSessionAffinity(official);
-  assert.deepEqual(officialResult.body.metadata, { user_id: "user_abc123_account__session_11112222" });
-
-  const genericResult = applyResponsesSessionAffinity(responsesInput());
-  assert.equal(genericResult.body.metadata, undefined);
-  assert.equal(genericResult.body.prompt_cache_key, "session-1111-2222");
+  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
 });
 
 test("caller-supplied prompt_cache_key is never overwritten", () => {
@@ -119,7 +112,7 @@ test("codex upstreams receive neither prompt_cache_key nor metadata", () => {
   assert.equal(result.body.metadata, undefined);
 });
 
-test("grok CLI upstreams receive neither prompt_cache_key nor metadata", () => {
+test("grok CLI upstreams keep prompt_cache_key and omit Anthropic metadata", () => {
   const input = responsesInput({
     targetProviderConfig: {
       name: "grok-cli-api::openai_responses",
@@ -130,18 +123,17 @@ test("grok CLI upstreams receive neither prompt_cache_key nor metadata", () => {
 
   const result = applyResponsesSessionAffinity(input);
 
-  assert.equal(result, input.upstreamRequest);
-  assert.equal(result.body.prompt_cache_key, undefined);
+  assert.equal(result.body.prompt_cache_key, "session-1111-2222");
   assert.equal(result.body.metadata, undefined);
 });
 
-test("non-strict openai_responses upstreams keep prompt_cache_key without Anthropic metadata", () => {
+test("non-codex openai_responses upstreams keep the affinity injection", () => {
   const input = responsesInput();
 
   const result = applyResponsesSessionAffinity(input);
 
   assert.equal(result.body.prompt_cache_key, "session-1111-2222");
-  assert.equal(result.body.metadata, undefined);
+  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
 });
 
 test("isCodexResponsesUpstream matches the outbound url and provider baseurl", () => {
@@ -161,13 +153,6 @@ test("isGrokCliResponsesUpstream matches the Grok CLI chat proxy", () => {
     isGrokCliResponsesUpstream("https://api.openai.com/v1/responses", { baseurl: "https://cli-chat-proxy.grok.com/v1" }),
     true
   );
-});
-
-test("isOfficialOpenAIResponsesUpstream matches api.openai.com only", () => {
-  assert.equal(isOfficialOpenAIResponsesUpstream("https://api.openai.com/v1/responses"), true);
-  assert.equal(isOfficialOpenAIResponsesUpstream("https://chatgpt.com/backend-api/codex/responses"), false);
-  assert.equal(isOfficialOpenAIResponsesUpstream("https://cli-chat-proxy.grok.com/v1/responses"), false);
-  assert.equal(isOfficialOpenAIResponsesUpstream("https://provider.example/v1/responses"), false);
 });
 
 test("non-Responses providers and non-JSON bodies pass through untouched", () => {

--- a/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
+++ b/packages/core/test/unit/gateway/responses-session-affinity.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { applyResponsesSessionAffinity, isCodexResponsesUpstream, resolveResponsesSessionKey } from "@ccr/core/gateway/core-runtime/responses-session-affinity.ts";
+import {
+  applyResponsesSessionAffinity,
+  isCodexResponsesUpstream,
+  isGrokCliResponsesUpstream,
+  isOfficialOpenAIResponsesUpstream,
+  resolveResponsesSessionKey
+} from "@ccr/core/gateway/core-runtime/responses-session-affinity.ts";
 import { createGatewayPlugin } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
 
 function responsesInput(overrides = {}) {
@@ -46,10 +52,16 @@ test("openai_responses bodies gain prompt_cache_key from the Claude Code session
   assert.equal(input.upstreamRequest.body.prompt_cache_key, undefined);
 });
 
-test("inbound metadata.user_id is carried onto the outbound Responses body", () => {
-  const result = applyResponsesSessionAffinity(responsesInput());
+test("inbound metadata.user_id is carried only onto the public OpenAI Responses API", () => {
+  const official = responsesInput();
+  official.upstreamRequest.url = "https://api.openai.com/v1/responses";
 
-  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+  const officialResult = applyResponsesSessionAffinity(official);
+  assert.deepEqual(officialResult.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+
+  const genericResult = applyResponsesSessionAffinity(responsesInput());
+  assert.equal(genericResult.body.metadata, undefined);
+  assert.equal(genericResult.body.prompt_cache_key, "session-1111-2222");
 });
 
 test("caller-supplied prompt_cache_key is never overwritten", () => {
@@ -107,13 +119,29 @@ test("codex upstreams receive neither prompt_cache_key nor metadata", () => {
   assert.equal(result.body.metadata, undefined);
 });
 
-test("non-codex openai_responses upstreams keep the affinity injection", () => {
+test("grok CLI upstreams receive neither prompt_cache_key nor metadata", () => {
+  const input = responsesInput({
+    targetProviderConfig: {
+      name: "grok-cli-api::openai_responses",
+      type: "openai_responses"
+    }
+  });
+  input.upstreamRequest.url = "https://cli-chat-proxy.grok.com/v1/responses";
+
+  const result = applyResponsesSessionAffinity(input);
+
+  assert.equal(result, input.upstreamRequest);
+  assert.equal(result.body.prompt_cache_key, undefined);
+  assert.equal(result.body.metadata, undefined);
+});
+
+test("non-strict openai_responses upstreams keep prompt_cache_key without Anthropic metadata", () => {
   const input = responsesInput();
 
   const result = applyResponsesSessionAffinity(input);
 
   assert.equal(result.body.prompt_cache_key, "session-1111-2222");
-  assert.deepEqual(result.body.metadata, { user_id: "user_abc123_account__session_11112222" });
+  assert.equal(result.body.metadata, undefined);
 });
 
 test("isCodexResponsesUpstream matches the outbound url and provider baseurl", () => {
@@ -124,6 +152,22 @@ test("isCodexResponsesUpstream matches the outbound url and provider baseurl", (
     true
   );
   assert.equal(isCodexResponsesUpstream("https://mirror.example/backend-api/codex/responses"), true);
+});
+
+test("isGrokCliResponsesUpstream matches the Grok CLI chat proxy", () => {
+  assert.equal(isGrokCliResponsesUpstream("https://cli-chat-proxy.grok.com/v1/responses"), true);
+  assert.equal(isGrokCliResponsesUpstream("https://api.openai.com/v1/responses"), false);
+  assert.equal(
+    isGrokCliResponsesUpstream("https://api.openai.com/v1/responses", { baseurl: "https://cli-chat-proxy.grok.com/v1" }),
+    true
+  );
+});
+
+test("isOfficialOpenAIResponsesUpstream matches api.openai.com only", () => {
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://api.openai.com/v1/responses"), true);
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://chatgpt.com/backend-api/codex/responses"), false);
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://cli-chat-proxy.grok.com/v1/responses"), false);
+  assert.equal(isOfficialOpenAIResponsesUpstream("https://provider.example/v1/responses"), false);
 });
 
 test("non-Responses providers and non-JSON bodies pass through untouched", () => {


### PR DESCRIPTION
Fixes #1730

## Problem

Claude Code always sends Anthropic Messages `metadata`. CCR's converter drops it, then session-affinity copies `metadata.user_id` onto **every** `openai_responses` body except Codex.

That is an Anthropic field. The public OpenAI Responses API documents `metadata`. Strict proxies do not. Grok CLI 1.0.5 returns `Argument not supported: metadata`. Codex already 400'd the same way before #1715. The next CLI preset will too if we keep a per-host denylist.

Checked live on Grok:

| Request | Result |
| --- | --- |
| no `metadata` | 200 |
| session header only (`prompt_cache_key`) | 200 |
| `metadata` present | 400 |

## Fix

One rule for all `openai_responses` providers, not a Grok special case:

- Copy Anthropic `metadata` only to `api.openai.com`
- Keep `prompt_cache_key` on every non-Codex Responses upstream (Grok accepts it)
- Codex: still skip all affinity (#1715)
- Codex/Grok `bodyRemove` still drops leftover `metadata` on the Responses body

## Test plan

- [x] `api.openai.com` gets `metadata` and `prompt_cache_key`
- [x] Grok CLI and generic Responses hosts get `prompt_cache_key` without `metadata`
- [x] Codex gets neither
- [x] Live Grok: `prompt_cache_key` 200, `metadata` 400
