### PR TITLE
docs(guides): clarify OpenAI Chat vs Responses for custom endpoints

### DIFF
--- a/docs/src/content/docs/en/guides/provider.md
+++ b/docs/src/content/docs/en/guides/provider.md
@@ -28,6 +28,29 @@ The protocol decides which request format CCR uses to talk to the upstream. It i
 
 If auto-detection misses the mark, turn it off in **Advanced settings**, choose a protocol manually, and confirm with a connectivity check.
 
+## OpenAI-compatible custom endpoints
+
+When you choose **Other / custom API endpoint**, two details are easy to get wrong on hosts that speak OpenAI Chat Completions but also expose other routes:
+
+1. **Use the `/v1` root as the API endpoint**, not `/v1/chat/completions`. CCR appends the route for the selected protocol and discovers models with `GET /v1/models`.
+2. **Pick OpenAI Chat**, not OpenAI Responses or Anthropic Messages. Auto-detect may choose **OpenAI Responses** when `POST /v1/responses` exists on the host — even if unauthenticated calls return `401` rather than `404`. Hosts that only support Chat Completions need **OpenAI Chat** manually.
+
+If auto-detect picked the wrong protocol, turn it off in **Advanced settings**, select **OpenAI Chat**, and confirm with **Check Connection**.
+
+### Worked example
+
+The following steps work against an OpenAI-compatible host whose catalog is available at `GET https://api.example.com/v1/models`:
+
+1. **Providers** → **Add Provider** → **Other / custom API endpoint**
+2. **Name**: any internal label (for example `my-gateway`)
+3. **API endpoint**: `https://api.example.com/v1`
+4. **API key**: your Bearer token
+5. **Protocol**: **OpenAI Chat** (disable auto-detect in **Advanced settings** if it selected Responses)
+6. **Models**: auto-fetch or add a model ID from the catalog
+7. **Check Connection** on one text model (this sends a real request)
+
+Do not append `/chat/completions` to the endpoint. Do not choose **Anthropic Messages** for an OpenAI-compatible wire.
+
 ## Verify connectivity
 
 Once credentials and models are in place, click **Check Connection**: CCR sends a real request with the current API endpoint, key, protocol, and selected models to confirm the full path works. Output is length-limited, but it may still consume a few tokens or count toward provider-side request limits, so select only the models you need to confirm.

--- a/docs/src/content/docs/zh/guides/provider.md
+++ b/docs/src/content/docs/zh/guides/provider.md
@@ -28,6 +28,29 @@ lead: "页面顶部的交互式面板可直接连到你正在运行的 CCR 添�
 
 自动探测结果不理想时，可在 **高级设置** 中关闭自动探测并手动选择协议，再用连通性检查确认。
 
+## OpenAI 兼容的自定义端点
+
+选择 **其他 / 自定义 API 地址** 时，如果上游同时提供 Chat Completions 和其他路由，下面两点很容易配错：
+
+1. **API 地址应填写 `/v1` 根路径**，不要写成 `/v1/chat/completions`。CCR 会按所选协议拼接具体路由，并通过 `GET /v1/models` 发现模型。
+2. **协议应选择 OpenAI Chat**，而不是 OpenAI Responses 或 Anthropic Messages。自动探测可能在主机存在 `POST /v1/responses` 时选中 **OpenAI Responses**——即使未认证请求返回的是 `401` 而不是 `404`。只支持 Chat Completions 的主机需要手动选择 **OpenAI Chat**。
+
+如果自动探测选错了协议，请在 **高级设置** 中关闭自动探测，选择 **OpenAI Chat**，再用 **检测连通性** 确认。
+
+### 示例
+
+以下步骤适用于可通过 `GET https://api.example.com/v1/models` 获取模型目录的 OpenAI 兼容主机：
+
+1. **供应商** → **添加供应商** → **其他 / 自定义 API 地址**
+2. **名称**：任意内部标识（例如 `my-gateway`）
+3. **API 地址**：`https://api.example.com/v1`
+4. **API 密钥**：你的 Bearer token
+5. **协议**：**OpenAI Chat**（若自动探测选了 Responses，请在 **高级设置** 中关闭自动探测）
+6. **模型**：自动获取，或手动添加目录中的模型 ID
+7. 对一个文本模型执行 **检测连通性**（会发送真实请求）
+
+不要在 API 地址末尾追加 `/chat/completions`。OpenAI 兼容线路不要选择 **Anthropic Messages**。
+
 ## 验证连通性
 
 填好凭据和模型后，点击 **检测连通性**：CCR 会用当前的 API 地址、密钥、协议和所选模型发送一次真实请求，确认整条链路可用。检测会限制输出长度，但仍可能产生少量 token 消耗或计入供应商侧请求次数，因此建议只勾选需要确认的模型。


### PR DESCRIPTION
## Summary

Add guidance to the **Add a provider** guide for OpenAI-compatible custom endpoints: use the `/v1` root as the API endpoint and manually select **OpenAI Chat** when auto-detect picks **OpenAI Responses**.

## Motivation

Fixes #1731.

Hosts that speak OpenAI Chat Completions often also expose `POST /v1/responses`. CCR's protocol probe treats `401`/`403` as support, so auto-detect may select **OpenAI Responses** even when the host only works with Chat Completions. Users also commonly paste `/v1/chat/completions` instead of the `/v1` root.

## Changes

- Add **OpenAI-compatible custom endpoints** section to `docs/src/content/docs/en/guides/provider.md`
- Add the same section in Chinese to `docs/src/content/docs/zh/guides/provider.md`
- Include a generic worked example (`api.example.com`) covering endpoint, protocol, and connectivity check

## Tests

```bash
npm run test:architecture
cd docs && npm run build
```

Both passed locally.

## Notes

- Documentation-only change; no runtime behavior changes.
- Reviewed with composer-2.5 before submission (APPROVE).