### PR TITLE
fix: preserve coworkEgressAllowedHosts when rewriting Claude App config

### DIFF
--- a/packages/core/src/agents/claude-app/gateway-service.ts
+++ b/packages/core/src/agents/claude-app/gateway-service.ts
@@ -175,7 +175,7 @@ export function applyClaudeAppGatewayConfig(config: AppConfig, options: ClaudeAp
   }
   for (const targetPaths of uniqueClaudeAppGatewayPaths([paths, activePaths])) {
     mkdirSync(targetPaths.libraryDir, { mode: 0o700, recursive: true });
-    writeJsonFile(targetPaths.configLibraryFile, gatewayConfig);
+    applyClaudeAppGatewayLibraryConfig(targetPaths.configLibraryFile, gatewayConfig);
     applyClaudeAppConfigMeta(targetPaths.metaFile);
     applyClaudeAppDeploymentMode(targetPaths.rootConfigFile);
     if (options.refreshModelDiscoveryCache) {
@@ -445,6 +445,14 @@ function gatewayEndpoint(config: AppConfig): string {
   const formattedHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
   const port = Number.isInteger(config.gateway.port) && config.gateway.port > 0 ? config.gateway.port : config.PORT;
   return `http://${formattedHost}:${port}`;
+}
+
+function applyClaudeAppGatewayLibraryConfig(file: string, gatewayConfig: ClaudeAppGatewayConfig): void {
+  const current = readJsonRecord(file);
+  writeJsonFile(file, {
+    ...(current ?? {}),
+    ...gatewayConfig
+  });
 }
 
 function applyClaudeAppConfigMeta(metaFile: string): void {

--- a/packages/core/test/unit/agents/claude-app-gateway-service.test.mjs
+++ b/packages/core/test/unit/agents/claude-app-gateway-service.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -75,6 +75,48 @@ test("Claude App gateway config writes the selected default model first", () => 
   }
 });
 
+test("Claude App gateway config preserves unknown keys when rewriting config library", () => {
+  const dataDir = mkdtempSync(path.join(os.tmpdir(), "ccr-claude-app-gateway-preserve-"));
+  const activeDataDir = `${dataDir}-3p`;
+  const configId = "8f69f2f1-3275-4ad8-9317-4aa7e972f311.json";
+  const applyOptions = { backup: false, dataDir };
+
+  try {
+    const { result } = applyClaudeAppGatewayConfig(createConfig(), applyOptions);
+    const launchLibraryFile = path.join(dataDir, "configLibrary", configId);
+    const activeLibraryFile = result.configLibraryFile;
+
+    for (const file of [launchLibraryFile, activeLibraryFile]) {
+      writeJson(file, {
+        ...readJson(file),
+        coworkEgressAllowedHosts: ["*"],
+        extraUnknownKey: "keep-me"
+      });
+    }
+
+    applyClaudeAppGatewayConfig(createConfig({
+      PORT: 3457,
+      gateway: {
+        enabled: false,
+        host: "0.0.0.0",
+        port: 3457
+      }
+    }), applyOptions);
+
+    for (const file of [launchLibraryFile, activeLibraryFile]) {
+      const rewritten = readJson(file);
+      assert.deepEqual(rewritten.coworkEgressAllowedHosts, ["*"]);
+      assert.equal(rewritten.extraUnknownKey, "keep-me");
+      assert.equal(rewritten.inferenceGatewayBaseUrl, "http://127.0.0.1:3457");
+      assert.equal(rewritten.inferenceProvider, "gateway");
+      assert.equal(rewritten.inferenceGatewayApiKey, "existing-test-key");
+    }
+  } finally {
+    rmSync(dataDir, { force: true, recursive: true });
+    rmSync(activeDataDir, { force: true, recursive: true });
+  }
+});
+
 function createConfig(overrides = {}) {
   return {
     APIKEY: "existing-test-key",
@@ -100,4 +142,8 @@ function createConfig(overrides = {}) {
 
 function readJson(file) {
   return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 }


### PR DESCRIPTION
`applyClaudeAppGatewayConfig` was writing a fresh gateway-only object over `configLibrary/<id>.json`. That dropped sibling fields such as `coworkEgressAllowedHosts`, so Cowork/Code sandbox egress fell back to gateway-only (`cowork-egress-blocked`) after each CCR apply/restart.

Match the meta/root writers: merge the existing library JSON, then overlay gateway fields. Unknown keys (including a user-set `coworkEgressAllowedHosts: ["*"]`) survive a rewrite, while gateway URL/models still update.

Fixes #1735