### PR TITLE
fix(ui): keep manual provider protocol deselection on probe and edit save

### DIFF
--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -1647,7 +1647,8 @@ function App() {
       providerCapabilitiesForProtocols(providerDraft.baseUrl, protocolsToSave, saveProbe, presetCapabilitiesFromDraft(providerDraft)),
       providerDraft.capabilities,
       existingProvider ? providerBaseUrl(existingProvider) : undefined,
-      providerDraft.baseUrl
+      providerDraft.baseUrl,
+      protocolsToSave
     );
     const primaryCapability =
       capabilities.find((capability) => capability.type === fallbackProtocol) ??

--- a/packages/ui/src/pages/home/components/providers.tsx
+++ b/packages/ui/src/pages/home/components/providers.tsx
@@ -2149,6 +2149,7 @@ export function AddProviderForm({
         modelSearch: "",
         presetId,
         providerPlugins: [],
+        protocolsManuallyEdited: false,
         selectedModels: [],
         selectedProtocols: []
       }, true);
@@ -2167,6 +2168,7 @@ export function AddProviderForm({
         modelSearch: "",
         presetId,
         providerPlugins: [],
+        protocolsManuallyEdited: false,
         selectedModels: [],
         selectedProtocols: []
       }, true);
@@ -2192,6 +2194,7 @@ export function AddProviderForm({
       presetId,
       providerPlugins: [],
       protocol: endpoint?.protocols[0] ?? draft.protocol,
+      protocolsManuallyEdited: false,
       selectedModels: [],
       selectedProtocols: uniqueProviderProtocols(preset?.endpoints.flatMap((item) => item.protocols) ?? endpoint?.protocols ?? [])
     }, true);
@@ -2490,6 +2493,7 @@ export function AddProviderForm({
                                     checked={checked}
                                     onCheckedChange={() => {
                                       onChange({
+                                        protocolsManuallyEdited: true,
                                         selectedProtocols: checked
                                           ? draft.selectedProtocols.filter((selected) => selected !== protocol)
                                           : uniqueProviderProtocols([...draft.selectedProtocols, protocol])
@@ -2523,6 +2527,7 @@ export function AddProviderForm({
                                         return;
                                       }
                                       onChange({
+                                        protocolsManuallyEdited: true,
                                         selectedProtocols: checked
                                           ? draft.selectedProtocols.filter((protocol) => protocol !== selectableProtocol)
                                           : uniqueProviderProtocols([...draft.selectedProtocols, selectableProtocol])

--- a/packages/ui/src/pages/home/shared/providers.ts
+++ b/packages/ui/src/pages/home/shared/providers.ts
@@ -661,6 +661,7 @@ export function createProviderDraftFromDeepLinkPayload(
     protocolDetectionMode: "auto",
     providerPlugins: [],
     protocol,
+    protocolsManuallyEdited: false,
     selectedModels: [],
     selectedProtocols: uniqueProviderProtocols(preset?.endpoints.flatMap((item) => item.protocols) ?? [protocol])
   };
@@ -758,6 +759,7 @@ export function createProviderDraft(providers: GatewayProviderConfig[]): AddProv
     protocolDetectionMode: "auto",
     providerPlugins: [],
     protocol: "openai_chat_completions",
+    protocolsManuallyEdited: false,
     selectedModels: [],
     selectedProtocols: []
   };
@@ -795,6 +797,7 @@ export function createProviderDraftFromProvider(provider: GatewayProviderConfig)
     protocolDetectionMode: provider.protocolDetectionMode === "manual" ? "manual" : "auto",
     providerPlugins: [],
     protocol,
+    protocolsManuallyEdited: true,
     selectedModels: [],
     selectedProtocols: selectedProviderProtocolsFromCapabilities(provider.capabilities, protocol)
   };
@@ -1905,14 +1908,15 @@ export function selectedProviderProtocolsForProbe(
   selectedProtocols: GatewayProviderProtocol[],
   probe: GatewayProviderProbeResult,
   _fallback: GatewayProviderProtocol,
-  presetId?: string
+  presetId?: string,
+  protocolsManuallyEdited = false
 ): GatewayProviderProtocol[] {
   const selectable = providerSelectableProtocolsFromProbe(probe);
   if (selectable.length === 0) {
     return [];
   }
 
-  if (selectedProtocolsMatchPresetDefault(selectedProtocols, presetId)) {
+  if (!protocolsManuallyEdited && selectedProtocolsMatchPresetDefault(selectedProtocols, presetId)) {
     return selectable;
   }
 
@@ -1981,11 +1985,28 @@ export function mergeProviderCapabilities(...groups: GatewayProviderCapability[]
   return capabilities;
 }
 
+const secondaryMediaProviderProtocols = new Set<GatewayProviderProtocol>([
+  "openai_image_generations",
+  "openai_video_generations",
+  "xai_video_generations"
+]);
+
+function preservedCapabilitiesForSelectedProtocols(
+  preservedCapabilities: GatewayProviderCapability[],
+  selectedProtocols: GatewayProviderProtocol[]
+): GatewayProviderCapability[] {
+  const selected = new Set(uniqueProviderProtocols(selectedProtocols));
+  return preservedCapabilities.filter((capability) =>
+    secondaryMediaProviderProtocols.has(capability.type) || selected.has(capability.type)
+  );
+}
+
 export function providerCapabilitiesForSave(
   currentCapabilities: GatewayProviderCapability[],
   preservedCapabilities: GatewayProviderCapability[],
   existingBaseUrl: string | undefined,
-  nextBaseUrl: string
+  nextBaseUrl: string,
+  selectedProtocols?: GatewayProviderProtocol[]
 ): GatewayProviderCapability[] {
   const normalizedExistingBaseUrl = existingBaseUrl === undefined
     ? undefined
@@ -1993,9 +2014,14 @@ export function providerCapabilitiesForSave(
   const normalizedNextBaseUrl = normalizeProviderBaseUrl(nextBaseUrl) || nextBaseUrl.trim();
   const preserveExisting = normalizedExistingBaseUrl === undefined ||
     normalizedExistingBaseUrl === normalizedNextBaseUrl;
+  const capabilitiesToPreserve = preserveExisting
+    ? selectedProtocols === undefined
+      ? preservedCapabilities
+      : preservedCapabilitiesForSelectedProtocols(preservedCapabilities, selectedProtocols)
+    : [];
   return mergeProviderCapabilities(
     currentCapabilities,
-    ...(preserveExisting ? [preservedCapabilities] : [])
+    ...(capabilitiesToPreserve.length > 0 ? [capabilitiesToPreserve] : [])
   );
 }
 
@@ -2149,7 +2175,13 @@ export function providerCapabilitiesForProtocols(
 
 export function applyProviderProbeResult(draft: AddProviderDraft, probe: GatewayProviderProbeResult): AddProviderDraft {
   const detectedProtocol = probe.detectedProtocol ?? draft.protocol;
-  const selectedProtocols = selectedProviderProtocolsForProbe(draft.selectedProtocols, probe, detectedProtocol, draft.presetId);
+  const selectedProtocols = selectedProviderProtocolsForProbe(
+    draft.selectedProtocols,
+    probe,
+    detectedProtocol,
+    draft.presetId,
+    draft.protocolsManuallyEdited
+  );
   const protocol = selectedProtocols.includes(draft.protocol)
     ? draft.protocol
     : selectedProtocols.includes(detectedProtocol)

--- a/packages/ui/src/pages/home/shared/types.ts
+++ b/packages/ui/src/pages/home/shared/types.ts
@@ -113,6 +113,7 @@ export type AddProviderDraft = {
   protocolDetectionMode: "auto" | "manual";
   providerPlugins: unknown[];
   protocol: GatewayProviderProtocol;
+  protocolsManuallyEdited: boolean;
   selectedModels: string[];
   selectedProtocols: GatewayProviderProtocol[];
   usageBalanceLimitPath: string;

--- a/packages/ui/test/integration/providers.test.ts
+++ b/packages/ui/test/integration/providers.test.ts
@@ -145,6 +145,84 @@ test("provider save keeps explicit secondary media origins when the base URL is 
     providerCapabilitiesForSave(current, media, "https://chat.example/v1/", "https://chat.example/v1"),
     [...current, ...media]
   );
+  assert.deepEqual(
+    providerCapabilitiesForSave(current, media, "https://chat.example/v1/", "https://chat.example/v1", ["openai_chat_completions"]),
+    [...current, ...media]
+  );
+});
+
+test("provider save drops deselected protocol capabilities on edit", () => {
+  const current = [{
+    baseUrl: "https://gateway.example/v1",
+    source: "detected" as const,
+    type: "openai_chat_completions" as const
+  }];
+  const previous = [
+    {
+      baseUrl: "https://gateway.example/v1",
+      source: "detected" as const,
+      type: "openai_chat_completions" as const
+    },
+    {
+      baseUrl: "https://gateway.example/anthropic",
+      source: "detected" as const,
+      type: "anthropic_messages" as const
+    }
+  ];
+
+  assert.deepEqual(
+    providerCapabilitiesForSave(
+      current,
+      previous,
+      "https://gateway.example/v1",
+      "https://gateway.example/v1",
+      ["openai_chat_completions"]
+    ),
+    current
+  );
+});
+
+test("provider probe keeps manual protocol deselection across auto-detect probes", () => {
+  setProviderPresets([moonshotGlobalProviderPreset]);
+  const draft = {
+    ...createProviderDraft([]),
+    baseUrl: "https://api.moonshot.ai/v1",
+    presetId: "moonshot-global",
+    protocol: "openai_chat_completions",
+    protocolsManuallyEdited: true,
+    selectedProtocols: ["openai_chat_completions"]
+  };
+  const probe = {
+    capabilities: [
+      {
+        baseUrl: "https://api.moonshot.ai/anthropic",
+        endpoint: "https://api.moonshot.ai/anthropic/v1/messages",
+        source: "detected" as const,
+        type: "anthropic_messages" as const
+      },
+      {
+        baseUrl: "https://api.moonshot.ai/v1",
+        source: "preset" as const,
+        type: "openai_chat_completions" as const
+      }
+    ],
+    detectedProtocol: "anthropic_messages" as const,
+    models: [],
+    normalizedBaseUrl: "https://api.moonshot.ai/anthropic",
+    protocols: [
+      {
+        endpoint: "https://api.moonshot.ai/anthropic/v1/messages",
+        message: "HTTP 400: model is required",
+        protocol: "anthropic_messages" as const,
+        status: 400,
+        supported: true
+      }
+    ]
+  };
+
+  const next = applyProviderProbeResult(draft, probe);
+
+  assert.deepEqual(next.selectedProtocols, ["openai_chat_completions"]);
 });
 
 test("provider save keeps hand-written fields the dialog cannot edit", () => {


### PR DESCRIPTION
## Summary

Fix the provider setup UI re-adding protocols the user explicitly deselected during auto-detect probes and when saving an edited provider.

## Motivation

Fixes #1727

When a provider supports multiple protocols, unchecking one in the web UI did not stick: auto-detect probes could expand the selection back to all detected protocols, and the edit save path could merge previously saved capabilities for deselected protocols.

## Changes

- Add `protocolsManuallyEdited` to `AddProviderDraft` and set it when users toggle protocol checkboxes
- Gate `selectedProviderProtocolsForProbe` preset-default expansion on that flag
- Filter preserved capabilities in `providerCapabilitiesForSave` by the selected protocol set, while still preserving secondary media origins (`openai_image_generations`, `openai_video_generations`, `xai_video_generations`)
- Treat edit-mode drafts loaded from an existing provider as manually edited so reopening the dialog does not silently re-expand protocols

## Tests

```bash
cd packages/ui && npm run test:integration
```

Result: 53 integration tests pass (including 2 new regression tests for probe persistence and edit save filtering).

## Notes

- composer-2.5 review: **APPROVE**
- Scope is limited to provider protocol selection UI/state; no gateway runtime behavior changes