### PR TITLE
fix(ui): 修复账户余额网格行数超限导致的卡片裁切

### DIFF
--- a/packages/ui/src/pages/home/components/dashboard.tsx
+++ b/packages/ui/src/pages/home/components/dashboard.tsx
@@ -4135,6 +4135,8 @@ function providerAccountBentoLayout(accounts: ProviderAccountSnapshot[], dimensi
   hiddenCount: number;
   items: Array<{ account: ProviderAccountSnapshot; span: ProviderAccountBentoSpan }>;
 } {
+  const columns = providerAccountBentoColumnCount(dimensions, accounts.length);
+  const maxRows = providerAccountBentoRowCount(dimensions);
   const maxUnits = providerAccountBentoMaxUnits(dimensions, accounts.length);
   const items = accounts.map((account) => ({
     account,
@@ -4150,27 +4152,92 @@ function providerAccountBentoLayout(accounts: ProviderAccountSnapshot[], dimensi
     }
   }
 
-  if (usedUnits <= maxUnits) {
-    return { hiddenCount: 0, items };
+  let visibleItems = items;
+  if (usedUnits > maxUnits) {
+    const visibleBudget = Math.max(0, maxUnits - 1);
+    visibleItems = [];
+    let visibleUnits = 0;
+
+    for (const item of items) {
+      const itemUnits = providerAccountBentoSpanUnits(item.span);
+      if (visibleUnits + itemUnits > visibleBudget) {
+        break;
+      }
+      visibleItems.push(item);
+      visibleUnits += itemUnits;
+    }
   }
 
-  const visibleBudget = Math.max(0, maxUnits - 1);
-  const visibleItems: Array<{ account: ProviderAccountSnapshot; span: ProviderAccountBentoSpan }> = [];
-  let visibleUnits = 0;
-
-  for (const item of items) {
-    const itemUnits = providerAccountBentoSpanUnits(item.span);
-    if (visibleUnits + itemUnits > visibleBudget) {
+  // 格子预算挡不住「行数超限」：双行卡片会把 dense 排布撑出额外行，
+  // auto-rows-fr 会把组件高度均分给实际用到的每一行，行数超过组件高度档位时
+  // 行高会被压到卡片最小内容高度以下，单行卡片内容被裁切。
+  // 这里按真实 dense 排布模拟行数，超限时先降级双行卡片（跳过手动尺寸），再从尾部隐藏。
+  for (let guard = 0; guard <= items.length * 2 + 1; guard += 1) {
+    const rowsUsed = providerAccountBentoPackedRowCount(visibleItems, columns, visibleItems.length < items.length);
+    if (rowsUsed <= maxRows || visibleItems.length === 0) {
       break;
     }
-    visibleItems.push(item);
-    visibleUnits += itemUnits;
+    let demotableIndex = -1;
+    for (let index = visibleItems.length - 1; index >= 0; index -= 1) {
+      if (visibleItems[index].span.height === 2 && !visibleItems[index].manual) {
+        demotableIndex = index;
+        break;
+      }
+    }
+    if (demotableIndex >= 0) {
+      visibleItems = visibleItems.map((item, index) => index === demotableIndex
+        ? { ...item, span: { ...item.span, height: 1 as const } }
+        : item);
+      continue;
+    }
+    if (visibleItems.length <= 1) {
+      break;
+    }
+    visibleItems = visibleItems.slice(0, -1);
   }
 
   return {
     hiddenCount: accounts.length - visibleItems.length,
     items: visibleItems
   };
+}
+
+function providerAccountBentoPackedRowCount(items: Array<{ span: ProviderAccountBentoSpan }>, columns: number, includeOverflowTile: boolean): number {
+  const occupied = new Set<string>();
+  let rowCount = 0;
+  const place = (itemWidth: number, itemHeight: number) => {
+    const width = Math.max(1, Math.min(itemWidth, columns));
+    const height = Math.max(1, itemHeight);
+    for (let row = 0; ; row += 1) {
+      for (let column = 0; column + width <= columns; column += 1) {
+        let fits = true;
+        for (let offsetY = 0; offsetY < height && fits; offsetY += 1) {
+          for (let offsetX = 0; offsetX < width; offsetX += 1) {
+            if (occupied.has(`${row + offsetY}:${column + offsetX}`)) {
+              fits = false;
+              break;
+            }
+          }
+        }
+        if (fits) {
+          for (let offsetY = 0; offsetY < height; offsetY += 1) {
+            for (let offsetX = 0; offsetX < width; offsetX += 1) {
+              occupied.add(`${row + offsetY}:${column + offsetX}`);
+            }
+          }
+          rowCount = Math.max(rowCount, row + height);
+          return;
+        }
+      }
+    }
+  };
+  for (const item of items) {
+    place(item.span.width, item.span.height);
+  }
+  if (includeOverflowTile) {
+    place(1, 1);
+  }
+  return rowCount;
 }
 
 function providerAccountBentoUsedUnits(items: Array<{ span: ProviderAccountBentoSpan }>): number {
@@ -4192,10 +4259,10 @@ function providerAccountBentoColumnCount(dimensions: OverviewWidgetDimensions, i
 }
 
 function providerAccountBentoRowCount(dimensions: OverviewWidgetDimensions): number {
-  if (dimensions.height <= 1) return 1;
-  if (dimensions.height === 2) return 3;
-  if (dimensions.height === 3) return 4;
-  return 5;
+  // Bento 行高由 auto-rows-fr 在组件内容高度内均分，单行卡片的最小内容高度约 100px，
+  // 组件每个高度档位（overview 网格一行约 148px）只够容纳等量的 bento 行；
+  // 行数一旦超过组件高度档位，行高会被均分压缩到卡片最小高度以下，内容被裁切。
+  return dimensions.height;
 }
 
 function providerAccountBentoGridClass(dimensions: OverviewWidgetDimensions, itemCount: number): string {


### PR DESCRIPTION
Fixes #1741

## 问题

概览页「账户余额」组件（Cards 视图）在供应商账户较多时（≥4 个，且部分卡片为双行 `row-span-2`）出现错位：单行卡片内容被拦腰裁切（额度标题和数值只露出上半截），网格出现大片空洞，行高不一致。账户数 ≤3 时完全正常。

## 根因

两个问题叠加：

1. **行数映射过于激进**：`providerAccountBentoRowCount()` 把高度 2 档的组件映射为最多 3 行 bento（3 档→4 行、4 档→5 行）。overview 网格每行 148px，高度 2 档组件内容区约 240px，而单行卡片最小内容高度约 93~105px。bento 一旦实际铺出 3 行，`auto-rows-fr`（`minmax(0,1fr)`）把高度均分后每行仅约 80px，卡片在 `overflow-hidden` 下被裁切。
2. **格子预算 ≠ 行数预算**：`providerAccountBentoLayout()` 只按格子数（列数 × 行数上限）限制可见卡片。`[1×1, 1×1, 1×2, 1×2]` 四张卡格子数 6 ≤ 预算 9，不会被收敛；双行卡片在 `grid-flow-dense` 下把网格实际撑出第 3 行，触发问题 1，同时留下空洞。

## 修复

- `providerAccountBentoRowCount`：行数上限改为跟随组件高度档位（height 即最大行数），保证每行约 120px；
- `providerAccountBentoLayout` 新增「行数收敛」阶段：新增 `providerAccountBentoPackedRowCount()` 按 CSS dense 规则模拟排布、计算真实占用行数（含 "+N" 溢出块占位）；超限时先从尾部降级双行卡片为单行（跳过手动设定尺寸的卡片），仍超限再从尾部隐藏进 "+N" 溢出块。

原有的格子预算降级/截断逻辑保持不变，行数收敛在其之后执行。

## 验证

用与 CSS `grid-flow-dense` 等价的模拟对各场景做了修复前后对比（3 列、高度 2 档组件）：

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| 4 账户 `[1x1,1x1,1x2,1x2]`（Issue 截图场景） | 3 行 × ~81px，单行卡裁切 ❌ | 2 行 × ~122px，4 张全可见 ✅ |
| 4 账户全部 `[1x2]` | 4 行 × ~61px，严重裁切 ❌ | 2 行 × ~122px，4 张全可见 ✅ |
| 3 账户 `[1x1,1x1,1x2]`（原本正常） | 2 行，正常 ✅ | 不变 ✅ |
| 6 账户全 `[1x1]` | 2 行，正常 ✅ | 不变 ✅ |
| 7 账户全 `[1x1]`（需 "+N" 块） | 3 行 × ~81px，裁切 ❌ | 2 行 × ~122px + "+2" 块 ✅ |
| 高度 3 档组件 | 正常 ✅ | 不变 ✅ |

- `npm run typecheck` 通过；
- 行为上唯一的取舍：空间不足时部分双行卡会降级为单行（compact 布局只显示主 meter + 进度条），用户仍可通过组件编辑手动调大卡片尺寸或调高组件高度恢复双行展示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)