### PR TITLE
feat: show the weekly Fable usage limit in provider accounts

### DIFF
--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -60,6 +60,17 @@ const claudeCodeAccountMapping: ProviderAccountMappingConfig = {
     percentLimitMapping("claude_opus_quota", "Opus quota", "$.seven_day_opus", "weekly"),
     percentLimitMapping("claude_sonnet_quota", "Sonnet quota", "$.seven_day_sonnet", "weekly"),
     {
+      id: "claude_fable_quota",
+      kind: "quota",
+      label: "Fable quota",
+      limit: 100,
+      remaining: "100 - $.limits[?(@.kind == \"weekly_scoped\" && @.scope.model.display_name == \"Fable\")].percent",
+      resetAt: "$.limits[?(@.kind == \"weekly_scoped\" && @.scope.model.display_name == \"Fable\")].resets_at",
+      unit: "%",
+      used: "$.limits[?(@.kind == \"weekly_scoped\" && @.scope.model.display_name == \"Fable\")].percent",
+      window: "weekly"
+    },
+    {
       id: "claude_extra_usage",
       kind: "quota",
       label: "Extra usage",
@@ -165,7 +176,7 @@ export function importClaudeCodeProvider(candidate: LocalAgentProviderCandidate,
   };
 }
 
-function claudeCodeProviderAccountConfig(): ProviderAccountConfig {
+export function claudeCodeProviderAccountConfig(): ProviderAccountConfig {
   return {
     connectors: [
       {

--- a/packages/core/src/agents/local-providers/claude-code.ts
+++ b/packages/core/src/agents/local-providers/claude-code.ts
@@ -3,14 +3,17 @@ import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import type {
+  GatewayProviderConfig,
   LocalAgentProviderCandidate,
   LocalAgentProviderImportResult,
   ProviderAccountConfig,
+  ProviderAccountConnectorConfig,
   ProviderAccountMappingConfig
 } from "@ccr/core/contracts/app";
 import {
   bearerAuthPlugin,
   isRecord,
+  localAgentProviderApiKey,
   missingCandidate,
   providerInternalNamePlaceholder,
   providerPayload,
@@ -20,6 +23,7 @@ import {
   uniqueStrings,
   type OAuthTokenSet
 } from "@ccr/core/agents/local-providers/shared";
+import { normalizeProviderBaseUrl } from "@ccr/core/providers/url";
 
 const claudeDefaultModels = ["claude-sonnet-5"];
 const claudeCodeKeychainServiceBase = "Claude Code-credentials";
@@ -192,6 +196,53 @@ export function claudeCodeProviderAccountConfig(): ProviderAccountConfig {
     ],
     enabled: true
   };
+}
+
+export function normalizeClaudeCodeProviderAccountConfig(provider: GatewayProviderConfig): GatewayProviderConfig {
+  if (!isLocalClaudeCodeProvider(provider) || !shouldUseCurrentClaudeCodeAccountConfig(provider.account)) {
+    return provider;
+  }
+  const account = claudeCodeProviderAccountConfig();
+  return {
+    ...provider,
+    account: {
+      ...account,
+      refreshIntervalMs: provider.account?.refreshIntervalMs ?? account.refreshIntervalMs
+    }
+  };
+}
+
+function isLocalClaudeCodeProvider(provider: GatewayProviderConfig): boolean {
+  return (
+    providerApiKey(provider) === localAgentProviderApiKey &&
+    normalizeProviderBaseUrl(providerBaseUrl(provider)) === normalizeProviderBaseUrl("https://api.anthropic.com")
+  );
+}
+
+function shouldUseCurrentClaudeCodeAccountConfig(account: ProviderAccountConfig | undefined): boolean {
+  if (account?.enabled === false) {
+    return false;
+  }
+  const connectors = account?.connectors ?? [];
+  if (connectors.length === 0) {
+    return true;
+  }
+  return connectors.every(isClaudeCodeAccountConnector);
+}
+
+function isClaudeCodeAccountConnector(connector: ProviderAccountConnectorConfig): boolean {
+  if (connector.type !== "http-json") {
+    return false;
+  }
+  return /^https:\/\/api\.anthropic\.com\/api\/oauth\/usage$/i.test(connector.endpoint.trim());
+}
+
+function providerApiKey(provider: GatewayProviderConfig): string {
+  return provider.api_key || provider.apiKey || provider.apikey || "";
+}
+
+function providerBaseUrl(provider: GatewayProviderConfig): string {
+  return provider.api_base_url || provider.baseUrl || provider.baseurl || "";
 }
 
 export function readClaudeCodeOauth(): OAuthTokenSet | undefined {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -10,6 +10,7 @@ import {
   replacePersistedConfigSnapshot
 } from "@ccr/core/config/config-repository";
 import { LEGACY_ACTIVE_CONFIG_FILE, LEGACY_CONFIG_FILE, LEGACY_WINDOWS_CONFIG_FILE } from "@ccr/core/config/constants";
+import { normalizeClaudeCodeProviderAccountConfig } from "@ccr/core/agents/local-providers/claude-code";
 import { normalizeCodexProviderAccountConfig } from "@ccr/core/agents/local-providers/codex";
 import { normalizeGrokProviderAccountConfig, normalizeGrokProviderMediaCapabilities } from "@ccr/core/agents/local-providers/grok";
 import { removeOpenCodeProviderAccountConfig } from "@ccr/core/agents/local-providers/opencode";
@@ -1448,7 +1449,7 @@ function parseProviders(value: unknown): GatewayProviderConfig[] | undefined {
       return removeOpenCodeProviderAccountConfig(
         normalizeProviderPresetCapabilities(
           normalizeGrokProviderMediaCapabilities(
-            normalizeGrokProviderAccountConfig(normalizeCodexProviderAccountConfig(provider))
+            normalizeGrokProviderAccountConfig(normalizeCodexProviderAccountConfig(normalizeClaudeCodeProviderAccountConfig(provider)))
           )
         )
       );

--- a/packages/core/src/providers/account-service.ts
+++ b/packages/core/src/providers/account-service.ts
@@ -1356,7 +1356,7 @@ function mappedMeterFromPayload(
   const limit = readMappedNumber(config.limit, payload);
   const remaining = readMappedNumber(config.remaining, payload);
   const used = readMappedNumber(config.used, payload);
-  if (limit === undefined && remaining === undefined && used === undefined) {
+  if (remaining === undefined && used === undefined) {
     return undefined;
   }
   return normalizeMeter({
@@ -1380,7 +1380,59 @@ function mappedMetersFromPayload(
   const meters = connector.mapping.meters
     .map((meter) => mappedMeterFromPayload(meter, payload, source))
     .filter((meter): meter is ProviderAccountMeter => Boolean(meter));
-  return attachCodexRateLimitResetCreditDetails(meters, payload);
+  return dropUnresolvedScopedMeters(attachCodexRateLimitResetCreditDetails(meters, payload), payload);
+}
+
+function dropUnresolvedScopedMeters(meters: ProviderAccountMeter[], payload: unknown): ProviderAccountMeter[] {
+  const scopedModelNames = new Set(
+    scopedMeterModelNames(meters)
+      .map((name) => [...jsonPathKeyAlternates(name), name.trim()])
+      .flat()
+      .filter(Boolean)
+  );
+  if (scopedModelNames.size === 0) {
+    return meters;
+  }
+  const models = scopedUsageModelNames(payload);
+  const present = new Set(models.flatMap((name) => [...jsonPathKeyAlternates(name), name.trim()].filter(Boolean)));
+  return meters.filter((meter) => {
+    const modelName = scopedMeterModelName(meter);
+    return !modelName || present.has(modelName);
+  });
+}
+
+function scopedMeterModelNames(meters: ProviderAccountMeter[]): string[] {
+  const names: string[] = [];
+  for (const meter of meters) {
+    const modelName = scopedMeterModelName(meter);
+    if (modelName) {
+      names.push(modelName);
+    }
+  }
+  return names;
+}
+
+function scopedMeterModelName(meter: ProviderAccountMeter): string | undefined {
+  return /^claude_(opus|sonnet|fable)_quota$/.exec(meter.id)?.[1];
+}
+
+function scopedUsageModelNames(payload: unknown): string[] {
+  if (!isRecord(payload) || !Array.isArray(payload.limits)) {
+    return [];
+  }
+  const names: string[] = [];
+  for (const item of payload.limits) {
+    if (!isRecord(item) || item.kind !== "weekly_scoped") {
+      continue;
+    }
+    const scope = isRecord(item.scope) ? item.scope : undefined;
+    const model = isRecord(scope?.model) ? scope.model : undefined;
+    const displayName = typeof model?.display_name === "string" ? model.display_name.trim() : "";
+    if (displayName) {
+      names.push(displayName);
+    }
+  }
+  return names;
 }
 
 function normalizeMeter(value: unknown, source: ProviderAccountConnectorSource): ProviderAccountMeter | undefined {

--- a/packages/core/test/unit/agents/local-agent-provider-claude-code.test.mjs
+++ b/packages/core/test/unit/agents/local-agent-provider-claude-code.test.mjs
@@ -4,7 +4,8 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:f
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { claudeCodeCandidate, importClaudeCodeProvider } from "@ccr/core/agents/local-providers/claude-code.ts";
+import { claudeCodeCandidate, claudeCodeProviderAccountConfig, importClaudeCodeProvider, normalizeClaudeCodeProviderAccountConfig } from "@ccr/core/agents/local-providers/claude-code.ts";
+import { localAgentProviderApiKey } from "@ccr/core/agents/local-providers/shared.ts";
 import { createDefaultAppConfig } from "@ccr/core/config/default-config.ts";
 import { compileCoreGatewayConfig } from "@ccr/core/gateway/core-runtime/config-compiler.ts";
 
@@ -280,6 +281,49 @@ test("Claude Code local provider reads the config-dir-suffixed keychain service"
       });
     });
   });
+});
+
+test("Claude Code local provider account config upgrades persisted usage mapping", () => {
+  const oldAccount = JSON.parse(JSON.stringify(claudeCodeProviderAccountConfig()));
+  oldAccount.refreshIntervalMs = 45000;
+  const usageConnector = oldAccount.connectors[0];
+  usageConnector.mapping.meters = usageConnector.mapping.meters.filter((meter) => meter.id !== "claude_fable_quota");
+
+  const provider = normalizeClaudeCodeProviderAccountConfig({
+    account: oldAccount,
+    api_base_url: "https://api.anthropic.com",
+    api_key: localAgentProviderApiKey,
+    models: ["claude-sonnet-5"],
+    name: "Claude Code API",
+    protocol: "anthropic_messages"
+  });
+
+  assert.equal(provider.account.refreshIntervalMs, 45000);
+  assert.ok(provider.account.connectors[0].mapping.meters.some((meter) => meter.id === "claude_fable_quota"));
+});
+
+test("Claude Code local provider account config preserves custom connectors", () => {
+  const customAccount = {
+    connectors: [
+      {
+        auth: "provider-api-key",
+        endpoint: "https://proxy.example.com/usage",
+        mapping: { meters: [] },
+        type: "http-json"
+      }
+    ],
+    enabled: true
+  };
+  const provider = normalizeClaudeCodeProviderAccountConfig({
+    account: customAccount,
+    api_base_url: "https://api.anthropic.com",
+    api_key: localAgentProviderApiKey,
+    models: ["claude-sonnet-5"],
+    name: "Claude Code API",
+    protocol: "anthropic_messages"
+  });
+
+  assert.equal(provider.account.connectors[0].endpoint, "https://proxy.example.com/usage");
 });
 
 test("Claude Code local provider explains login state that carries no OAuth token", { skip: process.platform === "win32" }, async () => {

--- a/packages/core/test/unit/providers/provider-account-service.test.mjs
+++ b/packages/core/test/unit/providers/provider-account-service.test.mjs
@@ -15,6 +15,7 @@ import {
   grokDefaultSubscriptionEndpoint,
   grokProviderAccountConfig
 } from "@ccr/core/agents/local-providers/grok.ts";
+import { claudeCodeProviderAccountConfig } from "@ccr/core/agents/local-providers/claude-code.ts";
 
 const localAgentProviderApiKey = "ccr-local-agent-login";
 const codexDefaultBaseUrl = "https://chatgpt.com/backend-api/codex";
@@ -205,6 +206,79 @@ test("webcontent-json connector defaults browser request origin to login URL ori
   assert.equal(captured.credentials, "include");
   assert.equal(captured.requestOrigin, "https://app.vendor.example.com");
   assert.equal(result.meters[0].remaining, 7);
+});
+
+test("Claude Code connector maps weekly Fable scoped limit from limits payload", async (t) => {
+  const previousFetch = globalThis.fetch;
+  let authorization = "";
+  let betaHeader = "";
+  globalThis.fetch = async (input, init) => {
+    assert.equal(String(input), "https://api.anthropic.com/api/oauth/usage");
+    authorization = init?.headers?.authorization ?? "";
+    betaHeader = init?.headers?.["anthropic-beta"] ?? "";
+    return new Response(JSON.stringify({
+      five_hour: { utilization: 54, resets_at: "2026-09-02T05:09:59.710911+00:00" },
+      seven_day: { utilization: 15, resets_at: "2026-09-05T10:00:00.710935+00:00" },
+      limits: [
+        { kind: "session", group: "session", percent: 54, severity: "normal", resets_at: "2026-09-02T05:09:59.710911+00:00", scope: null, is_active: true },
+        { kind: "weekly_all", group: "weekly", percent: 15, severity: "normal", resets_at: "2026-09-05T10:00:00.710935+00:00", scope: null, is_active: false },
+        { kind: "weekly_scoped", group: "weekly", percent: 25, severity: "normal", resets_at: "2026-09-05T09:59:59.711185+00:00", scope: { model: { id: null, display_name: "Fable" } }, is_active: false }
+      ]
+    }), { headers: { "content-type": "application/json" }, status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+
+  const connector = claudeCodeProviderAccountConfig().connectors?.[0];
+  assert.equal(connector?.type, "http-json");
+  const result = await testProviderAccountConnector({
+    apiKey: "claude-code-access-token",
+    baseUrl: "https://api.anthropic.com",
+    connector,
+    providerName: "Claude Code API"
+  });
+
+  assert.equal(authorization, "Bearer claude-code-access-token");
+  assert.equal(betaHeader, "oauth-2025-04-20");
+  assert.equal(result.meters.find((meter) => meter.id === "claude_five_hour_quota")?.remaining, 46);
+  assert.equal(result.meters.find((meter) => meter.id === "claude_seven_day_quota")?.remaining, 85);
+  assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota")?.remaining, 75);
+  assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota")?.used, 25);
+  assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota")?.resetAt, "2026-09-05T09:59:59.711185+00:00");
+  assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota")?.window, "weekly");
+});
+
+test("Claude Code connector omits Fable meter when payload has no weekly scoped limit", async (t) => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    assert.equal(String(input), "https://api.anthropic.com/api/oauth/usage");
+    return new Response(JSON.stringify({
+      five_hour: { utilization: 54, resets_at: "2026-09-02T05:09:59.710911+00:00" },
+      seven_day: { utilization: 15, resets_at: "2026-09-05T10:00:00.710935+00:00" },
+      limits: [
+        { kind: "session", group: "session", percent: 54, severity: "normal", resets_at: "2026-09-02T05:09:59.710911+00:00", scope: null, is_active: true },
+        { kind: "weekly_all", group: "weekly", percent: 15, severity: "normal", resets_at: "2026-09-05T10:00:00.710935+00:00", scope: null, is_active: false }
+      ]
+    }), { headers: { "content-type": "application/json" }, status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+
+  const connector = claudeCodeProviderAccountConfig().connectors?.[0];
+  const result = await testProviderAccountConnector({
+    apiKey: "claude-code-access-token",
+    baseUrl: "https://api.anthropic.com",
+    connector,
+    providerName: "Claude Code API"
+  });
+
+  const fableMeter = result.meters.find((meter) => meter.id === "claude_fable_quota");
+  assert.equal(fableMeter?.remaining, undefined);
+  assert.equal(fableMeter?.used, undefined);
+  assert.equal(fableMeter?.resetAt, undefined);
+  assert.equal(result.meters.find((meter) => meter.id === "claude_seven_day_quota")?.remaining, 85);
 });
 
 test("webcontent-json connector reports unsupported outside CCR Desktop", async () => {

--- a/packages/core/test/unit/providers/provider-account-service.test.mjs
+++ b/packages/core/test/unit/providers/provider-account-service.test.mjs
@@ -247,6 +247,8 @@ test("Claude Code connector maps weekly Fable scoped limit from limits payload",
   assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota")?.used, 25);
   assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota")?.resetAt, "2026-09-05T09:59:59.711185+00:00");
   assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota")?.window, "weekly");
+  assert.equal(result.meters.find((meter) => meter.id === "claude_opus_quota"), undefined);
+  assert.equal(result.meters.find((meter) => meter.id === "claude_sonnet_quota"), undefined);
 });
 
 test("Claude Code connector omits Fable meter when payload has no weekly scoped limit", async (t) => {
@@ -274,10 +276,7 @@ test("Claude Code connector omits Fable meter when payload has no weekly scoped 
     providerName: "Claude Code API"
   });
 
-  const fableMeter = result.meters.find((meter) => meter.id === "claude_fable_quota");
-  assert.equal(fableMeter?.remaining, undefined);
-  assert.equal(fableMeter?.used, undefined);
-  assert.equal(fableMeter?.resetAt, undefined);
+  assert.equal(result.meters.find((meter) => meter.id === "claude_fable_quota"), undefined);
   assert.equal(result.meters.find((meter) => meter.id === "claude_seven_day_quota")?.remaining, 85);
 });
 


### PR DESCRIPTION
## Summary

Claude Code now exposes a dedicated weekly usage limit for the Fable model. This PR surfaces that limit in the provider account widgets (dashboard, providers list, tray) as an additional meter alongside the general weekly quota.

## How the limit is exposed

The OAuth usage endpoint (`https://api.anthropic.com/api/oauth/usage`) does not return the Fable limit as a scalar field like `five_hour` or `seven_day_opus`. Instead, it arrives inside the `limits[]` array as an item with `kind: "weekly_scoped"` and `scope.model.display_name: "Fable"`:

```json
{
  "limits": [
    { "kind": "session", "percent": 54, "scope": null },
    { "kind": "weekly_all", "percent": 15, "scope": null },
    { "kind": "weekly_scoped", "percent": 25, "scope": { "model": { "display_name": "Fable" } } }
  ]
}
```

Not every account has this item: the scoped Fable limit is an add-on, so it must be treated as optional.

## Changes

- **`packages/core/src/agents/local-providers/claude-code.ts`**
  - New `claude_fable_quota` meter ("Fable quota", window `weekly`) in the declarative account mapping. It resolves `percent` / `resets_at` via the existing JSONPath resolver using a filter expression: `$.limits[?(@.kind == "weekly_scoped" && @.scope.model.display_name == "Fable")]`.
  - `claudeCodeProviderAccountConfig` is now exported so the connector can be tested directly.
  - New `normalizeClaudeCodeProviderAccountConfig`, mirroring the existing Codex pattern: at config load time, a persisted Claude Code provider whose connectors still match the default usage endpoint is reconciled with the current in-code mapping. This keeps accounts imported before this change up to date without requiring a re-import.
- **`packages/core/src/config/config.ts`**
  - Registers `normalizeClaudeCodeProviderAccountConfig` in the provider normalization chain.
- **`packages/core/src/providers/account-service.ts`**
  - Meters with no resolvable value (both `remaining` and `used` undefined) are no longer rendered with a static-limit fallback; they are omitted. Previously a null upstream field produced a misleading full bar or "100%".
  - Model-scoped weekly meters (`claude_opus_quota`, `claude_sonnet_quota`, `claude_fable_quota`) are omitted when the payload carries no matching `weekly_scoped` item, so accounts without a model-specific limit show nothing instead of an empty bar.

## Behavior

- Account **with** the scoped Fable limit: the "Fable quota" meter appears next to the general "7d quota", with its own percentage and reset time.
- Account **without** it: no Fable bar is rendered. The same rule now hides the Opus/Sonnet meters on accounts that do not have those scoped limits.

## Testing

- `packages/core/test/unit/providers/provider-account-service.test.mjs`: connector tests against a real-shaped `limits[]` payload (meter values, reset time, window) and a payload without the scoped item (meter omitted).
- `packages/core/test/unit/agents/local-agent-provider-claude-code.test.mjs`: normalization upgrades a persisted mapping while preserving a custom `refreshIntervalMs`, and leaves custom connectors untouched.