### PR TITLE
Add MiniMax image generation to Fusion media

### DIFF
--- a/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
+++ b/packages/core/src/gateway/core-runtime/upstream-header-sanitizer.ts
@@ -2,6 +2,7 @@ import { applyResponsesSessionAffinity } from "@ccr/core/gateway/core-runtime/re
 import type { ResponsesSessionAffinityInput } from "@ccr/core/gateway/core-runtime/responses-session-affinity";
 import { applyResponsesToolStrictness } from "@ccr/core/gateway/core-runtime/responses-tool-strictness";
 import type { ResponsesToolStrictnessInput } from "@ccr/core/gateway/core-runtime/responses-tool-strictness";
+import { fusionImageProviderSchemaForUrl } from "@ccr/core/media/provider-registry";
 
 type UpstreamRequest = {
   body: unknown;
@@ -22,7 +23,12 @@ type ProviderPluginRequestInput = {
     baseurl?: string;
     type?: string;
   };
+  sourceAdapterKey?: string;
   upstreamRequest: UpstreamRequest;
+};
+
+type ProviderPluginResponseInput = ProviderPluginRequestInput & {
+  upstreamPayload: unknown;
 };
 
 const ccrAuthHeaderNames = new Set([
@@ -138,6 +144,30 @@ export function rewriteUpstreamProviderUrl(
   return rewriteUrlBase(upstreamUrl, config?.anthropicBaseUrl, targetProviderConfig?.baseurl);
 }
 
+export function rewriteFusionMediaProviderRequest(input: ProviderPluginRequestInput): UpstreamRequest {
+  if (input.sourceAdapterKey !== "openai_image_generations") return input.upstreamRequest;
+  const match = fusionImageProviderSchemaForUrl(input.targetProviderConfig?.baseurl ?? input.upstreamRequest.url);
+  if (!match) return input.upstreamRequest;
+  const url = new URL(input.upstreamRequest.url);
+  if (!url.pathname.endsWith("/images/generations")) return input.upstreamRequest;
+  url.pathname = match.endpoint.generationPath;
+  return { ...input.upstreamRequest, url: url.toString() };
+}
+
+export function normalizeFusionMediaProviderResponse(input: ProviderPluginResponseInput): unknown {
+  if (input.sourceAdapterKey !== "openai_image_generations") return input.upstreamPayload;
+  if (!fusionImageProviderSchemaForUrl(input.targetProviderConfig?.baseurl ?? input.upstreamRequest.url)) {
+    return input.upstreamPayload;
+  }
+  if (!isRecord(input.upstreamPayload) || !isRecord(input.upstreamPayload.data)) return input.upstreamPayload;
+  const imageUrls = input.upstreamPayload.data.image_urls;
+  if (!Array.isArray(imageUrls)) return input.upstreamPayload;
+  const data = imageUrls
+    .filter((value): value is string => typeof value === "string" && Boolean(value.trim()))
+    .map((url) => ({ url }));
+  return { ...input.upstreamPayload, data };
+}
+
 function headerValues(value: string | string[] | undefined): string[] {
   if (value === undefined) return [];
   return Array.isArray(value) ? value : [value];
@@ -187,18 +217,29 @@ function joinUrlPath(base: string, remainder: string): string {
   return `${base}/${normalizedRemainder}`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function createGatewayPlugin() {
   return {
     providerHooks: [{
       key: "ccr-upstream-header-sanitizer",
       transformRequest(input: ProviderPluginRequestInput) {
+        const upstreamRequest = rewriteFusionMediaProviderRequest(input);
         return {
           ok: true as const,
           value: {
-            ...input.upstreamRequest,
-            headers: mergeUpstreamProviderHeaders(input.request?.headers, input.upstreamRequest.headers),
-            url: rewriteUpstreamProviderUrl(input.upstreamRequest.url, input.targetProviderConfig, input.config)
+            ...upstreamRequest,
+            headers: mergeUpstreamProviderHeaders(input.request?.headers, upstreamRequest.headers),
+            url: rewriteUpstreamProviderUrl(upstreamRequest.url, input.targetProviderConfig, input.config)
           }
+        };
+      },
+      transformResponse(input: ProviderPluginResponseInput) {
+        return {
+          ok: true as const,
+          value: normalizeFusionMediaProviderResponse(input)
         };
       }
     }, {

--- a/packages/core/src/media/models.ts
+++ b/packages/core/src/media/models.ts
@@ -5,6 +5,7 @@ import {
   isGatewayProviderEnabled
 } from "@ccr/core/contracts/app";
 import type { GatewayMediaProtocol, GatewayProviderConfig } from "@ccr/core/contracts/app";
+import { registeredMediaCapabilities } from "@ccr/core/media/provider-registry";
 
 const localAgentProviderApiKey = "ccr-local-agent-login";
 
@@ -63,7 +64,8 @@ export function providerSupportsMediaKind(provider: GatewayProviderConfig, kind:
     ? ["openai_image_generations"]
     : ["xai_video_generations", "openai_video_generations"];
   return isImportedGrokAgentProvider(provider) ||
-    (provider.capabilities ?? []).some((item) => capabilities.includes(item.type)) ||
+    [...(provider.capabilities ?? []), ...registeredMediaCapabilities(provider)]
+      .some((item) => capabilities.includes(item.type)) ||
     (provider.models ?? []).some((model) => grokMediaModelKind(model) === kind);
 }
 

--- a/packages/core/src/media/provider-registry.ts
+++ b/packages/core/src/media/provider-registry.ts
@@ -1,0 +1,64 @@
+import type { GatewayProviderCapability, GatewayProviderConfig } from "@ccr/core/contracts/app";
+
+export type FusionImageProviderSchema = {
+  endpoints: Array<{
+    baseUrl: string;
+    generationPath: string;
+  }>;
+  id: string;
+  models: string[];
+  protocol: "openai_image_generations";
+};
+
+export const miniMaxImageGenerationSchema: FusionImageProviderSchema = {
+  endpoints: [
+    {
+      baseUrl: "https://api.minimax.io/v1",
+      generationPath: "/v1/image_generation"
+    },
+    {
+      baseUrl: "https://api.minimaxi.com/v1",
+      generationPath: "/v1/image_generation"
+    }
+  ],
+  id: "minimax-image-generation",
+  models: ["image-01", "image-01-live"],
+  protocol: "openai_image_generations"
+};
+
+const fusionImageProviderSchemas = [miniMaxImageGenerationSchema];
+
+export function registeredMediaCapabilities(provider: GatewayProviderConfig): GatewayProviderCapability[] {
+  if ((provider.capabilities ?? []).some((capability) => capability.type === "openai_image_generations")) {
+    return [];
+  }
+  const providerBaseUrl = provider.baseurl || provider.baseUrl || provider.api_base_url;
+  if (!providerBaseUrl) return [];
+  const configuredModels = new Set(provider.models ?? []);
+  return fusionImageProviderSchemas.flatMap((schema) => {
+    if (!schema.models.some((model) => configuredModels.has(model))) return [];
+    const endpoint = schema.endpoints.find((item) => sameOrigin(item.baseUrl, providerBaseUrl));
+    return endpoint
+      ? [{ baseUrl: endpoint.baseUrl, source: "preset" as const, type: schema.protocol }]
+      : [];
+  });
+}
+
+export function fusionImageProviderSchemaForUrl(value: string): {
+  endpoint: FusionImageProviderSchema["endpoints"][number];
+  schema: FusionImageProviderSchema;
+} | undefined {
+  for (const schema of fusionImageProviderSchemas) {
+    const endpoint = schema.endpoints.find((item) => sameOrigin(item.baseUrl, value));
+    if (endpoint) return { endpoint, schema };
+  }
+  return undefined;
+}
+
+function sameOrigin(left: string, right: string): boolean {
+  try {
+    return new URL(left).origin === new URL(right).origin;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/media/service.ts
+++ b/packages/core/src/media/service.ts
@@ -13,7 +13,7 @@ import { grokMediaModelKind, isImportedGrokAgentProvider, migrateLegacyGrokMedia
 import { detectMediaType, MediaArtifactStore, MediaJobStore } from "@ccr/core/media/storage";
 import { mediaToolBindingsForConfig } from "@ccr/core/media/tools";
 import type { MediaToolBinding } from "@ccr/core/media/tools";
-import { activeProviderCredentials, inferProtocol, providerCapabilityInternalName, providerCredentialInternalName, sortProviderCredentialsForConfig } from "@ccr/core/providers/runtime-topology";
+import { activeProviderCredentials, inferProtocol, normalizedProviderCapabilities, providerCapabilityInternalName, providerCredentialInternalName, sortProviderCredentialsForConfig } from "@ccr/core/providers/runtime-topology";
 import { modelRegistryForConfig, parseProviderModelSelector, providerRuntimeId } from "@ccr/core/routing/model-registry";
 
 type QueueItem = {
@@ -736,14 +736,15 @@ export function resolveProviderMediaTarget(config: AppConfig, selector: string, 
   if (!kind || !providerSupportsMediaKind(provider, kind)) {
     throw new Error(`Provider ${provider.name} does not declare ${kind ?? "media"} generation support.`);
   }
+  const capabilities = normalizedProviderCapabilities(provider);
   const protocol: GatewayMediaProtocol = kind === "video"
-    ? provider.capabilities?.some((item) => item.type === "xai_video_generations") || isImportedGrokAgentProvider(provider)
+    ? capabilities.some((item) => item.type === "xai_video_generations") || isImportedGrokAgentProvider(provider)
       ? "xai_video_generations"
       : "openai_video_generations"
     : "openai_image_generations";
-  const capability = provider.capabilities?.find((item) => item.type === protocol) ??
+  const capability = capabilities.find((item) => item.type === protocol) ??
     (protocol === "xai_video_generations" && isImportedGrokAgentProvider(provider)
-      ? provider.capabilities?.find((item) => item.type === "openai_video_generations")
+      ? capabilities.find((item) => item.type === "openai_video_generations")
       : undefined);
   const providerBaseUrl = capability?.baseUrl ?? provider.baseurl ?? provider.baseUrl ?? provider.api_base_url;
   if (!providerBaseUrl?.trim()) {

--- a/packages/core/src/providers/presets/minimax/index.ts
+++ b/packages/core/src/providers/presets/minimax/index.ts
@@ -1,10 +1,11 @@
 import type { ProviderPreset } from "@ccr/core/providers/presets/types";
+import { miniMaxImageGenerationSchema } from "@ccr/core/media/provider-registry";
 import { standardProviderAccountConfig } from "@ccr/core/providers/presets/types";
 
 export const minimaxGlobalProviderPreset: ProviderPreset = {
   account: standardProviderAccountConfig,
   aliases: ["minimax", "minimax global"],
-  defaultModels: ["MiniMax-M3"],
+  defaultModels: ["MiniMax-M3", ...miniMaxImageGenerationSchema.models],
   endpoints: [
     {
       baseUrl: "https://api.minimax.io/v1",
@@ -25,7 +26,7 @@ export const minimaxGlobalProviderPreset: ProviderPreset = {
 export const minimaxChinaProviderPreset: ProviderPreset = {
   account: standardProviderAccountConfig,
   aliases: ["minimax", "minimaxi", "minimax china"],
-  defaultModels: ["MiniMax-M3"],
+  defaultModels: ["MiniMax-M3", ...miniMaxImageGenerationSchema.models],
   endpoints: [
     {
       baseUrl: "https://api.minimaxi.com/v1",

--- a/packages/core/src/providers/runtime-topology.ts
+++ b/packages/core/src/providers/runtime-topology.ts
@@ -4,6 +4,7 @@
 import { isGatewayProviderEnabled } from "@ccr/core/contracts/app";
 import type { AppConfig, GatewayProviderCapability, GatewayProviderCapabilityProtocol, GatewayProviderConfig, GatewayProviderProtocol, ProviderCredentialConfig } from "@ccr/core/contracts/app";
 import { findProviderPresetByBaseUrl, providerApiKeySafetyIssue } from "@ccr/core/providers/presets/index";
+import { registeredMediaCapabilities } from "@ccr/core/media/provider-registry";
 import { normalizeProviderBaseUrl as normalizeProviderBaseUrlInput } from "@ccr/core/providers/url";
 import { modelRegistryForConfig, parseProviderModelSelector, providerRuntimeId } from "@ccr/core/routing/model-registry";
 import { gatewayProviderProtocolFallbackOrder, type CoreGatewayProvider } from "@ccr/core/gateway/internal/shared";
@@ -178,7 +179,10 @@ export function sortProviderCredentialsForConfig(credentials: ProviderCredential
 }
 
 export function normalizedProviderCapabilities(provider: GatewayProviderConfig): GatewayProviderCapability[] {
-  const capabilities = Array.isArray(provider.capabilities) ? provider.capabilities : [];
+  const capabilities = [
+    ...(Array.isArray(provider.capabilities) ? provider.capabilities : []),
+    ...registeredMediaCapabilities(provider)
+  ];
   const normalized: GatewayProviderCapability[] = [];
   const byProtocol = new Map<GatewayProviderCapabilityProtocol, GatewayProviderCapability>();
   for (const capability of capabilities) {

--- a/packages/core/test/unit/gateway/upstream-header-sanitizer.test.mjs
+++ b/packages/core/test/unit/gateway/upstream-header-sanitizer.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createGatewayPlugin,
+  normalizeFusionMediaProviderResponse,
+  rewriteFusionMediaProviderRequest,
   rewriteUpstreamProviderUrl,
   sanitizeUpstreamProviderHeaders
 } from "@ccr/core/gateway/core-runtime/upstream-header-sanitizer.ts";
@@ -168,6 +170,68 @@ test("provider URL rewrite ignores unrelated providers and upstream hosts", () =
     ),
     "https://other.example/v1/messages"
   );
+});
+
+test("MiniMax image generation uses the official endpoint and response schema", () => {
+  const input = {
+    sourceAdapterKey: "openai_image_generations",
+    targetProviderConfig: {
+      baseurl: "https://api.minimax.io/v1",
+      type: "openai_image_generations"
+    },
+    upstreamRequest: {
+      body: {
+        aspect_ratio: "16:9",
+        model: "image-01",
+        prompt: "A blue cup",
+        response_format: "url"
+      },
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      url: "https://api.minimax.io/v1/images/generations"
+    }
+  };
+
+  const request = rewriteFusionMediaProviderRequest(input);
+  assert.equal(request.url, "https://api.minimax.io/v1/image_generation");
+  assert.deepEqual(request.body, input.upstreamRequest.body);
+
+  assert.deepEqual(normalizeFusionMediaProviderResponse({
+    ...input,
+    upstreamPayload: {
+      base_resp: { status_code: 0 },
+      data: { image_urls: ["https://cdn.example/one.png", "https://cdn.example/two.png"] },
+      metadata: { failed_count: 0, success_count: 2 }
+    }
+  }), {
+    base_resp: { status_code: 0 },
+    data: [
+      { url: "https://cdn.example/one.png" },
+      { url: "https://cdn.example/two.png" }
+    ],
+    metadata: { failed_count: 0, success_count: 2 }
+  });
+});
+
+test("MiniMax image schema handling does not affect unrelated providers", () => {
+  const upstreamRequest = {
+    body: { model: "image-model", prompt: "A blue cup" },
+    headers: { "content-type": "application/json" },
+    method: "POST",
+    url: "https://images.example/v1/images/generations"
+  };
+  const input = {
+    sourceAdapterKey: "openai_image_generations",
+    targetProviderConfig: {
+      baseurl: "https://images.example/v1",
+      type: "openai_image_generations"
+    },
+    upstreamRequest
+  };
+
+  assert.equal(rewriteFusionMediaProviderRequest(input), upstreamRequest);
+  const upstreamPayload = { data: [{ url: "https://cdn.example/image.png" }] };
+  assert.equal(normalizeFusionMediaProviderResponse({ ...input, upstreamPayload }), upstreamPayload);
 });
 
 test("gateway sanitizer hook does not forward reverse proxy metadata to providers", async () => {

--- a/packages/core/test/unit/media/provider-registry.test.mjs
+++ b/packages/core/test/unit/media/provider-registry.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDefaultAppConfig } from "@ccr/core/config/default-config.ts";
+import {
+  miniMaxImageGenerationSchema,
+  registeredMediaCapabilities
+} from "@ccr/core/media/provider-registry.ts";
+import { resolveProviderMediaTarget } from "@ccr/core/media/service.ts";
+import {
+  minimaxChinaProviderPreset,
+  minimaxGlobalProviderPreset
+} from "@ccr/core/providers/presets/minimax/index.ts";
+
+test("MiniMax presets register the supported image generation models", () => {
+  assert.deepEqual(miniMaxImageGenerationSchema.models, ["image-01", "image-01-live"]);
+  assert.ok(miniMaxImageGenerationSchema.models.every((model) => minimaxGlobalProviderPreset.defaultModels.includes(model)));
+  assert.ok(miniMaxImageGenerationSchema.models.every((model) => minimaxChinaProviderPreset.defaultModels.includes(model)));
+});
+
+test("MiniMax image models register their regional image generation endpoint", () => {
+  assert.deepEqual(registeredMediaCapabilities({
+    api_base_url: "https://api.minimax.io/v1",
+    models: ["MiniMax-M3", "image-01"],
+    name: "MiniMax (Global)"
+  }), [{
+    baseUrl: "https://api.minimax.io/v1",
+    source: "preset",
+    type: "openai_image_generations"
+  }]);
+  assert.deepEqual(registeredMediaCapabilities({
+    api_base_url: "https://api.minimaxi.com/anthropic/v1",
+    models: ["image-01-live"],
+    name: "MiniMax (China)"
+  }), [{
+    baseUrl: "https://api.minimaxi.com/v1",
+    source: "preset",
+    type: "openai_image_generations"
+  }]);
+});
+
+test("an explicit image capability takes precedence over the MiniMax registry", () => {
+  assert.deepEqual(registeredMediaCapabilities({
+    api_base_url: "https://api.minimax.io/v1",
+    capabilities: [{
+      baseUrl: "https://proxy.example/v1",
+      type: "openai_image_generations"
+    }],
+    models: ["image-01"],
+    name: "MiniMax through proxy"
+  }), []);
+});
+
+test("Fusion media resolves a registered MiniMax image model", () => {
+  const config = createDefaultAppConfig();
+  config.Providers = [{
+    api_base_url: "https://api.minimax.io/v1",
+    api_key: "provider-key",
+    models: ["MiniMax-M3", "image-01"],
+    name: "MiniMax (Global)",
+    type: "openai_chat_completions"
+  }];
+
+  const target = resolveProviderMediaTarget(config, "MiniMax (Global)/image-01", "image-generate");
+  assert.equal(target.model, "image-01");
+  assert.equal(target.protocol, "openai_image_generations");
+  assert.equal(target.providerBaseUrl, "https://api.minimax.io/v1");
+  assert.match(target.providerSelector, /::openai_image_generations$/);
+});


### PR DESCRIPTION
Reason: Add MiniMax image-generation endpoint and schema support to Fusion media.

This change registers the global and China image-generation endpoints and the supported image models. It routes Fusion image-generation requests to the provider-specific endpoint, normalizes returned image URLs to the existing media response shape, and preserves explicitly configured image capabilities.

Checks:

- `npm run typecheck`
- `node build/test.mjs core --scope unit`
- `node --test .test-dist/core/test/media/provider-registry.test.js .test-dist/core/test/gateway/upstream-header-sanitizer.test.js .test-dist/core/test/gateway/gateway-media-config.test.js`
