### PR TITLE
fix(providers): bound OpenRouter provider-catalog fetches with a timeout

### DIFF
--- a/packages/core/src/providers/openrouter-provider-catalog.ts
+++ b/packages/core/src/providers/openrouter-provider-catalog.ts
@@ -7,6 +7,18 @@ import type {
 const providerCache = new Map<string, { fetchedAt: number; providers: OpenRouterProviderCatalogItem[] }>();
 const providerCacheTtlMs = 10 * 60_000;
 const activityCache = new Map<string, { fetchedAt: number; totals: Map<string, number> }>();
+const defaultProviderCatalogTimeoutMs = 8_000;
+
+function providerCatalogTimeoutMs(): number {
+  const raw = process.env.CCR_OPENROUTER_CATALOG_TIMEOUT_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return defaultProviderCatalogTimeoutMs;
+}
 
 export async function getOpenRouterProviderCatalog(
   request: OpenRouterProviderCatalogRequest
@@ -27,7 +39,9 @@ export async function getOpenRouterProviderCatalog(
   const endpointPath = model
     ? modelEndpointsPath(model)
     : "/api/v1/providers";
-  const response = await fetch(`${trimRight(apiRoot, "/")}${endpointPath}`);
+  const response = await fetch(`${trimRight(apiRoot, "/")}${endpointPath}`, {
+    signal: AbortSignal.timeout(providerCatalogTimeoutMs())
+  });
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     throw new Error(`OpenRouter providers request failed (${response.status}): ${text.slice(0, 200)}`);
@@ -131,7 +145,8 @@ async function loadYesterdayProviderTokenTotals(
     const response = await fetch(url, {
       headers: {
         authorization: `Bearer ${apiKey}`
-      }
+      },
+      signal: AbortSignal.timeout(providerCatalogTimeoutMs())
     });
     if (!response.ok) {
       return undefined;

--- a/packages/core/test/unit/providers/openrouter-provider-catalog.test.mjs
+++ b/packages/core/test/unit/providers/openrouter-provider-catalog.test.mjs
@@ -86,6 +86,69 @@ test("OpenRouter provider catalog loads endpoint providers for a model", async (
   }
 });
 
+test("OpenRouter provider catalog issues the providers request with an abort signal", async () => {
+  const originalFetch = globalThis.fetch;
+  let signalSeen = null;
+  try {
+    globalThis.fetch = async (_url, init) => {
+      signalSeen = init?.signal ?? null;
+      return new Response(JSON.stringify({ data: [] }), {
+        headers: { "content-type": "application/json" },
+        status: 200
+      });
+    };
+
+    await getOpenRouterProviderCatalog({ baseUrl: "https://openrouter-signal.test/api/v1" });
+
+    assert.ok(
+      signalSeen instanceof AbortSignal,
+      "providers fetch must pass an AbortSignal so a stalled endpoint cannot hang the request"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenRouter provider catalog aborts instead of hanging on a stalled endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalTimeout = process.env.CCR_OPENROUTER_CATALOG_TIMEOUT_MS;
+  process.env.CCR_OPENROUTER_CATALOG_TIMEOUT_MS = "50";
+  try {
+    globalThis.fetch = (_url, init) => new Promise((_resolve, reject) => {
+      const signal = init?.signal;
+      if (signal instanceof AbortSignal) {
+        if (signal.aborted) {
+          reject(signal.reason ?? new Error("aborted"));
+          return;
+        }
+        signal.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("aborted"));
+        });
+      }
+      // No signal, or signal never fires: the endpoint stalls forever.
+    });
+
+    const call = getOpenRouterProviderCatalog({ baseUrl: "https://openrouter-stall.test/api/v1" });
+    const outcome = await Promise.race([
+      call.then(() => "resolved", () => "rejected"),
+      new Promise((resolve) => setTimeout(() => resolve("hung"), 1_000))
+    ]);
+
+    assert.equal(
+      outcome,
+      "rejected",
+      "a stalled OpenRouter endpoint must abort the catalog fetch, not hang indefinitely"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalTimeout === undefined) {
+      delete process.env.CCR_OPENROUTER_CATALOG_TIMEOUT_MS;
+    } else {
+      process.env.CCR_OPENROUTER_CATALOG_TIMEOUT_MS = originalTimeout;
+    }
+  }
+});
+
 test("OpenRouter provider catalog loads model endpoints without an API key", async () => {
   const originalFetch = globalThis.fetch;
   const requestedUrls = [];


### PR DESCRIPTION
### Problem

`packages/core/src/providers/openrouter-provider-catalog.ts` fetches the OpenRouter provider/model catalog and the `/api/v1/activity` endpoint with bare `fetch(...)` calls — no `signal`, no timeout:

```ts
const response = await fetch(`${trimRight(apiRoot, "/")}${endpointPath}`);   // L30
...
const response = await fetch(url, { headers: {...} });                        // L131
```

`getOpenRouterProviderCatalog` backs the OpenRouter provider picker from two real entry points — the Electron IPC handler (`packages/electron/src/main/ipc.ts:119`) and the web management server (`packages/core/src/web/management-server.ts:34`). If `openrouter.ai` (or a slow user-configured `baseUrl`) stalls, the IPC/RPC call hangs indefinitely and the UI never resolves.

### Fix

Bound both fetches with `AbortSignal.timeout(...)` — the idiom already used across this repo (`codex/media-preview-bridge.ts`, `agents/claude-app/cdp.ts`, `mcp/fusion-vision-mcp.ts`). The default is **8s**, matching the house convention in the sibling provider files (`providers/icons.ts`, `providers/manifest-service.ts`, `providers/account-service.ts` all use 8000ms), and is overridable via `CCR_OPENROUTER_CATALOG_TIMEOUT_MS`:

```ts
const defaultProviderCatalogTimeoutMs = 8_000;
function providerCatalogTimeoutMs(): number { /* env override */ }
...
fetch(url, { signal: AbortSignal.timeout(providerCatalogTimeoutMs()) })
```

### Test

Two tests added to `packages/core/test/unit/providers/openrouter-provider-catalog.test.mjs`:
1. **Structural** — the providers fetch must receive an `AbortSignal`.
2. **Real stall** — a `globalThis.fetch` stub that hangs unless the signal aborts, with `CCR_OPENROUTER_CATALOG_TIMEOUT_MS=50`, raced against a 1s watchdog.

- **Before:** test 1 fails (no signal); test 2 hangs → still pending at ~1002ms.
- **After:** all 5 pass; the stalled fetch aborts at ~51ms instead of hanging.

`npm run typecheck` and `npm run build:assets` are clean (exit 0). The remaining `test:core`/UI non-zero exits are **pre-existing at clean HEAD** (RequestLogStore bounded-heap assertions, Claude-Design tests needing the external `../ccr-extensions` repo, and the `OverviewView bento` UI tests) — verified by stashing this change and re-running: identical failures, none introduced here. The 5 openrouter-catalog tests pass.
