### PR TITLE
docs: add Parallel Search ToolHub setup example

### DIFF
--- a/docs/src/content/docs/en/configuration/toolhub.md
+++ b/docs/src/content/docs/en/configuration/toolhub.md
@@ -103,6 +103,30 @@ Remote MCP servers need a URL. Authentication can use:
 
 If a remote server starts slowly or has long-running calls, adjust that server's **Startup timeout** or **Request timeout**.
 
+### Parallel Search example
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search (`web_search`) and page extraction (`web_fetch`) without a Parallel account or API key. Free access is rate limited.
+
+In **Settings → ToolHub**, use **Import JSON** to add this remote server:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "parallel-search",
+      "transport": "streamable-http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  ]
+}
+```
+
+Leave **API key**, **API key env**, and **Headers** empty for anonymous access. Keep your existing resolver model configured, enable ToolHub, save settings, and reopen the agent from CCR. The resolver model still uses its own provider credentials; key-free access applies to Parallel's MCP server.
+
+Ask the agent to find a public page and read it. ToolHub discovers the server's tools, resolves the tools needed for the task, and invokes them through `tool_hub.invoke`. This uses ToolHub's remote MCP path and does not require CCR Desktop's built-in browser or change Fusion's built-in search provider.
+
+Once enabled, the agent can call these tools during its work. Queries, requested URLs, and any supplied objectives or context are sent to Parallel. To remove this connection, delete `parallel-search` from ToolHub's MCP servers, save settings, and reopen the agent so it loads the updated configuration.
+
 ## JSON example
 
 The desktop app's SQLite config is the effective source, so prefer editing through the UI. The fields below are useful for backups, migration, or troubleshooting:

--- a/docs/src/content/docs/zh/configuration/toolhub.md
+++ b/docs/src/content/docs/zh/configuration/toolhub.md
@@ -103,6 +103,30 @@ ToolHub 会合并 **ToolHub 页面配置的 MCP servers** 和兼容旧配置中�
 
 如果远程服务启动慢或请求耗时长，可以单独调高该 server 的 **Startup timeout** 或 **Request timeout**。
 
+### Parallel Search 示例
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) 提供公开网页搜索（`web_search`）和网页内容提取（`web_fetch`），无需 Parallel 账号或 API Key。免费访问有速率限制。
+
+在 **设置 → ToolHub** 中，使用 **导入 JSON** 添加此远程服务：
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "parallel-search",
+      "transport": "streamable-http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  ]
+}
+```
+
+匿名访问时，将 **API key**、**API key env** 和 **Headers** 留空。保留已配置的解析模型，启用 ToolHub，保存设置后从 CCR 重新打开 Agent。解析模型仍使用其供应商凭据；无需 API Key 仅适用于 Parallel 的 MCP 服务。
+
+让 Agent 查找并阅读一个公开网页。ToolHub 会发现该服务的工具，为任务选择所需工具，再通过 `tool_hub.invoke` 调用它们。这使用 ToolHub 的远程 MCP 通道，不依赖 CCR Desktop 的内置浏览器，也不会改变 Fusion 的内置搜索供应商。
+
+启用后，Agent 可以在执行任务时调用这些工具。搜索词、请求的 URL，以及提供的目标或上下文会发送给 Parallel。要移除此连接，请从 ToolHub 的 MCP Server 列表删除 `parallel-search`，保存设置并重新打开 Agent，使其加载更新后的配置。
+
 ## JSON 示例
 
 桌面 App 的 SQLite 配置是当前生效来源，建议优先通过 UI 修改。下面字段适用于备份、迁移或排查时理解 ToolHub 配置结构：


### PR DESCRIPTION
This adds a copyable Parallel Search example to the English and Chinese ToolHub guides, so users can try web search and page extraction without a Parallel account or API key. I work at Parallel, which operates the service.

I looked through the existing search setup before choosing the comparisons. [Search starts disabled](https://github.com/musistudio/claude-code-router/blob/5ad5083b4eca8e0fe04f69f03b2e674772305425/packages/core/src/config/default-config.ts#L222-L234), although [Fusion preselects Brave when adding web search](https://github.com/musistudio/claude-code-router/blob/5ad5083b4eca8e0fe04f69f03b2e674772305425/packages/ui/src/pages/home/shared/options.ts#L330-L340). Brave, Tavily, and Exa are the supported search providers that also appear on Artificial Analysis. The [current adapters](https://github.com/musistudio/claude-code-router/blob/5ad5083b4eca8e0fe04f69f03b2e674772305425/packages/core/src/mcp/fusion-vision-mcp.ts#L688-L806) call Brave's web endpoint and Tavily's basic mode; Exa doesn't set a search type, so I've used its strongest benchmarked option, auto.

The results that stood out to me are in [Artificial Analysis's Search API leaderboard](https://artificialanalysis.ai/agents/search-api), with latest data dated August 31, 2026. Scores below are out of 100, rounded to one decimal; higher is better. Enable all provider rows to see Brave web and Tavily basic.

| Search API | Search Index | DeepSearchQA F1 | BrowseComp accuracy |
| --- | ---: | ---: | ---: |
| Parallel advanced | 74.8 | 80.6 | 76.5 |
| Brave web | 64.6 | 62.3 | 67.0 |
| Tavily basic | 65.6 | 74.4 | 58.5 |
| Exa auto | 73.7 | 77.8 | 73.5 |

Parallel advanced is 18.3 points ahead of Brave web on DeepSearchQA and 18 points ahead of Tavily basic on BrowseComp. It also edges out Exa auto on both. That seems like a good reason to let CCR users try Parallel through the MCP support that's already here.

These are [API benchmarks in Artificial Analysis's harness](https://artificialanalysis.ai/methodology/search-api), not measured scores for CCR or the free MCP endpoint. Advanced isn't ahead everywhere: Exa auto scores higher on Omniscience, and Brave web and Exa auto finish benchmark tasks faster.

The example covers importing the server, leaving authentication fields empty, keeping the resolver configured, and removing the connection. Once enabled, agents can send queries, URLs, and supplied context to Parallel. Free access is rate limited. Existing providers and defaults stay unchanged.

Checked the documented server entry with the published 3.0.22 ToolHub runtime: discovery, `web_search`, and `web_fetch` all worked without Parallel credentials. Tool resolution used the existing local fallback without model credentials. JSON matches across both translations, and `git diff --check` passed. The UI, model-based resolver, docs build, and full suite were not run. No repository build was performed.
