### PR TITLE
fix(gateway): fall back on provider error inside a 200 SSE stream

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     image: claude-code-router:local
+    container_name: claude-code-router
     ports:
       # Publish only Nginx. Internal web/gateway listeners stay inside the container.
       - "3458:8080"

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -42,6 +42,7 @@ export function createDefaultAppConfig(options: DefaultAppConfigOptions = {}): A
         }
       },
       fallback: {
+        detectStreamErrors: true,
         mode: "off",
         models: [],
         retryCount: 1

--- a/packages/core/src/contracts/app.ts
+++ b/packages/core/src/contracts/app.ts
@@ -739,6 +739,12 @@ export type RouterFallbackMode = "off" | "retry" | "model-chain";
 export const ROUTER_FALLBACK_MAX_RETRY_COUNT = 9999;
 
 export type RouterFallbackConfig = {
+  // Some providers commit `200 text/event-stream` headers before they know the
+  // upstream rejected the request, then report the failure in the first SSE
+  // frame. Status-code-based fallback cannot see that. When enabled (the
+  // default) the executor peeks the first frame and treats such a response as a
+  // failed attempt. Set false to forward those bodies to the client untouched.
+  detectStreamErrors?: boolean;
   mode: RouterFallbackMode;
   models: string[];
   retryCount: number;

--- a/packages/core/src/gateway/upstream/executor.ts
+++ b/packages/core/src/gateway/upstream/executor.ts
@@ -22,6 +22,7 @@ import { retryDelayAfterNetworkError, retryDelayAfterStatus, shouldFallbackAfter
 import { claudeCodeOauthBetaHeader, claudeCodeOauthRequiredBeta, UpstreamRequestError } from "@ccr/core/gateway/internal/shared";
 import type { ApiKeyLimitUsage, ProviderCredentialRoutingTarget, UpstreamAttempt, UpstreamFailedAttempt, UpstreamFetchResult } from "@ccr/core/gateway/internal/shared";
 import type { RouteTraceObserver } from "@ccr/core/observability/route-trace";
+import { detectSseError } from "@ccr/core/observability/request-log-store";
 
 const providerCredentialSpilloverThreshold = 0.8;
 const openRouterDiscountModelHeader = "x-ccr-openrouter-discount-model";
@@ -467,12 +468,18 @@ export async function fetchUpstreamWithFallback(input: {
     releaseJsonObject(input.body);
 
     try {
-      const response = await fetchWithSystemProxy(attemptUrl, {
+      const fetched = await fetchWithSystemProxy(attemptUrl, {
         body: shouldSendBody(input.method) ? attempt.body?.toString("utf8") : undefined,
         headers: upstreamHeaders,
         method: input.method,
         signal: input.signal
       });
+
+      // A provider that already committed `200 text/event-stream` headers can
+      // only report a late failure inside the body. Judge the attempt on the
+      // first frame that actually arrived rather than on the status line alone;
+      // the peek restates such a response as 529 so the machinery below reacts.
+      const { response, streamError } = await peekUpstreamStreamFailure(fetched, input.fallback, input.signal);
 
       if (hasNextAttempt && shouldFallbackAfterStatus(response.status, fallbackMode)) {
         const delayMs = retryDelayAfterStatus(response.headers, failedAttempts.length);
@@ -482,7 +489,7 @@ export async function fetchUpstreamWithFallback(input: {
           kind: "outcome",
           name: "upstream.attempt.outcome",
           outcome: {
-            fallbackReason: `http:${response.status}`,
+            fallbackReason: streamError === undefined ? `http:${response.status}` : `stream-error:${streamError}`,
             retryDelayMs: delayMs,
             statusCode: response.status
           },
@@ -498,6 +505,7 @@ export async function fetchUpstreamWithFallback(input: {
           credentialChain: attempt.credentialChain,
           credentialIds: attempt.credentialIds,
           delayMs,
+          ...(streamError === undefined ? {} : { error: streamError }),
           model: attempt.model,
           statusCode: response.status
         });
@@ -1163,6 +1171,207 @@ function isRouteTraceChange(value: RequestRouteTraceChange | undefined): value i
   return Boolean(value);
 }
 
+
+// Status assigned to a 2xx response whose body turned out to carry a provider
+// failure. 529 already classifies as a server error, so both `retry` and
+// `model-chain` react to it without special-casing the failure classifier, and
+// a client left without a fallback target still receives a retryable status
+// instead of a success it cannot parse.
+const IN_STREAM_FAILURE_STATUS = 529;
+
+// Ceiling on the bytes buffered while looking for the first real event. A
+// provider that sends headers and then stalls must not hold the attempt open,
+// so past this the response is forwarded unjudged.
+const STREAM_PEEK_MAX_BYTES = 64 * 1024;
+
+type PeekedUpstreamResponse = {
+  response: Response;
+  streamError?: string;
+};
+
+type SsePrefixVerdict =
+  | { kind: "content" }
+  | { kind: "error"; message: string }
+  | { kind: "pending" };
+
+/**
+ * Reads just far enough into a streaming response to tell a real answer from a
+ * failure frame, then hands back a response that still replays every byte read.
+ *
+ * Returns the original response untouched when detection is disabled, when the
+ * status already conveys the outcome, or when the payload is not an event
+ * stream. When the first meaningful frame is a provider error — or the stream
+ * ends without producing one — the returned response carries
+ * `IN_STREAM_FAILURE_STATUS` and `streamError` explains why.
+ */
+async function peekUpstreamStreamFailure(
+  response: Response,
+  fallback: RouterFallbackConfig,
+  signal?: AbortSignal
+): Promise<PeekedUpstreamResponse> {
+  const contentType = response.headers.get("content-type") ?? undefined;
+  if (fallback.detectStreamErrors === false || response.status >= 400 || !looksLikeSseContentType(contentType)) {
+    return { response };
+  }
+  if (!response.body) {
+    return {
+      response: inStreamFailureResponse(response, new Uint8Array(0)),
+      streamError: "upstream returned an empty stream"
+    };
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf8");
+  const buffered: Uint8Array[] = [];
+  let bufferedBytes = 0;
+  let prefix = "";
+  let streamError: string | undefined;
+  let settled = false;
+
+  try {
+    while (!settled) {
+      const { done, value } = await reader.read();
+      if (done) {
+        // The stream closed before a complete event. An empty body is the
+        // failure clients report as a malformed response; a partial-but-present
+        // frame is forwarded rather than second-guessed.
+        const trailing = prefix + decoder.decode();
+        const trailingError = detectSseError(trailing, contentType);
+        if (trailingError !== undefined) {
+          streamError = trailingError;
+        } else if (trailing.trim().length === 0) {
+          streamError = "upstream returned an empty stream";
+        }
+        break;
+      }
+      if (value) {
+        buffered.push(value);
+        bufferedBytes += value.byteLength;
+        prefix += decoder.decode(value, { stream: true });
+      }
+
+      const verdict = classifySsePrefix(prefix, contentType);
+      if (verdict.kind === "error") {
+        streamError = verdict.message;
+        settled = true;
+      } else if (verdict.kind === "content" || bufferedBytes >= STREAM_PEEK_MAX_BYTES) {
+        settled = true;
+      }
+    }
+  } catch (error) {
+    // An aborted request is the caller's decision, not an upstream failure, so
+    // it must not be recycled into a fallback attempt.
+    if (signal?.aborted) {
+      throw error;
+    }
+    streamError = formatError(error);
+  }
+
+  if (streamError !== undefined) {
+    await reader.cancel().catch(() => undefined);
+    return { response: inStreamFailureResponse(response, concatChunks(buffered)), streamError };
+  }
+  return { response: responseWithReplayedStream(response, buffered, reader) };
+}
+
+/**
+ * Verdict for the bytes read so far: `pending` while only comments and
+ * keepalives have arrived, `content` once a real event completed intact, and
+ * `error` when that first real event is a provider failure.
+ */
+function classifySsePrefix(prefix: string, contentType: string | undefined): SsePrefixVerdict {
+  const normalized = prefix.replaceAll("\r\n", "\n");
+  let searchFrom = 0;
+  for (;;) {
+    const boundary = normalized.indexOf("\n\n", searchFrom);
+    if (boundary === -1) {
+      return { kind: "pending" };
+    }
+    const block = normalized.slice(searchFrom, boundary);
+    searchFrom = boundary + 2;
+    if (isSseKeepaliveBlock(block)) {
+      continue;
+    }
+    const message = detectSseError(`${block}\n\n`, contentType);
+    return message === undefined ? { kind: "content" } : { kind: "error", message };
+  }
+}
+
+// Comment lines (`: ...`) and ping events carry no verdict about the request.
+function isSseKeepaliveBlock(block: string): boolean {
+  const lines = block.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    return true;
+  }
+  if (lines.every((line) => line.startsWith(":"))) {
+    return true;
+  }
+  const eventLine = lines.find((line) => line.toLowerCase().startsWith("event:"));
+  return eventLine !== undefined && eventLine.slice("event:".length).trim().toLowerCase() === "ping";
+}
+
+function looksLikeSseContentType(contentType: string | undefined): boolean {
+  return (contentType ?? "").toLowerCase().includes("text/event-stream");
+}
+
+// Rebuilds a response that replays the peeked bytes before the untouched
+// remainder, so consumers see the stream exactly as the upstream sent it.
+function responseWithReplayedStream(
+  source: Response,
+  buffered: Uint8Array[],
+  reader: ReadableStreamDefaultReader<Uint8Array>
+): Response {
+  const body = new ReadableStream<Uint8Array>({
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(value);
+    },
+    start(controller) {
+      for (const chunk of buffered) {
+        controller.enqueue(chunk);
+      }
+    }
+  });
+  return new Response(body, {
+    headers: peekedResponseHeaders(source),
+    status: source.status,
+    statusText: source.statusText
+  });
+}
+
+function inStreamFailureResponse(source: Response, body: Uint8Array): Response {
+  // `BodyInit` does not accept a generic `Uint8Array`, so hand over a compacted
+  // copy of just these bytes as an ArrayBuffer.
+  return new Response(body.slice().buffer, {
+    headers: peekedResponseHeaders(source),
+    status: IN_STREAM_FAILURE_STATUS
+  });
+}
+
+// The body is re-emitted from buffered chunks, so any length the upstream
+// declared no longer describes what will actually be written.
+function peekedResponseHeaders(source: Response): Headers {
+  const headers = new Headers(source.headers);
+  headers.delete("content-length");
+  return headers;
+}
+
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+  const merged = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}
 
 async function drainResponseBody(response: Response): Promise<void> {
   try {

--- a/packages/core/test/unit/gateway/upstream-executor.test.mjs
+++ b/packages/core/test/unit/gateway/upstream-executor.test.mjs
@@ -474,3 +474,195 @@ test("model-chain fallback rebuilds every protocol attempt from the canonical re
     globalThis.fetch = originalFetch;
   }
 });
+
+
+// ---------------------------------------------------------------------------
+// In-stream failures delivered inside an HTTP 200.
+//
+// OpenRouter and Anthropic commit `200 text/event-stream` response headers
+// before they know whether the upstream provider will accept the request. When
+// it does not, the failure can only be expressed in the body, as the first SSE
+// frame. Status-code-based fallback never sees it, so without a peek the
+// gateway forwards a "successful" 200 whose body is one error frame and the
+// client reports an empty or malformed response with no retry.
+// ---------------------------------------------------------------------------
+
+const streamErrorConfig = {
+  Providers: [
+    {
+      capabilities: [{ baseUrl: "https://stream-primary.example", type: "anthropic_messages" }],
+      id: "stream-primary",
+      models: ["primary-model"],
+      name: "Stream Primary"
+    },
+    {
+      capabilities: [{ baseUrl: "https://stream-recovery.example", type: "anthropic_messages" }],
+      id: "stream-recovery",
+      models: ["recovery-model"],
+      name: "Stream Recovery"
+    }
+  ],
+  Router: { fallback: { mode: "off", models: [], retryCount: 0 }, rules: [] },
+  virtualModelProfiles: []
+};
+
+const streamChainFallback = {
+  mode: "model-chain",
+  models: ["Stream Recovery/recovery-model"],
+  retryCount: 0
+};
+
+// Byte-for-byte the frame OpenRouter emits when the upstream provider rejects a
+// request that has already been answered with 200 headers.
+const providerErrorFrame =
+  'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Provider returned error"}}\n\n';
+
+const healthyFirstFrame = 'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1"}}\n\n';
+
+function sseResponse(body) {
+  return new Response(body, {
+    headers: { "content-type": "text/event-stream" },
+    status: 200
+  });
+}
+
+// Emits each string as its own network chunk so frames that straddle a chunk
+// boundary are exercised rather than assumed away.
+function sseChunkedResponse(chunks) {
+  const encoder = new TextEncoder();
+  return sseResponse(new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    }
+  }));
+}
+
+async function runStreamAttempt({ fallback, responses }) {
+  const captured = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    const index = captured.length;
+    captured.push(JSON.parse(init.body));
+    return responses[index]();
+  };
+
+  try {
+    const result = await fetchUpstreamWithFallback({
+      body: Buffer.from(JSON.stringify({
+        messages: [{ content: "hello", role: "user" }],
+        model: "Stream Primary/primary-model",
+        stream: true
+      })),
+      config: streamErrorConfig,
+      coreAuthToken: "core-token",
+      fallback,
+      headers: {},
+      method: "POST",
+      path: "/v1/messages",
+      routedModel: "Stream Primary/primary-model",
+      upstreamUrl: "http://127.0.0.1:3456/v1/messages"
+    });
+    return { captured, result };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("an SSE error frame inside HTTP 200 hands the attempt to the fallback chain", async () => {
+  const { captured, result } = await runStreamAttempt({
+    fallback: streamChainFallback,
+    responses: [
+      () => sseResponse(providerErrorFrame),
+      () => sseResponse(healthyFirstFrame)
+    ]
+  });
+
+  assert.equal(captured.length, 2, "an error frame must not be accepted as a successful attempt");
+  assert.deepEqual(captured.map((body) => body.model), ["primary-model", "recovery-model"]);
+  assert.equal(result.response.status, 200);
+  assert.equal(result.failedAttempts.length, 1);
+  assert.equal(result.failedAttempts[0].statusCode, 529);
+  assert.match(result.failedAttempts[0].error ?? "", /Provider returned error/);
+  assert.equal(await result.response.text(), healthyFirstFrame);
+});
+
+test("a healthy stream is forwarded byte-for-byte across chunk boundaries", async () => {
+  // The first frame is deliberately split mid-JSON: a peek that decodes without
+  // buffering the remainder would corrupt or drop the payload here.
+  const chunks = [
+    'event: message_start\ndata: {"type":"message_st',
+    'art","message":{"id":"msg_1"}}\n\n',
+    'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"hi"}}\n\n',
+    'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+  ];
+
+  const { captured, result } = await runStreamAttempt({
+    fallback: streamChainFallback,
+    responses: [() => sseChunkedResponse(chunks)]
+  });
+
+  assert.equal(captured.length, 1, "a healthy stream must not trigger a fallback attempt");
+  assert.equal(result.response.status, 200);
+  assert.equal(await result.response.text(), chunks.join(""));
+});
+
+test("keepalive frames ahead of the first real event are not read as a failure", async () => {
+  const chunks = [
+    ": keepalive\n\n",
+    'event: ping\ndata: {"type":"ping"}\n\n',
+    healthyFirstFrame
+  ];
+
+  const { captured, result } = await runStreamAttempt({
+    fallback: streamChainFallback,
+    responses: [() => sseChunkedResponse(chunks)]
+  });
+
+  assert.equal(captured.length, 1);
+  assert.equal(await result.response.text(), chunks.join(""));
+});
+
+test("an empty HTTP 200 stream body is treated as a failed attempt", async () => {
+  const { captured, result } = await runStreamAttempt({
+    fallback: streamChainFallback,
+    responses: [
+      () => sseResponse(""),
+      () => sseResponse(healthyFirstFrame)
+    ]
+  });
+
+  assert.equal(captured.length, 2, "a 200 with no body at all is the original bug report");
+  assert.equal(result.failedAttempts.length, 1);
+  assert.equal(result.failedAttempts[0].statusCode, 529);
+  assert.equal(await result.response.text(), healthyFirstFrame);
+});
+
+test("without a fallback target the in-stream error surfaces as a retryable 529", async () => {
+  const { captured, result } = await runStreamAttempt({
+    fallback: { mode: "off", models: [], retryCount: 0 },
+    responses: [() => sseResponse(providerErrorFrame)]
+  });
+
+  assert.equal(captured.length, 1);
+  assert.equal(
+    result.response.status,
+    529,
+    "a 200 carrying only an error frame must not reach the client as a success"
+  );
+  // The upstream explanation is preserved so the client reports the real cause.
+  assert.equal(await result.response.text(), providerErrorFrame);
+});
+
+test("detectStreamErrors=false forwards the error frame verbatim", async () => {
+  const { captured, result } = await runStreamAttempt({
+    fallback: { ...streamChainFallback, detectStreamErrors: false },
+    responses: [() => sseResponse(providerErrorFrame)]
+  });
+
+  assert.equal(captured.length, 1, "detection is opt-out; no fallback attempt may be made");
+  assert.equal(result.response.status, 200);
+  assert.equal(await result.response.text(), providerErrorFrame);
+});

--- a/packages/ui/src/pages/home/components/routing.tsx
+++ b/packages/ui/src/pages/home/components/routing.tsx
@@ -284,6 +284,19 @@ export function RouterFallbackControl({
           </div>
         ) : null}
       </div>
+      <div className="mt-3 flex items-center gap-2">
+        <Toggle
+          ariaLabel={t("Detect in-stream errors")}
+          checked={fallback.detectStreamErrors !== false}
+          onChange={(detectStreamErrors) => updateFallbackPatch({ detectStreamErrors })}
+        />
+        <div className="min-w-0">
+          <div className="text-[12px] font-medium">{t("Detect in-stream errors")}</div>
+          <div className="text-[11px] text-muted-foreground">
+            {t("Treat a provider error sent inside a 200 stream as a failed attempt")}
+          </div>
+        </div>
+      </div>
       {fallback.mode === "model-chain" ? (
         <div className="mt-3 flex min-w-0 flex-wrap gap-2">
           {fallback.models.length === 0 ? (

--- a/packages/ui/src/pages/home/shared/i18n.tsx
+++ b/packages/ui/src/pages/home/shared/i18n.tsx
@@ -1089,6 +1089,8 @@ export const appCopy: Record<ResolvedLanguage, AppCopy> = {
       "Default target model": "默认目标模型",
       "Default failure handling": "默认故障处理",
       "Default on failure": "默认失败处理",
+      "Detect in-stream errors": "检测流内错误",
+      "Treat a provider error sent inside a 200 stream as a failed attempt": "将 200 流中返回的供应商错误视为失败尝试",
       "Description": "描述",
       "CCR scanned this computer for Claude Code, Codex, Grok CLI, OpenCode CLI, and ZCode login states. Click Import to add one as a gateway provider.": "CCR 已扫描本机的 Claude Code、Codex、Grok CLI、OpenCode CLI 和 ZCode 登录态。点击导入即可添加为网关供应商。",
       "CCR is checking this provider. Wait for the check to finish before continuing.": "CCR 正在检查这个供应商，请等待检查结束后再继续。",

--- a/packages/ui/src/pages/home/shared/routing.ts
+++ b/packages/ui/src/pages/home/shared/routing.ts
@@ -84,6 +84,10 @@ export function normalizeRouterFallbackConfig(value: Partial<RouterFallbackConfi
     : [];
 
   return {
+    // Absent in configs written before in-stream error detection existed. Those
+    // default to enabled so the fix applies without a migration; opting out is
+    // an explicit false.
+    detectStreamErrors: typeof record.detectStreamErrors === "boolean" ? record.detectStreamErrors : true,
     mode,
     models,
     retryCount: Number.isFinite(retryCount) ? retryCount : fallbackConfig.Router.fallback.retryCount


### PR DESCRIPTION
## Summary

OpenRouter and Anthropic commit `200 text/event-stream` response headers
before they know whether the upstream will accept the request. When it
does not, the failure can only be expressed in the body, as the first SSE
frame. The gateway decided fallback purely from the status line, so it
forwarded a "successful" 200 whose body was a single error frame and the
client reported an empty or malformed response with no retry.

The upstream executor now peeks the first meaningful SSE frame before
returning an attempt, skipping comments and pings. An error frame — or a
stream that ends without producing any event — is restated as HTTP 529,
which already classifies as a server error, so `retry` and `model-chain`
react without any change to the failure classifier. With no fallback
target left, the client receives a retryable 529 instead of an
unparseable success. Healthy streams are replayed byte-for-byte from the
peeked prefix.

Detection is on by default and can be turned off per fallback config via
`Router.fallback.detectStreamErrors`, exposed as a toggle in the routing
view. Configs written before this field default to enabled, so the fix
applies without a migration.

## Reproduction

Before the fix, a request like the following could land in the client
with an empty / malformed body when the upstream model rejects mid-stream:

```bash
curl -N -H 'Accept: text/event-stream' -H 'anthropic-version: 2023-06-01' \
  -H 'x-api-key: <redacted>' -H 'Content-Type: application/json' \
  -d '{"model":"<redacted>","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":32}' \
  http://127.0.0.1:3458/v1/messages
```

With the fix, the same request returns `529` and the configured
`retry` / `model-chain` fallback kicks in.

## Changes

- `packages/core/src/gateway/upstream/executor.ts` — peek the first
  meaningful SSE frame, restate provider-in-body errors as 529, replay
  healthy streams byte-for-byte.
- `packages/core/src/contracts/app.ts` — add
  `Router.fallback.detectStreamErrors` toggle (default `true`).
- `packages/core/src/config/default-config.ts` — set the new default.
- `packages/ui/src/pages/home/components/routing.tsx`,
  `packages/ui/src/pages/home/shared/routing.ts`,
  `packages/ui/src/pages/home/shared/i18n.tsx` — surface the toggle in
  the routing view.
- `packages/core/test/unit/gateway/upstream-executor.test.mjs` — cover
  error frames, empty streams, healthy stream passthrough, and the
  toggle off.
- `docker-compose.yml` — pin `container_name: claude-code-router` so the
  container can be addressed by a stable name.

## Test plan

- [x] Unit tests added in
  `packages/core/test/unit/gateway/upstream-executor.test.mjs`
  covering: error frame → 529, empty stream → 529, healthy stream
  byte-for-byte replay, comment/ping skip, toggle off bypasses peek.
- [x] `pnpm -F @musistudio/claude-code-router-core test` — green.
- [ ] Manual: replicate the `curl` above and confirm the response is
  `529` with the model-chain fallback.
- [ ] Manual: routing view shows the new toggle, default enabled, and
  disabling it preserves the old behavior.

## Risk

Low. The change is gated by a per-config toggle (default on) and the
healthy-path replay is byte-for-byte. Existing `retry` / `model-chain`
behavior is preserved — they now react to a new upstream signal, but
their decision logic is unchanged.