### PR TITLE
fix: provider model list not loading when editing a Claude Code provider

### DIFF
--- a/packages/core/src/providers/probe.ts
+++ b/packages/core/src/providers/probe.ts
@@ -13,9 +13,12 @@ import type {
   GatewayProviderProtocol
 } from "@ccr/core/contracts/app";
 import { codexDefaultBaseUrl, readCodexAuth } from "@ccr/core/agents/local-providers/codex";
+import { readClaudeCodeOauth } from "@ccr/core/agents/local-providers/claude-code";
 import { localAgentProviderApiKey } from "@ccr/core/agents/local-providers/shared";
+import { claudeCodeOauthBetaHeader, claudeCodeOauthRequiredBeta } from "@ccr/core/gateway/internal/shared";
 import { findProviderPresetByBaseUrl, providerApiKeySafetyIssue } from "@ccr/core/providers/presets/index";
 import { getProviderCatalogModels } from "@ccr/core/providers/model-catalog";
+import { isLocalClaudeCodeOauthProviderPlugin, mergeAnthropicBetaValues } from "@ccr/core/providers/oauth-plugin";
 import { fetchWithSystemProxy } from "@ccr/core/proxy/system-proxy-fetch";
 import {
   compactProviderUrl,
@@ -912,6 +915,24 @@ async function providerProbeAuthRequest(
     request = providerProbeStaticAuthRequest(request.url, request.init, auth);
   }
 
+  const liveClaudeCodeAccessToken = providerProbeLiveClaudeCodeOauth(apiKey, providerPlugins);
+  if (liveClaudeCodeAccessToken) {
+    const headers = new Headers(request.init.headers);
+    headers.set("authorization", `Bearer ${liveClaudeCodeAccessToken}`);
+    headers.delete("x-api-key");
+    headers.set(claudeCodeOauthBetaHeader, mergeAnthropicBetaValues(
+      headers.get(claudeCodeOauthBetaHeader) ?? undefined,
+      claudeCodeOauthRequiredBeta
+    ));
+    request = {
+      ...request,
+      init: {
+        ...request.init,
+        headers
+      }
+    };
+  }
+
   if (codexOauth) {
     request = await providerProbeCodexOauthRequest(request.url, request.init, codexOauth);
   }
@@ -969,6 +990,24 @@ function isCodexProbeEndpoint(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+// Saved Claude Code OAuth plugins carry the access token from import time, but
+// the CLI rotates it; a stale token gets 401 from /v1/models. The gateway
+// refreshes these plugins at config compile time, so the probe must do the
+// same to stay consistent with the traffic it previews.
+function providerProbeLiveClaudeCodeOauth(
+  apiKey: string | undefined,
+  providerPlugins: unknown[]
+): string | undefined {
+  if (apiKey !== localAgentProviderApiKey) {
+    return undefined;
+  }
+  if (!providerPlugins.some(isLocalClaudeCodeOauthProviderPlugin)) {
+    return undefined;
+  }
+
+  return readClaudeCodeOauth()?.accessToken;
 }
 
 function providerProbeStaticAuthRequest(

--- a/packages/core/test/unit/providers/provider-probe.test.mjs
+++ b/packages/core/test/unit/providers/provider-probe.test.mjs
@@ -813,6 +813,72 @@ test("connectivity probe recovers Codex OAuth auth when saved plugin is missing"
   assert.equal(calls[1]?.body?.max_output_tokens, undefined);
 });
 
+test("connectivity probe prefers live Claude Code OAuth over saved plugin tokens", async (t) => {
+  const claudeConfigDir = useTemporaryClaudeCodeHome(t, "ccr-claude-code-probe-live-");
+  const previousFetch = globalThis.fetch;
+  const savedToken = "sk-ant-oat01-saved-stale-token";
+  const liveToken = "sk-ant-oat01-live-access-token";
+  const calls = [];
+
+  fs.mkdirSync(claudeConfigDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeConfigDir, ".credentials.json"), JSON.stringify({
+    claudeAiOauth: {
+      accessToken: liveToken,
+      refreshToken: "refresh-live"
+    }
+  }));
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const headers = new Headers(init?.headers);
+    calls.push({
+      anthropicBeta: headers.get("anthropic-beta"),
+      authorization: headers.get("authorization"),
+      method: init?.method,
+      pathname: url.pathname,
+      xApiKey: headers.get("x-api-key")
+    });
+
+    const ok =
+      headers.get("authorization") === `Bearer ${liveToken}` &&
+      headers.get("x-api-key") === null;
+    return new Response(JSON.stringify(ok ? { data: [{ id: "claude-sonnet-5" }] } : { error: { message: "Unauthorized" } }), {
+      headers: { "content-type": "application/json" },
+      status: ok ? 200 : 401
+    });
+  };
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+
+  const result = await probeGatewayProvider({
+    apiKey: "ccr-local-agent-login",
+    baseUrl: "http://127.0.0.1:49126",
+    forceRefresh: true,
+    mode: "models",
+    providerPlugins: [{
+      auth: {
+        headers: {
+          authorization: `Bearer ${savedToken}`
+        },
+        removeHeaders: ["x-api-key"]
+      },
+      key: "ccr-local-agent-claude-code-api-claude-code-oauth",
+      providerName: "Claude Code API"
+    }],
+    protocols: ["anthropic_messages"]
+  });
+
+  assert.deepEqual(calls.map((call) => call.pathname).filter((pathname, index, all) => all.indexOf(pathname) === index), [
+    "/v1/models",
+    "/v1/messages"
+  ]);
+  assert.equal(calls[0]?.authorization, `Bearer ${liveToken}`);
+  assert.equal(calls[0]?.xApiKey, null);
+  assert.equal(calls[0]?.anthropicBeta, "oauth-2025-04-20");
+  assert.deepEqual(result.models, ["claude-sonnet-5"]);
+});
+
 test("New API response headers enable key quota account connector", () => {
   assert.equal(detectedProviderFromHeaders({ "X-New-Api-Version": "0.8.0" }), "new-api");
   assert.equal(detectedProviderFromHeaders({ "x-oneapi-request-id": "req-1" }), "new-api");
@@ -884,6 +950,20 @@ function jwt(payload) {
 
 function base64url(value) {
   return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function useTemporaryClaudeCodeHome(t, prefix) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const previousHome = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = path.join(home, ".claude");
+  t.after(() => {
+    if (previousHome === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousHome;
+    }
+  });
+  return path.join(home, ".claude");
 }
 
 function useTemporaryCodexHome(t, prefix) {

--- a/packages/ui/src/pages/home/App.tsx
+++ b/packages/ui/src/pages/home/App.tsx
@@ -1348,11 +1348,13 @@ function App() {
 
     providerProbeRequestId.current += 1;
     const requestId = providerProbeRequestId.current;
+    const existingProvider = providerEditIndex === undefined ? undefined : draftConfig.Providers[providerEditIndex];
     const candidates = providerProbeCandidates(providerDraft).filter(isProviderProbeCandidateReady);
     const draftProbeApiKey = providerConnectivityApiKeyFromDraft(providerDraft);
     const shouldDiscoverModels = Boolean(draftProbeApiKey);
     const probeMode = shouldDiscoverModels ? "models" : "protocols";
     const probeApiKey = shouldDiscoverModels ? draftProbeApiKey : "";
+    const providerPlugins = providerConnectivityProviderPlugins(providerDraft, draftConfig.providerPlugins, existingProvider);
     const inputKey = providerProbeInputKey(candidates, probeApiKey, []);
 
     setProviderProbeError("");
@@ -1363,7 +1365,7 @@ function App() {
     setProviderProbeLoading(true);
 
     const timer = window.setTimeout(() => {
-      void probeProviderCandidates(candidates, probeApiKey, [], { mode: probeMode })
+      void probeProviderCandidates(candidates, probeApiKey, [], { mode: probeMode, providerPlugins })
         .then((result) => {
           if (providerProbeRequestId.current !== requestId) {
             return;
@@ -1416,7 +1418,7 @@ function App() {
         setProviderProbeLoading(false);
       }
     };
-  }, [activeView, onboardingStep, providerAddOpen, providerDraft.apiKey, providerDraft.baseUrl, providerDraft.credentialMode, providerDraft.credentials, providerDraft.presetId, providerDraft.protocol, providerDraft.protocolDetectionMode, providerDraft.providerPlugins]);
+  }, [activeView, draftConfig.Providers, draftConfig.providerPlugins, onboardingStep, providerAddOpen, providerDraft.apiKey, providerDraft.baseUrl, providerDraft.credentialMode, providerDraft.credentials, providerDraft.name, providerDraft.presetId, providerDraft.protocol, providerDraft.protocolDetectionMode, providerDraft.providerPlugins, providerEditIndex]);
 
   async function refreshProviderModels(): Promise<void> {
     if (providerProbeLoading) {


### PR DESCRIPTION
Summary

When adding a new local agent provider (Claude Code), the model list loads and models can be selected. When editing that same provider afterwards, the model catalog comes back empty. This PR fixes two gaps that combine to cause it.

## Root cause

Two independent defects break the edit flow:

1. The auto-probe effect in the provider form (`App.tsx`) called `probeProviderCandidates` without resolving provider plugins. Refreshing models manually (`refreshProviderModels`) already resolved them via `providerConnectivityProviderPlugins`, but the auto-probe did not. An imported local agent provider stores only the sentinel key `ccr-local-agent-login` as its API key; without the plugins, the probe sends that sentinel to `https://api.anthropic.com/v1/models` and gets a 401.
  
2. Even with the plugins attached, the probe still failed: saved Claude Code OAuth plugins carry the access token from import time, and the Claude Code CLI rotates that token every few hours. The gateway refreshes these plugins at config compile time (`withClaudeCodeOauthRuntimeDefaults`), but the probe path never did, so it authenticated with a stale token and got a 401.
  

## Changes

- `packages/ui/src/pages/home/App.tsx`: the auto-probe effect now resolves provider plugins with `providerConnectivityProviderPlugins(providerDraft, draftConfig.providerPlugins, existingProvider)`, mirroring `refreshProviderModels`. The effect dependency list was updated for the newly read values (`draftConfig.Providers`, `draftConfig.providerPlugins`, `providerDraft.name`, `providerEditIndex`).
- `packages/core/src/providers/probe.ts`: added `providerProbeLiveClaudeCodeOauth`, mirroring the existing Codex mechanism (`providerProbeLiveCodexOauth`). When a probe request uses the `ccr-local-agent-login` sentinel and a `claude-code-oauth` plugin is present, the probe injects the live access token read from the local Claude Code login (`readClaudeCodeOauth()`), removes `x-api-key`, and ensures the `anthropic-beta: oauth-2025-04-20` header via the existing `mergeAnthropicBetaValues` helper.
- `packages/core/test/unit/providers/provider-probe.test.mjs`: new test covering a saved plugin with a stale token plus a live local login; asserts the probe authenticates with the live token and discovers models.

## Testing

- `npm run typecheck` passes.
- `npm run test:core`: no new failures (the only failures are pre-existing Claude Design and RequestLogStore heap ones, identical with and without this change).
- Verified end to end against the real Anthropic API: with a rotated local token, `GET /v1/models` returns 200 and the full model catalog (11 models) instead of 401.